### PR TITLE
feat(value_store): implement serialization support (Phase 2)

### DIFF
--- a/core/value_store.cpp
+++ b/core/value_store.cpp
@@ -32,6 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "container/core/value_store.h"
 #include <stdexcept>
+#include <cstring>
 
 namespace container_module {
 
@@ -112,24 +113,162 @@ bool value_store::empty() const {
 }
 
 std::string value_store::serialize() const {
-    // TODO: Implement JSON serialization in Sprint 3 Phase 2
-    // For now, return placeholder
-    throw std::runtime_error("value_store::serialize() not yet implemented - Sprint 3 Phase 2");
+    if (thread_safe_enabled_.load(std::memory_order_relaxed)) {
+        std::shared_lock lock(mutex_);
+        return serialize_impl();
+    }
+    return serialize_impl();
+}
+
+std::string value_store::serialize_impl() const {
+    read_count_.fetch_add(1, std::memory_order_relaxed);
+
+    std::string result = "{";
+    bool first = true;
+
+    for (const auto& [key, val] : values_) {
+        if (!first) {
+            result += ",";
+        }
+        first = false;
+
+        // Escape key for JSON
+        result += "\"";
+        for (char c : key) {
+            switch (c) {
+                case '"': result += "\\\""; break;
+                case '\\': result += "\\\\"; break;
+                case '\n': result += "\\n"; break;
+                case '\r': result += "\\r"; break;
+                case '\t': result += "\\t"; break;
+                default: result += c;
+            }
+        }
+        result += "\":";
+        result += val.to_json();
+    }
+
+    result += "}";
+    return result;
 }
 
 std::vector<uint8_t> value_store::serialize_binary() const {
-    // TODO: Implement binary serialization in Sprint 3 Phase 2
-    throw std::runtime_error("value_store::serialize_binary() not yet implemented - Sprint 3 Phase 2");
+    if (thread_safe_enabled_.load(std::memory_order_relaxed)) {
+        std::shared_lock lock(mutex_);
+        return serialize_binary_impl();
+    }
+    return serialize_binary_impl();
 }
 
-value_store value_store::deserialize(std::string_view json_data) {
-    // TODO: Implement JSON deserialization in Sprint 3 Phase 2
-    throw std::runtime_error("value_store::deserialize() not yet implemented - Sprint 3 Phase 2");
+std::vector<uint8_t> value_store::serialize_binary_impl() const {
+    read_count_.fetch_add(1, std::memory_order_relaxed);
+
+    std::vector<uint8_t> result;
+
+    // Version byte for future compatibility
+    constexpr uint8_t version = 1;
+    result.push_back(version);
+
+    // Header: number of entries (4 bytes)
+    uint32_t count = static_cast<uint32_t>(values_.size());
+    result.insert(result.end(),
+                 reinterpret_cast<const uint8_t*>(&count),
+                 reinterpret_cast<const uint8_t*>(&count) + sizeof(count));
+
+    // Serialize each key-value pair
+    for (const auto& [key, val] : values_) {
+        // Key length and key
+        uint32_t key_len = static_cast<uint32_t>(key.size());
+        result.insert(result.end(),
+                     reinterpret_cast<const uint8_t*>(&key_len),
+                     reinterpret_cast<const uint8_t*>(&key_len) + sizeof(key_len));
+        result.insert(result.end(), key.begin(), key.end());
+
+        // Value serialization
+        auto value_data = val.serialize();
+        uint32_t value_len = static_cast<uint32_t>(value_data.size());
+        result.insert(result.end(),
+                     reinterpret_cast<const uint8_t*>(&value_len),
+                     reinterpret_cast<const uint8_t*>(&value_len) + sizeof(value_len));
+        result.insert(result.end(), value_data.begin(), value_data.end());
+    }
+
+    return result;
 }
 
-value_store value_store::deserialize_binary(const std::vector<uint8_t>& binary_data) {
-    // TODO: Implement binary deserialization in Sprint 3 Phase 2
-    throw std::runtime_error("value_store::deserialize_binary() not yet implemented - Sprint 3 Phase 2");
+std::unique_ptr<value_store> value_store::deserialize(std::string_view /*json_data*/) {
+    // JSON deserialization requires a JSON parser library
+    // For now, use serialize_binary/deserialize_binary for round-trip serialization
+    throw std::runtime_error(
+        "value_store::deserialize() requires JSON parser - use deserialize_binary() instead");
+}
+
+std::unique_ptr<value_store> value_store::deserialize_binary(const std::vector<uint8_t>& binary_data) {
+    auto store = std::make_unique<value_store>();
+
+    if (binary_data.size() < 1 + sizeof(uint32_t)) {
+        throw std::runtime_error("value_store::deserialize_binary() - invalid data: too small");
+    }
+
+    size_t offset = 0;
+
+    // Read version byte
+    uint8_t version = binary_data[offset++];
+    if (version != 1) {
+        throw std::runtime_error("value_store::deserialize_binary() - unsupported version: "
+                                + std::to_string(version));
+    }
+
+    // Read number of entries
+    uint32_t count;
+    std::memcpy(&count, binary_data.data() + offset, sizeof(count));
+    offset += sizeof(count);
+
+    // Read each key-value pair
+    for (uint32_t i = 0; i < count; ++i) {
+        if (offset + sizeof(uint32_t) > binary_data.size()) {
+            throw std::runtime_error("value_store::deserialize_binary() - truncated data at entry "
+                                    + std::to_string(i));
+        }
+
+        // Read key length
+        uint32_t key_len;
+        std::memcpy(&key_len, binary_data.data() + offset, sizeof(key_len));
+        offset += sizeof(key_len);
+
+        if (offset + key_len + sizeof(uint32_t) > binary_data.size()) {
+            throw std::runtime_error("value_store::deserialize_binary() - truncated key data");
+        }
+
+        // Read key
+        std::string key(binary_data.begin() + offset,
+                       binary_data.begin() + offset + key_len);
+        offset += key_len;
+
+        // Read value length
+        uint32_t value_len;
+        std::memcpy(&value_len, binary_data.data() + offset, sizeof(value_len));
+        offset += sizeof(value_len);
+
+        if (offset + value_len > binary_data.size()) {
+            throw std::runtime_error("value_store::deserialize_binary() - truncated value data");
+        }
+
+        // Deserialize value
+        std::vector<uint8_t> value_data(binary_data.begin() + offset,
+                                        binary_data.begin() + offset + value_len);
+        offset += value_len;
+
+        auto value_opt = value::deserialize(value_data);
+        if (value_opt) {
+            store->values_[key] = std::move(*value_opt);
+        } else {
+            throw std::runtime_error("value_store::deserialize_binary() - failed to deserialize value for key: "
+                                    + key);
+        }
+    }
+
+    return store;
 }
 
 void value_store::enable_thread_safety() {

--- a/core/value_store.h
+++ b/core/value_store.h
@@ -151,18 +151,18 @@ public:
     /**
      * @brief Deserialize from JSON string
      * @param json_data JSON string
-     * @return value_store instance
+     * @return unique_ptr to value_store instance (nullptr on failure)
      * @throws std::runtime_error if deserialization fails
      */
-    static value_store deserialize(std::string_view json_data);
+    static std::unique_ptr<value_store> deserialize(std::string_view json_data);
 
     /**
      * @brief Deserialize from binary format
      * @param binary_data Binary data
-     * @return value_store instance
+     * @return unique_ptr to value_store instance
      * @throws std::runtime_error if deserialization fails
      */
-    static value_store deserialize_binary(const std::vector<uint8_t>& binary_data);
+    static std::unique_ptr<value_store> deserialize_binary(const std::vector<uint8_t>& binary_data);
 
     // =========================================================================
     // Thread Safety
@@ -210,6 +210,11 @@ public:
 protected:
     // Key-value storage using value
     std::unordered_map<std::string, value> values_;
+
+private:
+    // Internal serialization helpers (lock-free, called with lock held)
+    std::string serialize_impl() const;
+    std::vector<uint8_t> serialize_binary_impl() const;
 
     // Thread safety
     mutable std::shared_mutex mutex_;

--- a/docs/advanced/VALUE_STORE_DESIGN.md
+++ b/docs/advanced/VALUE_STORE_DESIGN.md
@@ -89,14 +89,23 @@ class value_store {
 };
 ```
 
-### Phase 2: Implementation & Tests (TODO - Sprint 3 continuation)
+### Phase 2: Serialization Implementation ✅ (2025-11-26)
 
-**Planned Tasks:**
-1. Implement JSON serialization/deserialization
-2. Implement binary serialization/deserialization
-3. Write comprehensive unit tests
-4. Add integration tests with variant_value_v2
-5. Performance benchmarks
+**Completed:**
+- Implemented JSON serialization (`serialize()`) - outputs human-readable JSON
+- Implemented binary serialization (`serialize_binary()`) with version byte for forward compatibility
+- Implemented binary deserialization (`deserialize_binary()`) with round-trip support
+- JSON deserialization deferred (requires JSON parser library)
+- Added comprehensive unit tests (11 tests covering various scenarios)
+- Thread-safe serialization support
+
+**API Changes:**
+- `deserialize()` and `deserialize_binary()` now return `std::unique_ptr<value_store>` instead of `value_store` (due to deleted move constructor)
+
+**Binary Format (v1):**
+```
+[version:1][count:4]([key_len:4][key:UTF-8][value_len:4][value_serialized])...
+```
 
 ### Phase 3: message_container Wrapper (TODO - Sprint 3 continuation)
 
@@ -221,24 +230,25 @@ consumer.join();
 
 ---
 
-## Next Steps (Phase 2)
+## Next Steps (Phase 3)
 
-1. **Serialization Implementation** (Week 1-2)
-   - JSON format using existing container serialization
-   - Binary format for performance-critical scenarios
-   - Version field for forward/backward compatibility
+**Phase 2 Completed (2025-11-26):**
+- ✅ Binary serialization with version support
+- ✅ JSON serialization (output only)
+- ✅ Comprehensive unit tests (11 tests)
 
-2. **Testing** (Week 2)
-   - Unit tests for all public methods
-   - Thread-safety tests with ThreadSanitizer
-   - Serialization round-trip tests
+**Remaining Tasks:**
 
-3. **message_container Wrapper** (Week 3)
+1. **JSON Deserialization** (Optional - requires JSON parser)
+   - Consider adding nlohmann/json or similar library
+   - For now, use binary serialization for round-trip
+
+2. **message_container Wrapper** (Phase 3)
    - Create wrapper with messaging fields
    - Migration guide for existing users
    - Deprecation notices
 
-4. **Documentation** (Week 4)
+3. **Documentation**
    - API reference
    - Migration guide
    - Performance characteristics
@@ -250,7 +260,8 @@ consumer.join();
 - ✅ Interface compiles without errors
 - ✅ Basic operations (add/get/remove) work correctly
 - ✅ Thread-safety opt-in model implemented
-- ⏳ Serialization round-trip tests pass (Phase 2)
+- ✅ Serialization round-trip tests pass (Phase 2 - 2025-11-26)
+- ✅ Binary serialization with version support for forward compatibility
 - ⏳ Zero performance regression vs. current container (Phase 2)
 - ⏳ All existing tests pass after migration (Phase 3)
 


### PR DESCRIPTION
## Summary

- Implement JSON serialization for human-readable output
- Implement binary serialization with version byte for forward compatibility
- Implement binary deserialization with full round-trip support
- Add thread-safe serialization operations
- Update API to return `unique_ptr` for deserialization methods

## Changes

### Core Implementation
- `serialize()` - JSON output for debugging and logging
- `serialize_binary()` - Compact binary format with version support
- `deserialize_binary()` - Full round-trip deserialization
- Thread-safe operations when enabled

### Binary Format (v1)
```
[version:1][count:4]([key_len:4][key:UTF-8][value_len:4][value_serialized])...
```

### API Changes
- `deserialize()` and `deserialize_binary()` now return `std::unique_ptr<value_store>` (due to deleted move constructor)
- JSON deserialization throws runtime_error (requires external JSON parser)

## Test plan

- [x] EmptyStoreJSONSerialization
- [x] SingleValueJSONSerialization
- [x] MultipleValuesJSONSerialization
- [x] EmptyStoreBinarySerialization
- [x] BinarySerializationRoundTrip
- [x] BinaryDeserializeInvalidData
- [x] JSONDeserializeNotImplemented
- [x] ThreadSafeSerialization
- [x] SpecialCharactersInKeys
- [x] BytesValueSerialization
- [x] LargeValuesSerialization

All 11 tests passing.