### PR TITLE
Improve namespace usage with namespace alias

### DIFF
--- a/core/container.h
+++ b/core/container.h
@@ -88,9 +88,8 @@ using ::common::map;
 using ::common::and_then;
 using ::common::or_else;
 using ::common::try_catch;
-namespace error_codes {
-using namespace ::common::error_codes;
-} // namespace error_codes
+// Import common system error codes as namespace alias (not 'using namespace')
+namespace error_codes = ::common::error_codes;
 } // namespace common
 } // namespace kcenon
 #endif // KCENON_COMMON_RESULT_FALLBACK_DEFINED


### PR DESCRIPTION
## Summary

This PR replaces `using namespace` with namespace alias for error_codes to follow coding style guidelines and avoid namespace pollution.

## Changes

**File**: `core/container.h`

**Before:**
```cpp
namespace error_codes {
using namespace ::common::error_codes;
} // namespace error_codes
```

**After:**
```cpp
// Import common system error codes as namespace alias (not 'using namespace')
namespace error_codes = ::common::error_codes;
```

## Benefits

- **Code Clarity**: Makes namespace usage explicit
- **No Pollution**: Avoids polluting the parent namespace
- **Best Practices**: Follows C++20 coding guidelines
- **Type Safety**: Maintains proper namespace boundaries

## Rationale

The `using namespace` directive inside a namespace can lead to name collisions and makes it unclear where symbols come from. Using a namespace alias provides the same convenience while being more explicit and safer.

## Testing

- ✅ All samples build successfully
- ✅ No breaking changes to public API
- ✅ Full system build verification completed

## Related Standards

This change aligns with the coding style guidelines defined in CODING_STYLE_RULES.md, specifically the requirement to avoid `using namespace` in favor of explicit namespace usage or aliases.