### PR TITLE
feat(REACT-004): migrate samples to variant-based API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,16 +472,17 @@ endif()
 
 if(NOT BUILD_CONTAINERSYSTEM_AS_SUBMODULE)
     if(BUILD_CONTAINER_SAMPLES)
-#         add_subdirectory(samples)
+        add_subdirectory(samples)
         message(STATUS "Container samples will be built")
     endif()
 
-    # Build examples (now supported with common_system integration)
+    # Build examples (requires migration to variant-based API - see REACT-004)
     option(BUILD_CONTAINER_EXAMPLES "Build container system examples" ON)
 
     if(BUILD_CONTAINER_EXAMPLES)
-#         add_subdirectory(examples)
-        message(STATUS "Container examples will be built")
+        # Examples require legacy API migration - temporarily disabled
+        # add_subdirectory(examples)
+        message(STATUS "Container examples temporarily disabled (pending API migration)")
     endif()
 else()
     message(STATUS "Container samples and examples disabled (submodule mode)")

--- a/docs/kanban/REACT-004-samples-examples-reactivation.md
+++ b/docs/kanban/REACT-004-samples-examples-reactivation.md
@@ -5,7 +5,7 @@
 - **Priority**: LOW
 - **Estimated Duration**: 2 days
 - **Dependencies**: REACT-001, REACT-002
-- **Status**: TODO
+- **Status**: IN_PROGRESS
 - **Assignee**: TBD
 - **Related Documents**: [REACTIVATION_PLAN.md](../advanced/REACTIVATION_PLAN.md)
 
@@ -187,15 +187,16 @@ int main() {
 
 ## Checklist
 
-- [ ] Migrate all files in samples/ directory
+- [x] Migrate all files in samples/ directory
 - [ ] Migrate all files in examples/ directory
-- [ ] Add SOO example
-- [ ] Add Thread-safe example
-- [ ] Add Type-safe pattern example
-- [ ] Enable samples/examples in CMakeLists.txt
+- [x] Add SOO example (included in basic_usage.cpp)
+- [x] Add Thread-safe example (thread_safe_example.cpp)
+- [x] Add Type-safe pattern example (included in basic_usage.cpp)
+- [x] Enable samples in CMakeLists.txt
+- [ ] Enable examples in CMakeLists.txt (pending migration)
 - [ ] Update README
-- [ ] Verify all examples compile
-- [ ] Verify all examples run
+- [x] Verify all samples compile
+- [x] Verify all samples run
 
 ---
 

--- a/samples/basic_usage.cpp
+++ b/samples/basic_usage.cpp
@@ -19,56 +19,55 @@ int main() {
     auto container = std::make_shared<value_container>();
     container->set_message_type("user_profile");
 
-    // Set various types of values
-    container->add(std::make_shared<string_value>("user_id", "12345"));
-    container->add(std::make_shared<string_value>("username", "john_doe"));
-    container->add(std::make_shared<int_value>("age", 30));
-    container->add(std::make_shared<bool_value>("is_active", true));
-    container->add(std::make_shared<double_value>("balance", 1000.50));
+    // Set various types of values using new set_value API
+    container->set_value("user_id", std::string("12345"));
+    container->set_value("username", std::string("john_doe"));
+    container->set_value("age", static_cast<int32_t>(30));
+    container->set_value("is_active", true);
+    container->set_value("balance", 1000.50);
 
     std::cout << "Container message type: " << container->message_type() << std::endl;
 
     // 2. Reading values from container
     std::cout << "\n2. Reading Values:" << std::endl;
 
-    auto user_id = container->get_value("user_id");
-    if (user_id) {
-        std::cout << "User ID: " << user_id->to_string() << std::endl;
+    if (auto user_id = container->get_value("user_id")) {
+        if (auto* str = std::get_if<std::string>(&user_id->data)) {
+            std::cout << "User ID: " << *str << std::endl;
+        }
     }
 
-    auto username = container->get_value("username");
-    if (username) {
-        std::cout << "Username: " << username->to_string() << std::endl;
+    if (auto username = container->get_value("username")) {
+        if (auto* str = std::get_if<std::string>(&username->data)) {
+            std::cout << "Username: " << *str << std::endl;
+        }
     }
 
-    auto age = container->get_value("age");
-    if (age) {
-        std::cout << "Age: " << age->to_int() << std::endl;
+    if (auto age = container->get_value("age")) {
+        if (auto* val = std::get_if<int32_t>(&age->data)) {
+            std::cout << "Age: " << *val << std::endl;
+        }
     }
 
-    auto is_active = container->get_value("is_active");
-    if (is_active) {
-        std::cout << "Is Active: " << (is_active->to_boolean() ? "Yes" : "No") << std::endl;
+    if (auto is_active = container->get_value("is_active")) {
+        if (auto* val = std::get_if<bool>(&is_active->data)) {
+            std::cout << "Is Active: " << (*val ? "Yes" : "No") << std::endl;
+        }
     }
 
-    auto balance = container->get_value("balance");
-    if (balance) {
-        std::cout << "Balance: $" << balance->to_double() << std::endl;
+    if (auto balance = container->get_value("balance")) {
+        if (auto* val = std::get_if<double>(&balance->data)) {
+            std::cout << "Balance: $" << *val << std::endl;
+        }
     }
 
-    // 3. Multiple values with same name
-    std::cout << "\n3. Multiple Values with Same Name:" << std::endl;
+    // 3. Using iterators for all values
+    std::cout << "\n3. Iterating Over All Values:" << std::endl;
 
-    container->add(std::make_shared<string_value>("tag", "cpp"));
-    container->add(std::make_shared<string_value>("tag", "programming"));
-    container->add(std::make_shared<string_value>("tag", "example"));
-
-    auto tags = container->value_array("tag");
-    std::cout << "User has " << tags.size() << " tags:" << std::endl;
-    for (const auto& tag : tags) {
-        std::cout << "  - " << tag->to_string() << std::endl;
+    for (const auto& val : *container) {
+        std::cout << "  - " << val.name << " (type: " << static_cast<int>(val.type) << ")" << std::endl;
     }
-    
+
     // 4. Container serialization
     std::cout << "\n4. Serialization:" << std::endl;
 
@@ -81,14 +80,16 @@ int main() {
     auto restored_container = std::make_shared<value_container>(serialized);
     std::cout << "Restored container message type: " << restored_container->message_type() << std::endl;
 
-    auto restored_username = restored_container->get_value("username");
-    if (restored_username) {
-        std::cout << "Restored username: " << restored_username->to_string() << std::endl;
+    if (auto restored_username = restored_container->get_value("username")) {
+        if (auto* str = std::get_if<std::string>(&restored_username->data)) {
+            std::cout << "Restored username: " << *str << std::endl;
+        }
     }
 
-    auto restored_balance = restored_container->get_value("balance");
-    if (restored_balance) {
-        std::cout << "Restored balance: $" << restored_balance->to_double() << std::endl;
+    if (auto restored_balance = restored_container->get_value("balance")) {
+        if (auto* val = std::get_if<double>(&restored_balance->data)) {
+            std::cout << "Restored balance: $" << *val << std::endl;
+        }
     }
 
     // 6. Container metadata
@@ -100,6 +101,14 @@ int main() {
     std::cout << "Source: " << container->source_id() << "/" << container->source_sub_id() << std::endl;
     std::cout << "Target: " << container->target_id() << "/" << container->target_sub_id() << std::endl;
     std::cout << "Message type: " << container->message_type() << std::endl;
+
+    // 7. Memory efficiency demonstration
+    std::cout << "\n7. Memory Efficiency:" << std::endl;
+
+    auto [heap, stack] = container->memory_stats();
+    std::cout << "Heap allocations: " << heap << std::endl;
+    std::cout << "Stack allocations: " << stack << std::endl;
+    std::cout << "Total memory footprint: " << container->memory_footprint() << " bytes" << std::endl;
 
     std::cout << "\n=== Example completed successfully ===" << std::endl;
     return 0;

--- a/samples/performance_benchmark.cpp
+++ b/samples/performance_benchmark.cpp
@@ -21,6 +21,7 @@ public:
         benchmark_basic_operations();
         benchmark_serialization();
         benchmark_value_types();
+        benchmark_memory_efficiency();
 
         std::cout << "\n=== All benchmarks completed ===" << std::endl;
     }
@@ -34,29 +35,29 @@ private:
         auto container = std::make_shared<value_container>();
         container->set_message_type("benchmark_container");
 
-        // Benchmark: Add operations
+        // Benchmark: set_value operations
         auto start = std::chrono::high_resolution_clock::now();
         for (int i = 0; i < iterations; ++i) {
             std::string key = "key_" + std::to_string(i);
             std::string value = "value_" + std::to_string(i);
-            container->add(std::make_shared<string_value>(key, value));
+            container->set_value(key, value);
         }
         auto end = std::chrono::high_resolution_clock::now();
 
         auto add_duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
         double add_ops_per_sec = (double)iterations / add_duration.count() * 1000000;
 
-        std::cout << "Add operations:" << std::endl;
-        std::cout << "  " << iterations << " operations in " << add_duration.count() << " μs" << std::endl;
+        std::cout << "set_value operations:" << std::endl;
+        std::cout << "  " << iterations << " operations in " << add_duration.count() << " us" << std::endl;
         std::cout << "  " << std::fixed << std::setprecision(2) << add_ops_per_sec << " ops/sec" << std::endl;
-        std::cout << "  " << std::fixed << std::setprecision(3) << (double)add_duration.count() / iterations << " μs/op" << std::endl;
+        std::cout << "  " << std::fixed << std::setprecision(3) << (double)add_duration.count() / iterations << " us/op" << std::endl;
 
-        // Benchmark: Get operations
+        // Benchmark: get_value operations
         start = std::chrono::high_resolution_clock::now();
         for (int i = 0; i < iterations; ++i) {
             std::string key = "key_" + std::to_string(i);
             auto value = container->get_value(key);
-            volatile bool exists = (value != nullptr);
+            volatile bool exists = value.has_value();
             (void)exists;
         }
         end = std::chrono::high_resolution_clock::now();
@@ -64,10 +65,10 @@ private:
         auto get_duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
         double get_ops_per_sec = (double)iterations / get_duration.count() * 1000000;
 
-        std::cout << "Get operations:" << std::endl;
-        std::cout << "  " << iterations << " operations in " << get_duration.count() << " μs" << std::endl;
+        std::cout << "get_value operations:" << std::endl;
+        std::cout << "  " << iterations << " operations in " << get_duration.count() << " us" << std::endl;
         std::cout << "  " << std::fixed << std::setprecision(2) << get_ops_per_sec << " ops/sec" << std::endl;
-        std::cout << "  " << std::fixed << std::setprecision(3) << (double)get_duration.count() / iterations << " μs/op" << std::endl;
+        std::cout << "  " << std::fixed << std::setprecision(3) << (double)get_duration.count() / iterations << " us/op" << std::endl;
     }
 
     void benchmark_serialization() {
@@ -95,8 +96,8 @@ private:
             auto deserialize_duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
 
             std::cout << "Container with " << size << " entries:" << std::endl;
-            std::cout << "  Serialization: " << serialize_duration.count() << " μs" << std::endl;
-            std::cout << "  Deserialization: " << deserialize_duration.count() << " μs" << std::endl;
+            std::cout << "  Serialization: " << serialize_duration.count() << " us" << std::endl;
+            std::cout << "  Deserialization: " << deserialize_duration.count() << " us" << std::endl;
             std::cout << "  Serialized size: " << serialized.size() << " bytes" << std::endl;
             std::cout << "  Bytes per entry: " << serialized.size() / size << std::endl;
         }
@@ -113,11 +114,11 @@ private:
             auto container = std::make_shared<value_container>();
             auto start = std::chrono::high_resolution_clock::now();
             for (int i = 0; i < iterations; ++i) {
-                container->add(std::make_shared<string_value>("str_" + std::to_string(i), "value_" + std::to_string(i)));
+                container->set_value("str_" + std::to_string(i), std::string("value_" + std::to_string(i)));
             }
             auto end = std::chrono::high_resolution_clock::now();
             auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-            std::cout << "String values: " << duration.count() << " μs for " << iterations << " ops" << std::endl;
+            std::cout << "String values: " << duration.count() << " us for " << iterations << " ops" << std::endl;
         }
 
         // Integer values
@@ -125,11 +126,11 @@ private:
             auto container = std::make_shared<value_container>();
             auto start = std::chrono::high_resolution_clock::now();
             for (int i = 0; i < iterations; ++i) {
-                container->add(std::make_shared<int_value>("int_" + std::to_string(i), i));
+                container->set_value("int_" + std::to_string(i), static_cast<int32_t>(i));
             }
             auto end = std::chrono::high_resolution_clock::now();
             auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-            std::cout << "Integer values: " << duration.count() << " μs for " << iterations << " ops" << std::endl;
+            std::cout << "Integer values: " << duration.count() << " us for " << iterations << " ops" << std::endl;
         }
 
         // Double values
@@ -137,11 +138,11 @@ private:
             auto container = std::make_shared<value_container>();
             auto start = std::chrono::high_resolution_clock::now();
             for (int i = 0; i < iterations; ++i) {
-                container->add(std::make_shared<double_value>("dbl_" + std::to_string(i), i * 1.5));
+                container->set_value("dbl_" + std::to_string(i), static_cast<double>(i * 1.5));
             }
             auto end = std::chrono::high_resolution_clock::now();
             auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-            std::cout << "Double values: " << duration.count() << " μs for " << iterations << " ops" << std::endl;
+            std::cout << "Double values: " << duration.count() << " us for " << iterations << " ops" << std::endl;
         }
 
         // Boolean values
@@ -149,12 +150,34 @@ private:
             auto container = std::make_shared<value_container>();
             auto start = std::chrono::high_resolution_clock::now();
             for (int i = 0; i < iterations; ++i) {
-                container->add(std::make_shared<bool_value>("bool_" + std::to_string(i), i % 2 == 0));
+                container->set_value("bool_" + std::to_string(i), i % 2 == 0);
             }
             auto end = std::chrono::high_resolution_clock::now();
             auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-            std::cout << "Boolean values: " << duration.count() << " μs for " << iterations << " ops" << std::endl;
+            std::cout << "Boolean values: " << duration.count() << " us for " << iterations << " ops" << std::endl;
         }
+    }
+
+    void benchmark_memory_efficiency() {
+        std::cout << "\n4. Memory Efficiency Benchmark:" << std::endl;
+        std::cout << std::string(50, '-') << std::endl;
+
+        const int iterations = 1000;
+        auto container = std::make_shared<value_container>();
+
+        for (int i = 0; i < iterations; ++i) {
+            container->set_value("key_" + std::to_string(i), static_cast<int32_t>(i));
+        }
+
+        auto [heap, stack] = container->memory_stats();
+        size_t footprint = container->memory_footprint();
+
+        std::cout << "Container with " << iterations << " int values:" << std::endl;
+        std::cout << "  Heap allocations: " << heap << std::endl;
+        std::cout << "  Stack allocations: " << stack << std::endl;
+        std::cout << "  Total memory footprint: " << footprint << " bytes" << std::endl;
+        std::cout << "  Bytes per value: " << footprint / iterations << std::endl;
+        std::cout << "  optimized_value size: " << sizeof(optimized_value) << " bytes" << std::endl;
     }
 
     std::shared_ptr<value_container> create_test_container(int size) {
@@ -171,16 +194,16 @@ private:
 
             switch (value_type) {
                 case 0:
-                    container->add(std::make_shared<string_value>(key, "value_" + std::to_string(i)));
+                    container->set_value(key, std::string("value_" + std::to_string(i)));
                     break;
                 case 1:
-                    container->add(std::make_shared<int_value>(key, i));
+                    container->set_value(key, static_cast<int32_t>(i));
                     break;
                 case 2:
-                    container->add(std::make_shared<double_value>(key, i * 1.5));
+                    container->set_value(key, static_cast<double>(i * 1.5));
                     break;
                 case 3:
-                    container->add(std::make_shared<bool_value>(key, i % 2 == 0));
+                    container->set_value(key, i % 2 == 0);
                     break;
             }
         }


### PR DESCRIPTION
## Summary
- Migrate samples directory to use variant-based API (set_value/get_value)
- Enable samples build in CMakeLists.txt
- Temporarily disable examples directory (pending separate migration)

## Changes
- **samples/basic_usage.cpp**: Updated to use new set_value/get_value API, added memory efficiency demonstration
- **samples/thread_safe_example.cpp**: Migrated to use variant-based value access with std::get_if
- **samples/performance_benchmark.cpp**: Updated benchmarks to use new API, added memory efficiency benchmark
- **CMakeLists.txt**: Enabled samples build, added note for examples pending migration

## Testing
- All samples compile successfully
- All 14 core tests pass (1 unrelated environment validation test failure)
- Verified samples demonstrate new API patterns correctly

## Related
- Part of REACT-004 (Samples and Examples Reactivation)
- Examples migration to follow in separate PR