### PR TITLE
feat: Add Fuzz Testing Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ if(NOT BUILD_WITH_COMMON_SYSTEM)
 endif()
 option(CONTAINER_BUILD_BENCHMARKS "Build container system benchmarks" OFF)
 option(CONTAINER_BUILD_INTEGRATION_TESTS "Build container system integration tests" ON)
+option(BUILD_FUZZ_TESTS "Build fuzz tests" OFF)
 set(COMMON_SYSTEM_ROOT "" CACHE PATH "Path to the common_system repository root")
 
 # Respect global BUILD_INTEGRATION_TESTS flag if set
@@ -386,6 +387,25 @@ if(BUILD_TESTS AND NOT BUILD_CONTAINERSYSTEM_AS_SUBMODULE)
 #     enable_testing()
 #     add_subdirectory(integration_tests)
     message(STATUS "Container: Integration tests enabled")
+endif()
+
+if(BUILD_FUZZ_TESTS)
+    message(STATUS "Container: Fuzz tests enabled")
+    
+    # Check if we are compiling with a fuzzer-capable compiler
+    if(NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+        message(WARNING "Fuzzing typically requires Clang. Proceeding, but link might fail if -fsanitize=fuzzer is not supported.")
+    endif()
+
+    add_executable(container_fuzzer tests/fuzz/container_fuzzer.cpp)
+    
+    # Link against the container library
+    target_link_libraries(container_fuzzer PRIVATE container_system)
+    
+    # Add fuzzer flags
+    # Note: We use -g -O1 for better stack traces and moderate performance during fuzzing
+    target_compile_options(container_fuzzer PRIVATE -g -O1 -fsanitize=fuzzer,address,undefined)
+    target_link_options(container_fuzzer PRIVATE -fsanitize=fuzzer,address,undefined)
 endif()
 
 ##################################################

--- a/tests/fuzz/container_fuzzer.cpp
+++ b/tests/fuzz/container_fuzzer.cpp
@@ -1,0 +1,42 @@
+#include <cstdint>
+#include <vector>
+#include <string>
+#include "container/core/container.h"
+
+// Fuzzer entry point
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+    // Don't test empty input as it's trivial
+    if (Size == 0) {
+        return 0;
+    }
+
+    // Construct a vector from the raw data
+    std::vector<uint8_t> input_data(Data, Data + Size);
+
+    try {
+        // Fuzz the constructor that parses the header and values
+        // We alternate based on the first byte's parity to cover both paths
+        // bit 0: parse_header_only
+        bool parse_header_only = (Data[0] & 1) == 0;
+        
+        container_module::value_container container(input_data, parse_header_only);
+
+        // Exercise read methods to ensure internal state is consistent
+        [[maybe_unused]] auto src = container.source_id();
+        [[maybe_unused]] auto type = container.message_type();
+
+        // Exercise serialization paths
+        // These should be safe even if the container contains garbage (as long as it was constructed "successfully")
+        // Note: The constructor might throw if the data is completely invalid, which is fine.
+        if (!parse_header_only) {
+            container.to_json();
+            container.serialize_array();
+        }
+        
+    } catch (...) {
+        // Catch all exceptions. The fuzzer should only fail on crashes (segfaults, ASan violations),
+        // not on handled C++ exceptions (e.g., parse errors).
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This PR introduces initial fuzz testing support using libFuzzer.

### Changes
- Added `BUILD_FUZZ_TESTS` option to CMakeLists.txt
- Added `tests/fuzz/container_fuzzer.cpp` with basic container deserialization fuzzing
- Configured compilation flags for sanitizers (Address, Undefined, Fuzzer)

### How to run
```bash
mkdir build_fuzz && cd build_fuzz
cmake -DBUILD_FUZZ_TESTS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
make container_fuzzer
./bin/container_fuzzer -max_total_time=60
```