### PR TITLE
Phase 1: Build Configuration Standardization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ option(BUILD_TESTS "Build unit tests" ON)
 option(BUILD_CONTAINER_SAMPLES "Build container system samples" ON)
 option(USE_THREAD_SAFE_OPERATIONS "Enable thread-safe operations" ON)
 option(USE_LOCKFREE_BY_DEFAULT "Use lock-free implementations by default" OFF)
-option(BUILD_WITH_COMMON_SYSTEM "Enable common_system integration" OFF)
+option(BUILD_WITH_COMMON_SYSTEM "Enable common_system integration" ON)
 
 # When common_system integration is enabled, disable legacy samples/tests by default
 if(BUILD_WITH_COMMON_SYSTEM)


### PR DESCRIPTION
## Summary
- Change BUILD_WITH_COMMON_SYSTEM default value to ON
- Align with system integration goals

## Changes
- BUILD_WITH_COMMON_SYSTEM: OFF -> ON (default)

## Testing
Build verification needed after merge

## Part of
Phase 1: Build Configuration Standardization - Task 1.2