### PR TITLE
Refactor: Remove embedded common_system and use centralized Sources directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ Thumbs.db
 
 # Documentation
 documents/
+
+# Embedded system dependencies (use Sources/ directory instead)
+common_system/
+thread_system/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,10 @@ if(BUILD_WITH_COMMON_SYSTEM)
     if(DEFINED ENV{COMMON_SYSTEM_ROOT})
         list(APPEND _common_system_roots $ENV{COMMON_SYSTEM_ROOT})
     endif()
+    # Priority order: Sources/ directory (macOS), Sources/ directory (Linux), then relative paths
     list(APPEND _common_system_roots
+        /Users/dongcheolshin/Sources/common_system
+        /home/$ENV{USER}/Sources/common_system
         ${CMAKE_CURRENT_SOURCE_DIR}/../common_system
         ${CMAKE_CURRENT_SOURCE_DIR}/common_system
     )


### PR DESCRIPTION
## Summary

This PR refactors container_system's dependency management to use a centralized Sources directory instead of an embedded common_system subfolder.

## Changes

- Remove embedded `common_system/` subfolder
- Update CMakeLists.txt with prioritized search paths for common_system
- Add .gitignore entry to prevent accidental commits of embedded common_system
- Implement 4-tier priority system:
  1. macOS development: `/Users/dongcheolshin/Sources/common_system/include` (highest priority)
  2. Linux development: `/home/${USER}/Sources/common_system/include`
  3. Sibling directory: `${CMAKE_CURRENT_SOURCE_DIR}/../common_system/include`
  4. Source root sibling: `${CMAKE_SOURCE_DIR}/../common_system/include`

## Benefits

- **Single Source of Truth**: common_system maintained in one central location
- **Easier Updates**: Dependency updates only need to be made in one place
- **Reduced Duplication**: Eliminates duplicate git repository
- **Better Maintainability**: Clearer dependency structure across all projects
- **Consistent Pattern**: Same search strategy as other system projects
- **CI/CD Compatible**: Maintains multiple fallback paths for various CI workflows

## Testing

- ✅ CMake configuration successfully finds common_system in Sources directory
- ✅ Build completes without errors
- ✅ All existing functionality preserved

## Migration Guide

Developers should ensure they have the following structure:
```
/Users/dongcheolshin/Sources/
├── common_system/
├── container_system/
└── [other projects]
```

For Linux users, the equivalent is `/home/${USER}/Sources/`.