### PR TITLE
Add missing GNUInstallDirs for CMAKE_INSTALL_INCLUDEDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,6 +467,8 @@ endif()
 # Installation
 ##################################################
 
+include(GNUInstallDirs)
+
 # Install adapter headers if BUILD_WITH_COMMON_SYSTEM is enabled
 if(BUILD_WITH_COMMON_SYSTEM)
     install(FILES


### PR DESCRIPTION
## Problem
CI builds were failing with error:
```
CMake Error at build/cmake_install.cmake:49 (file):
  file cannot create directory: /container/adapters. Maybe need
  administrative privileges.
```

## Root Cause
`${CMAKE_INSTALL_INCLUDEDIR}` was undefined because `include(GNUInstallDirs)` was missing.

When undefined, CMake interprets `/container/adapters` as an absolute path from root `/`.

## Solution
Add `include(GNUInstallDirs)` before installation section (line 470).

## Changes
```cmake
##################################################
# Installation  
##################################################

include(GNUInstallDirs)  # NEW

# Install adapter headers if BUILD_WITH_COMMON_SYSTEM is enabled
if(BUILD_WITH_COMMON_SYSTEM)
    install(FILES
        ${CMAKE_CURRENT_SOURCE_DIR}/include/container/adapters/common_result_adapter.h
        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/container/adapters
        ...
```

## Impact
✅ Headers install to: `<prefix>/include/container/adapters/` (correct)
✅ Fixes CI failures in database_system and other downstream projects
✅ Follows CMake best practices
✅ No breaking changes

## Related
- Fixes installation failures in database_system PR #73