### PR TITLE
fix: Disable messaging features by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,8 +50,8 @@ if(BUILD_WITH_COMMON_SYSTEM)
 endif()
 
 # New messaging system integration options
-option(ENABLE_MESSAGING_FEATURES "Enable messaging-specific optimizations" ON)
-option(ENABLE_EXTERNAL_INTEGRATION "Enable integration with external systems" ON)
+option(ENABLE_MESSAGING_FEATURES "Enable messaging-specific optimizations" OFF)
+option(ENABLE_EXTERNAL_INTEGRATION "Enable integration with external systems" OFF)
 option(ENABLE_PERFORMANCE_METRICS "Enable performance metrics collection" OFF)
 
 # Output directories


### PR DESCRIPTION
## Summary
- Changed ENABLE_MESSAGING_FEATURES and ENABLE_EXTERNAL_INTEGRATION options to OFF by default for more conservative build configuration

## Test plan
- [x] Build system compiles successfully
- [x] Tests pass with features disabled
- [x] No impact on existing functionality