### PR TITLE
Documentation: Fix Performance Metrics Accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,37 +122,46 @@ This project addresses the fundamental challenge faced by developers worldwide: 
 
 ### 📊 **Performance Benchmarks**
 
-*Benchmarked on Intel i7-12700K (16 threads) @ 3.8GHz, 32GB, Windows 11, MSVC 2022*
+*Primary benchmarks on Apple M1 (8 cores, ARM NEON), macOS 26.1, Apple Clang 17.0*
+
+> **📌 Note**: Performance metrics are platform-dependent. BASELINE.md contains detailed measurements for Apple M1 (ARM). Windows/x86 results may vary. See PERFORMANCE.md for cross-platform comparisons.
 
 > **🚀 Architecture Update**: Latest modular architecture with SIMD optimizations delivers exceptional performance for serialization-intensive applications. Type-safe operations ensure reliability without performance compromise.
 
-#### Core Performance Metrics (Latest Benchmarks)
-- **Container Creation**: Up to 5M containers/second (empty containers)
+#### Core Performance Metrics (Apple M1, Release Build)
+- **Container Creation**: 2M containers/second (measured baseline)
 - **Value Operations**:
-  - String value addition: 15M values/s with efficient string handling
-  - Numeric value addition: 25M values/s with SIMD acceleration
-  - Complex nested structures: 1.2M containers/s
-- **Serialization Performance**:
-  - Binary serialization: 2M containers/s (1KB average size)
-  - JSON serialization: 800K containers/s with structured output
-  - XML serialization: 600K containers/s with schema validation
-- **Deserialization**: 1.5M containers/s from binary format
-- **Memory efficiency**: ~128 bytes baseline with optimized variant storage
+  - variant_value creation: 3.5M values/s
+  - variant_value move: 4.2M ops/s (zero-copy)
+  - String value addition: 2.8M values/s
+  - Numeric value addition: 4.5M values/s with ARM NEON acceleration
+- **Serialization Performance** (see BASELINE.md for details):
+  - Binary serialization: 1.8M ops/s
+  - JSON serialization: 950K ops/s with structured output
+  - XML serialization: 720K ops/s with schema validation
+- **Deserialization**: 2.1M ops/s from binary format
+- **Memory baseline**: 1.5 MB (empty container with allocator overhead)
 
 #### Performance Comparison with Industry Standards
-| Serialization Type | Throughput | Size Overhead | Memory Usage | Best Use Case |
-|-------------------|------------|---------------|--------------|---------------|
-| 🏆 **Container System Binary** | **2M/s** | **~10%** | **128B+data** | All scenarios (optimized) |
-| 📦 **Protocol Buffers** | 1.2M/s | ~15% | 200B+data | Cross-language compatibility |
-| 📦 **JSON (nlohmann)** | 400K/s | ~40% | 300B+data | Human-readable interchange |
-| 📦 **MessagePack** | 1.8M/s | ~12% | 150B+data | Compact binary format |
-| 📦 **XML (pugixml)** | 200K/s | ~60% | 400B+data | Schema validation needs |
+> **⚠️ Important**: All measurements below are from Apple M1 platform. Cross-platform results may differ. For Protocol Buffers comparison, see PERFORMANCE.md section 3.2 for methodology.
+
+| Serialization Type | Throughput (ops/s) | Size Overhead | Memory Baseline | Best Use Case |
+|-------------------|-------------------|---------------|-----------------|---------------|
+| 🏆 **Container System Binary** | **1.8M** | **100% (baseline)** | **1.5 MB** | High-performance scenarios |
+| 📦 **MessagePack** | 1.6M | ~95% (compact) | ~1.4 MB | Compact binary format |
+| 📦 **JSON (nlohmann)** | 950K | ~180% (readable) | ~2.0 MB | Human-readable interchange |
+| 📦 **XML (pugixml)** | 720K | ~220% (verbose) | ~2.5 MB | Schema validation needs |
+
+> **Note on Protocol Buffers**: Direct comparison requires identical data structures and measurement methodology. See benchmarks/protobuf_comparison.md (when available) for controlled comparison.
 
 #### Key Performance Insights
-- 🏃 **Binary format**: Industry-leading performance with minimal overhead
-- 🏋️ **SIMD operations**: 2.5x performance boost for numeric arrays
+- 🏃 **Binary format**: Competitive performance with minimal overhead
+- 🏋️ **ARM NEON SIMD**: 3.2x performance boost for bulk operations (scalar: 1.2 GB/s → NEON: 3.8 GB/s)
 - ⏱️ **Type safety**: Zero runtime overhead for type checking
-- 📈 **Scalability**: Linear performance scaling with container complexity
+- 📈 **Scalability**: Performance degrades with container size (see BASELINE.md Table 6)
+  - 10 values: 3.5M ops/s
+  - 100 values: 2.0M ops/s
+  - 1000 values: 450K ops/s
 
 ## Features
 


### PR DESCRIPTION
## Problem

README.md contained performance metrics that did not match the actual benchmark results documented in BASELINE.md, creating reproducibility and credibility issues.

### Specific Discrepancies Found

1. **Benchmark Environment Mismatch**
   - README claimed: Intel i7-12700K, Windows 11, MSVC 2022
   - Actual (BASELINE.md): Apple M1, macOS 26.1, Apple Clang 17.0
   - Impact: Cross-platform confusion, cannot reproduce claimed results

2. **Serialization Performance Inaccuracies**
   - JSON: README 400K/s vs BASELINE 950K/s (137% understatement)
   - XML: README 200K/s vs BASELINE 720K/s (260% understatement)
   - MessagePack: README 1.8M/s vs BASELINE 1.6M/s (12.5% overstatement)
   - Binary: README 2M/s vs BASELINE 1.8M/s (11% overstatement)

3. **Memory Usage Misleading**
   - README claimed: ~128 bytes baseline
   - Actual (BASELINE.md): 1.5 MB baseline (empty container)
   - Impact: 11,700x discrepancy, no explanation of measurement conditions

4. **Unverifiable Protocol Buffers Claims**
   - README: 1.2M/s with ~15% overhead
   - Source: No benchmark data exists in repository
   - PERFORMANCE.md references different units (MB/s not ops/s)

## Solution

### Changes Made

1. **Corrected Benchmark Environment**
   ```
   - Before: Intel i7-12700K (16 threads) @ 3.8GHz, Windows 11, MSVC 2022
   + After: Apple M1 (8 cores, ARM NEON), macOS 26.1, Apple Clang 17.0
   ```
   Added disclaimer: "Performance metrics are platform-dependent"

2. **Updated Serialization Metrics to Match BASELINE.md**
   | Metric | README (Before) | BASELINE.md (Actual) | README (After) |
   |--------|----------------|----------------------|----------------|
   | Binary | 2M/s | 1.8M ops/s | 1.8M ops/s ✓ |
   | JSON | 400K/s | 950K ops/s | 950K ops/s ✓ |
   | XML | 200K/s | 720K ops/s | 720K ops/s ✓ |
   | MessagePack | 1.8M/s | 1.6M ops/s | 1.6M ops/s ✓ |

3. **Fixed Memory Baseline**
   ```
   - Before: ~128 bytes baseline with optimized variant storage
   + After: 1.5 MB (empty container with allocator overhead)
   ```

4. **Updated SIMD Performance**
   ```
   - Before: 2.5x performance boost
   + After: 3.2x performance boost (scalar: 1.2 GB/s → NEON: 3.8 GB/s)
   ```
   Source: BASELINE.md Table 5

5. **Removed Unverifiable Protocol Buffers Comparison**
   - Replaced with note: "Direct comparison requires identical data structures and measurement methodology"
   - Added reference: "See benchmarks/protobuf_comparison.md (when available)"

6. **Added Scalability Data**
   Performance degradation with container size (from BASELINE.md):
   - 10 values: 3.5M ops/s
   - 100 values: 2.0M ops/s
   - 1000 values: 450K ops/s

### Documentation Consistency

- ✅ README.md matches BASELINE.md data
- ✅ README_KO.md matches BASELINE.md data
- ✅ Performance comparison table uses consistent units (ops/s)
- ✅ Platform disclaimers added to prevent confusion
- ✅ References to BASELINE.md and PERFORMANCE.md for details

## Impact

### Before (Issues)
- ❌ Claims could not be reproduced (wrong platform)
- ❌ JSON/XML performance significantly understated
- ❌ Memory usage claim 11,700x off
- ❌ Protocol Buffers comparison unverifiable
- ❌ No mention of performance scaling characteristics

### After (Fixed)
- ✅ All metrics match measured BASELINE.md results
- ✅ Platform clearly identified (Apple M1)
- ✅ Disclaimer added for cross-platform differences
- ✅ Memory usage accurate with explanation
- ✅ Unverifiable claims removed or qualified
- ✅ Scalability characteristics documented

## Verification

All metrics verified against:
- Primary source: `BASELINE.md` lines 41-70
- Cross-reference: `BASELINE_KO.md`
- Platform info: `BASELINE.md` lines 14-26

## Files Modified

- `README.md` - English documentation
- `README_KO.md` - Korean documentation

## Breaking Changes

None. This is purely documentation correction.

## Recommendations for Future

1. Add automated script to extract metrics from BASELINE.md into README
2. Create benchmarks/protobuf_comparison.md with controlled comparison
3. Add CI check to ensure README metrics match BASELINE.md
4. Consider adding Windows/x86 benchmark results as separate section

## Related Issues

Addresses documentation accuracy concerns raised in code review.