### PR TITLE
feat(grpc): add unit tests, integration tests, and documentation

### DIFF
--- a/grpc/CMakeLists.txt
+++ b/grpc/CMakeLists.txt
@@ -182,15 +182,26 @@ endif()
 # =============================================================================
 
 if(CONTAINER_GRPC_BUILD_TESTS)
-    # Tests will be added in Week 3
-    # find_package(GTest REQUIRED)
-    # add_executable(grpc_adapter_test tests/adapter_test.cpp)
-    # target_link_libraries(grpc_adapter_test PRIVATE
-    #     container_grpc
-    #     GTest::gtest
-    #     GTest::gtest_main
-    # )
-    # add_test(NAME grpc_adapter_test COMMAND grpc_adapter_test)
+    find_package(GTest REQUIRED)
+    enable_testing()
+
+    # Adapter unit tests
+    add_executable(grpc_adapter_test tests/adapter_test.cpp)
+    target_link_libraries(grpc_adapter_test PRIVATE
+        container_grpc
+        GTest::gtest
+        GTest::gtest_main
+    )
+    add_test(NAME grpc_adapter_test COMMAND grpc_adapter_test)
+
+    # Service integration tests
+    add_executable(grpc_service_test tests/service_test.cpp)
+    target_link_libraries(grpc_service_test PRIVATE
+        container_grpc
+        GTest::gtest
+        GTest::gtest_main
+    )
+    add_test(NAME grpc_service_test COMMAND grpc_service_test)
 endif()
 
 # =============================================================================

--- a/grpc/README.md
+++ b/grpc/README.md
@@ -1,0 +1,325 @@
+# Container System gRPC Integration
+
+A gRPC protocol layer for the container_system that enables remote container exchange via Protocol Buffers. This integration follows a **minimal modification** approach with zero changes to existing container system code.
+
+## Features
+
+- **Bidirectional Conversion**: Seamless conversion between native `value_container` and gRPC proto messages
+- **Full Type Support**: All container value types are supported (bool, integers, floats, strings, bytes, nested containers)
+- **Zero Modification**: Existing container_system code remains unchanged
+- **Isolated Build**: Separate CMake configuration; builds independently
+- **Thread-Safe**: Server supports concurrent client connections
+
+## Architecture
+
+```
+container_system/grpc/
+├── proto/                    # Protocol Buffer definitions
+│   └── container_service.proto
+├── adapters/                 # Conversion layer
+│   ├── container_adapter.h/cpp
+│   └── value_mapper.h
+├── server/                   # gRPC server implementation
+│   ├── grpc_server.h/cpp
+│   └── service_impl.h/cpp
+├── client/                   # gRPC client implementation
+│   └── grpc_client.h/cpp
+├── examples/                 # Usage examples
+│   ├── server_example.cpp
+│   └── client_example.cpp
+├── tests/                    # Unit and integration tests
+│   ├── adapter_test.cpp
+│   └── service_test.cpp
+└── CMakeLists.txt           # Isolated build configuration
+```
+
+## Quick Start
+
+### Building
+
+```bash
+cd container_system/grpc
+mkdir build && cd build
+cmake .. -DCONTAINER_GRPC_BUILD_TESTS=ON -DCONTAINER_GRPC_BUILD_EXAMPLES=ON
+make
+```
+
+### Server Example
+
+```cpp
+#include "server/grpc_server.h"
+#include "core/container.h"
+
+int main() {
+    container_grpc::grpc_server server("0.0.0.0:50051");
+
+    // Optional: Set custom processor
+    server.set_processor([](auto container) {
+        // Process incoming container
+        container->add_value("processed", container_module::value_types::bool_value, true);
+        return container;
+    });
+
+    server.start();
+    server.wait();  // Block until shutdown
+
+    return 0;
+}
+```
+
+### Client Example
+
+```cpp
+#include "client/grpc_client.h"
+#include "core/container.h"
+
+int main() {
+    container_grpc::grpc_client client("localhost:50051");
+
+    auto container = std::make_shared<container_module::value_container>();
+    container->set_message_type("request");
+    container->add_value("count", container_module::value_types::int_value, 42);
+
+    auto result = client.process(container);
+
+    if (result) {
+        std::cout << "Response type: " << result.value->message_type() << std::endl;
+    } else {
+        std::cerr << "Error: " << result.error_message << std::endl;
+    }
+
+    return 0;
+}
+```
+
+## API Reference
+
+### grpc_server
+
+```cpp
+namespace container_grpc {
+
+struct server_config {
+    std::string address = "0.0.0.0:50051";
+    int max_receive_message_size = 64 * 1024 * 1024;
+    int max_send_message_size = 64 * 1024 * 1024;
+    int num_completion_queues = 1;
+    bool enable_reflection = false;
+};
+
+class grpc_server {
+public:
+    explicit grpc_server(const std::string& address);
+    explicit grpc_server(const server_config& config);
+
+    bool start();
+    void stop(int deadline_ms = 5000);
+    void wait();
+
+    bool is_running() const noexcept;
+    std::string address() const noexcept;
+
+    void set_processor(container_processor processor);
+
+    size_t request_count() const noexcept;
+    size_t error_count() const noexcept;
+};
+
+}
+```
+
+### grpc_client
+
+```cpp
+namespace container_grpc {
+
+struct client_config {
+    std::string target_address = "localhost:50051";
+    std::chrono::milliseconds timeout{30000};
+    int max_retries = 3;
+    bool use_ssl = false;
+    std::string client_id = "";
+};
+
+template<typename T>
+struct client_result {
+    bool success = false;
+    std::string error_message;
+    T value;
+
+    explicit operator bool() const noexcept { return success; }
+};
+
+class grpc_client {
+public:
+    explicit grpc_client(const std::string& target);
+    explicit grpc_client(const client_config& config);
+
+    // Unary operations
+    client_result<std::shared_ptr<value_container>> send(std::shared_ptr<value_container> container);
+    client_result<std::shared_ptr<value_container>> process(std::shared_ptr<value_container> container);
+
+    // Streaming operations
+    bool stream(std::shared_ptr<value_container> request, stream_callback callback);
+    client_result<std::vector<std::shared_ptr<value_container>>> send_batch(
+        const std::vector<std::shared_ptr<value_container>>& containers);
+
+    // Status
+    bool ping();
+    std::optional<std::pair<int64_t, int64_t>> get_status();
+
+    // Configuration
+    void set_timeout(std::chrono::milliseconds timeout);
+    std::chrono::milliseconds timeout() const noexcept;
+    std::string target() const noexcept;
+};
+
+}
+```
+
+### container_adapter
+
+```cpp
+namespace container_grpc {
+
+class container_adapter {
+public:
+    // Main conversion functions
+    static GrpcContainer to_grpc(const container_module::value_container& container);
+    static std::shared_ptr<container_module::value_container> from_grpc(const GrpcContainer& grpc_container);
+
+    // Value conversion
+    static GrpcValue to_grpc_value(const container_module::optimized_value& value);
+    static container_module::optimized_value from_grpc_value(const GrpcValue& grpc_value);
+
+    // Type mapping
+    static ValueType to_grpc_type(container_module::value_types type);
+    static container_module::value_types from_grpc_type(ValueType type);
+
+    // Validation
+    static bool can_convert(const container_module::value_container& container) noexcept;
+    static bool can_convert(const GrpcContainer& grpc_container) noexcept;
+};
+
+}
+```
+
+## Supported Value Types
+
+| Native Type | Proto Type | Notes |
+|-------------|------------|-------|
+| `null_value` | `NULL_VALUE` | Empty/null marker |
+| `bool_value` | `BOOL_VALUE` | Boolean |
+| `short_value` | `SHORT_VALUE` | int16, stored as int32 |
+| `ushort_value` | `USHORT_VALUE` | uint16, stored as uint32 |
+| `int_value` | `INT_VALUE` | int32 |
+| `uint_value` | `UINT_VALUE` | uint32 |
+| `long_value` | `LONG_VALUE` | int64 |
+| `ulong_value` | `ULONG_VALUE` | uint64 |
+| `llong_value` | `LLONG_VALUE` | int64 (platform alias) |
+| `ullong_value` | `ULLONG_VALUE` | uint64 (platform alias) |
+| `float_value` | `FLOAT_VALUE` | 32-bit float |
+| `double_value` | `DOUBLE_VALUE` | 64-bit double |
+| `string_value` | `STRING_VALUE` | UTF-8 string |
+| `bytes_value` | `BYTES_VALUE` | Binary data |
+| `container_value` | `CONTAINER_VALUE` | Nested container |
+| `array_value` | `ARRAY_VALUE` | Heterogeneous array |
+
+## gRPC Service Definition
+
+```protobuf
+service ContainerService {
+    // Unary RPC: Send a single container and receive response
+    rpc SendContainer(SendContainerRequest) returns (SendContainerResponse);
+
+    // Unary RPC: Process a container and receive transformed result
+    rpc ProcessContainer(GrpcContainer) returns (GrpcContainer);
+
+    // Server streaming: Subscribe to containers matching criteria
+    rpc StreamContainers(SendContainerRequest) returns (stream GrpcContainer);
+
+    // Client streaming: Send multiple containers, receive summary
+    rpc CollectContainers(stream GrpcContainer) returns (BatchContainerResponse);
+
+    // Bidirectional streaming: Full duplex container exchange
+    rpc ProcessStream(stream GrpcContainer) returns (stream GrpcContainer);
+
+    // Utility: Get stream status
+    rpc GetStreamStatus(SendContainerRequest) returns (StreamStatus);
+}
+```
+
+## Configuration Options
+
+### Server Configuration
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `address` | `0.0.0.0:50051` | Server bind address |
+| `max_receive_message_size` | 64MB | Maximum incoming message size |
+| `max_send_message_size` | 64MB | Maximum outgoing message size |
+| `num_completion_queues` | 1 | Number of completion queues |
+| `enable_reflection` | false | Enable gRPC reflection |
+
+### Client Configuration
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `target_address` | `localhost:50051` | Server address to connect |
+| `timeout` | 30000ms | Request timeout |
+| `max_retries` | 3 | Maximum retry attempts |
+| `use_ssl` | false | Enable SSL/TLS |
+| `client_id` | "" | Client identifier |
+
+## Error Handling
+
+All client operations return a `client_result<T>` that includes:
+- `success`: Boolean indicating operation success
+- `error_message`: Detailed error description on failure
+- `value`: Result value on success
+
+```cpp
+auto result = client.process(container);
+if (!result) {
+    std::cerr << "Operation failed: " << result.error_message << std::endl;
+    // Handle error...
+}
+```
+
+## Running Tests
+
+```bash
+cd build
+
+# Run adapter unit tests
+./grpc_adapter_test
+
+# Run service integration tests
+./grpc_service_test
+```
+
+## Dependencies
+
+- **gRPC**: >= 1.50.0
+- **Protobuf**: >= 3.21.0
+- **C++ Standard**: C++20
+- **GTest**: For testing (optional)
+
+## Design Principles
+
+1. **Zero Modification**: No changes to existing container_system code
+2. **Read-Only Access**: Adapter layer only reads from native containers
+3. **Stateless Conversion**: All conversion functions are stateless and thread-safe
+4. **Graceful Degradation**: Missing gRPC dependencies do not affect core functionality
+5. **Maximum Nesting Depth**: 32 levels to prevent stack overflow
+
+## Performance Notes
+
+- Conversion overhead is minimal for primitive types (stack-allocated)
+- Large binary data and strings are zero-copy where possible
+- Nested containers incur recursive conversion cost
+- Consider batch operations for high-throughput scenarios
+
+## License
+
+BSD 3-Clause License. See LICENSE file for details.

--- a/grpc/tests/adapter_test.cpp
+++ b/grpc/tests/adapter_test.cpp
@@ -1,0 +1,480 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file adapter_test.cpp
+ * @brief Unit tests for container_adapter conversion layer
+ *
+ * Tests verify bidirectional conversion between container_module types
+ * and gRPC proto messages with data integrity preservation.
+ */
+
+#include <gtest/gtest.h>
+
+#include "adapters/container_adapter.h"
+#include "adapters/value_mapper.h"
+#include "container_service.pb.h"
+#include "core/container.h"
+
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace container_grpc;
+using namespace container_module;
+
+/**
+ * Test fixture for container adapter tests
+ */
+class ContainerAdapterTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Create a sample container for testing
+        sample_container_ = std::make_shared<value_container>();
+        sample_container_->set_source("test_source", "test_sub_source");
+        sample_container_->set_target("test_target", "test_sub_target");
+        sample_container_->set_message_type("test_message");
+    }
+
+    void TearDown() override {
+        sample_container_.reset();
+    }
+
+    std::shared_ptr<value_container> sample_container_;
+};
+
+// =============================================================================
+// Round-Trip Conversion Tests
+// =============================================================================
+
+TEST_F(ContainerAdapterTest, RoundTripEmptyContainer) {
+    auto container = std::make_shared<value_container>();
+    container->set_message_type("empty");
+
+    // Convert to gRPC
+    auto grpc = container_adapter::to_grpc(*container);
+
+    // Convert back
+    auto restored = container_adapter::from_grpc(grpc);
+
+    ASSERT_NE(restored, nullptr);
+    EXPECT_EQ(restored->message_type(), "empty");
+}
+
+TEST_F(ContainerAdapterTest, RoundTripWithHeaderFields) {
+    sample_container_->set_source("source_id", "source_sub_id");
+    sample_container_->set_target("target_id", "target_sub_id");
+    sample_container_->set_message_type("test_type");
+
+    auto grpc = container_adapter::to_grpc(*sample_container_);
+    auto restored = container_adapter::from_grpc(grpc);
+
+    ASSERT_NE(restored, nullptr);
+    EXPECT_EQ(restored->source_id(), "source_id");
+    EXPECT_EQ(restored->source_sub_id(), "source_sub_id");
+    EXPECT_EQ(restored->target_id(), "target_id");
+    EXPECT_EQ(restored->target_sub_id(), "target_sub_id");
+    EXPECT_EQ(restored->message_type(), "test_type");
+}
+
+// =============================================================================
+// Primitive Type Conversion Tests
+// =============================================================================
+
+TEST_F(ContainerAdapterTest, ConvertBoolValue) {
+    sample_container_->add_value("bool_true", value_types::bool_value, true);
+    sample_container_->add_value("bool_false", value_types::bool_value, false);
+
+    auto grpc = container_adapter::to_grpc(*sample_container_);
+    auto restored = container_adapter::from_grpc(grpc);
+
+    ASSERT_NE(restored, nullptr);
+
+    auto val_true = restored->get_variant_value("bool_true");
+    auto val_false = restored->get_variant_value("bool_false");
+
+    ASSERT_TRUE(val_true.has_value());
+    ASSERT_TRUE(val_false.has_value());
+
+    EXPECT_TRUE(std::get<bool>(val_true->data));
+    EXPECT_FALSE(std::get<bool>(val_false->data));
+}
+
+TEST_F(ContainerAdapterTest, ConvertIntegerTypes) {
+    // Test various integer types
+    sample_container_->add_value("short_val", value_types::short_value,
+                                  static_cast<short>(32767));
+    sample_container_->add_value("ushort_val", value_types::ushort_value,
+                                  static_cast<unsigned short>(65535));
+    sample_container_->add_value("int_val", value_types::int_value, 2147483647);
+    sample_container_->add_value("uint_val", value_types::uint_value, 4294967295U);
+    sample_container_->add_value("long_val", value_types::long_value,
+                                  static_cast<long>(2147483647L));
+    sample_container_->add_value("llong_val", value_types::llong_value,
+                                  9223372036854775807LL);
+
+    auto grpc = container_adapter::to_grpc(*sample_container_);
+    auto restored = container_adapter::from_grpc(grpc);
+
+    ASSERT_NE(restored, nullptr);
+
+    auto short_v = restored->get_variant_value("short_val");
+    ASSERT_TRUE(short_v.has_value());
+    EXPECT_EQ(std::get<short>(short_v->data), 32767);
+
+    auto int_v = restored->get_variant_value("int_val");
+    ASSERT_TRUE(int_v.has_value());
+    EXPECT_EQ(std::get<int>(int_v->data), 2147483647);
+
+    auto llong_v = restored->get_variant_value("llong_val");
+    ASSERT_TRUE(llong_v.has_value());
+    EXPECT_EQ(std::get<long long>(llong_v->data), 9223372036854775807LL);
+}
+
+TEST_F(ContainerAdapterTest, ConvertFloatingPointTypes) {
+    sample_container_->add_value("float_val", value_types::float_value, 3.14159f);
+    sample_container_->add_value("double_val", value_types::double_value,
+                                  3.141592653589793);
+
+    auto grpc = container_adapter::to_grpc(*sample_container_);
+    auto restored = container_adapter::from_grpc(grpc);
+
+    ASSERT_NE(restored, nullptr);
+
+    auto float_v = restored->get_variant_value("float_val");
+    ASSERT_TRUE(float_v.has_value());
+    EXPECT_NEAR(std::get<float>(float_v->data), 3.14159f, 0.00001f);
+
+    auto double_v = restored->get_variant_value("double_val");
+    ASSERT_TRUE(double_v.has_value());
+    EXPECT_NEAR(std::get<double>(double_v->data), 3.141592653589793, 0.0000000001);
+}
+
+TEST_F(ContainerAdapterTest, ConvertStringValue) {
+    std::string test_string = "Hello, gRPC World!";
+    sample_container_->add_value("string_val", value_types::string_value,
+                                  test_string);
+
+    auto grpc = container_adapter::to_grpc(*sample_container_);
+    auto restored = container_adapter::from_grpc(grpc);
+
+    ASSERT_NE(restored, nullptr);
+
+    auto str_v = restored->get_variant_value("string_val");
+    ASSERT_TRUE(str_v.has_value());
+    EXPECT_EQ(std::get<std::string>(str_v->data), test_string);
+}
+
+TEST_F(ContainerAdapterTest, ConvertEmptyString) {
+    sample_container_->add_value("empty_string", value_types::string_value,
+                                  std::string(""));
+
+    auto grpc = container_adapter::to_grpc(*sample_container_);
+    auto restored = container_adapter::from_grpc(grpc);
+
+    ASSERT_NE(restored, nullptr);
+
+    auto str_v = restored->get_variant_value("empty_string");
+    ASSERT_TRUE(str_v.has_value());
+    EXPECT_EQ(std::get<std::string>(str_v->data), "");
+}
+
+TEST_F(ContainerAdapterTest, ConvertBytesValue) {
+    std::vector<uint8_t> test_bytes = {0x00, 0x01, 0x02, 0xFF, 0xFE, 0xFD};
+    sample_container_->add_value("bytes_val", value_types::bytes_value, test_bytes);
+
+    auto grpc = container_adapter::to_grpc(*sample_container_);
+    auto restored = container_adapter::from_grpc(grpc);
+
+    ASSERT_NE(restored, nullptr);
+
+    auto bytes_v = restored->get_variant_value("bytes_val");
+    ASSERT_TRUE(bytes_v.has_value());
+    EXPECT_EQ(std::get<std::vector<uint8_t>>(bytes_v->data), test_bytes);
+}
+
+TEST_F(ContainerAdapterTest, ConvertNullValue) {
+    sample_container_->add_value("null_val", value_types::null_value,
+                                  std::monostate{});
+
+    auto grpc = container_adapter::to_grpc(*sample_container_);
+    auto restored = container_adapter::from_grpc(grpc);
+
+    ASSERT_NE(restored, nullptr);
+
+    auto null_v = restored->get_variant_value("null_val");
+    ASSERT_TRUE(null_v.has_value());
+    EXPECT_EQ(null_v->type, value_types::null_value);
+}
+
+// =============================================================================
+// Nested Container Tests
+// =============================================================================
+
+TEST_F(ContainerAdapterTest, ConvertNestedContainer) {
+    auto nested = std::make_shared<value_container>();
+    nested->set_message_type("nested_type");
+    nested->add_value("nested_int", value_types::int_value, 42);
+    nested->add_value("nested_string", value_types::string_value,
+                       std::string("nested value"));
+
+    sample_container_->add_value("nested_container", value_types::container_value,
+                                  nested);
+
+    auto grpc = container_adapter::to_grpc(*sample_container_);
+    auto restored = container_adapter::from_grpc(grpc);
+
+    ASSERT_NE(restored, nullptr);
+
+    auto nested_v = restored->get_variant_value("nested_container");
+    ASSERT_TRUE(nested_v.has_value());
+    ASSERT_EQ(nested_v->type, value_types::container_value);
+
+    auto restored_nested =
+        std::get<std::shared_ptr<value_container>>(nested_v->data);
+    ASSERT_NE(restored_nested, nullptr);
+    EXPECT_EQ(restored_nested->message_type(), "nested_type");
+
+    auto nested_int = restored_nested->get_variant_value("nested_int");
+    ASSERT_TRUE(nested_int.has_value());
+    EXPECT_EQ(std::get<int>(nested_int->data), 42);
+}
+
+TEST_F(ContainerAdapterTest, ConvertDeeplyNestedContainer) {
+    // Create 3 levels of nesting
+    auto level3 = std::make_shared<value_container>();
+    level3->set_message_type("level3");
+    level3->add_value("depth", value_types::int_value, 3);
+
+    auto level2 = std::make_shared<value_container>();
+    level2->set_message_type("level2");
+    level2->add_value("depth", value_types::int_value, 2);
+    level2->add_value("child", value_types::container_value, level3);
+
+    auto level1 = std::make_shared<value_container>();
+    level1->set_message_type("level1");
+    level1->add_value("depth", value_types::int_value, 1);
+    level1->add_value("child", value_types::container_value, level2);
+
+    sample_container_->add_value("root_child", value_types::container_value, level1);
+
+    auto grpc = container_adapter::to_grpc(*sample_container_);
+    auto restored = container_adapter::from_grpc(grpc);
+
+    ASSERT_NE(restored, nullptr);
+
+    // Navigate through nested structure
+    auto l1 = restored->get_variant_value("root_child");
+    ASSERT_TRUE(l1.has_value());
+    auto l1_container = std::get<std::shared_ptr<value_container>>(l1->data);
+    ASSERT_NE(l1_container, nullptr);
+
+    auto l2 = l1_container->get_variant_value("child");
+    ASSERT_TRUE(l2.has_value());
+    auto l2_container = std::get<std::shared_ptr<value_container>>(l2->data);
+    ASSERT_NE(l2_container, nullptr);
+
+    auto l3 = l2_container->get_variant_value("child");
+    ASSERT_TRUE(l3.has_value());
+    auto l3_container = std::get<std::shared_ptr<value_container>>(l3->data);
+    ASSERT_NE(l3_container, nullptr);
+
+    auto depth = l3_container->get_variant_value("depth");
+    ASSERT_TRUE(depth.has_value());
+    EXPECT_EQ(std::get<int>(depth->data), 3);
+}
+
+// =============================================================================
+// Edge Cases and Error Handling
+// =============================================================================
+
+TEST_F(ContainerAdapterTest, ConvertSpecialFloatValues) {
+    sample_container_->add_value("infinity", value_types::double_value,
+                                  std::numeric_limits<double>::infinity());
+    sample_container_->add_value("neg_infinity", value_types::double_value,
+                                  -std::numeric_limits<double>::infinity());
+
+    auto grpc = container_adapter::to_grpc(*sample_container_);
+    auto restored = container_adapter::from_grpc(grpc);
+
+    ASSERT_NE(restored, nullptr);
+
+    auto inf_v = restored->get_variant_value("infinity");
+    ASSERT_TRUE(inf_v.has_value());
+    EXPECT_TRUE(std::isinf(std::get<double>(inf_v->data)));
+    EXPECT_GT(std::get<double>(inf_v->data), 0);
+
+    auto neg_inf_v = restored->get_variant_value("neg_infinity");
+    ASSERT_TRUE(neg_inf_v.has_value());
+    EXPECT_TRUE(std::isinf(std::get<double>(neg_inf_v->data)));
+    EXPECT_LT(std::get<double>(neg_inf_v->data), 0);
+}
+
+TEST_F(ContainerAdapterTest, ConvertLargeBinaryData) {
+    // Test with 1MB of binary data
+    std::vector<uint8_t> large_data(1024 * 1024);
+    for (size_t i = 0; i < large_data.size(); ++i) {
+        large_data[i] = static_cast<uint8_t>(i % 256);
+    }
+
+    sample_container_->add_value("large_bytes", value_types::bytes_value, large_data);
+
+    auto grpc = container_adapter::to_grpc(*sample_container_);
+    auto restored = container_adapter::from_grpc(grpc);
+
+    ASSERT_NE(restored, nullptr);
+
+    auto bytes_v = restored->get_variant_value("large_bytes");
+    ASSERT_TRUE(bytes_v.has_value());
+    EXPECT_EQ(std::get<std::vector<uint8_t>>(bytes_v->data).size(),
+              large_data.size());
+    EXPECT_EQ(std::get<std::vector<uint8_t>>(bytes_v->data), large_data);
+}
+
+TEST_F(ContainerAdapterTest, ConvertUnicodeString) {
+    std::string unicode_str = u8"Hello \u4e16\u754c \U0001F600"; // "Hello 世界 😀"
+    sample_container_->add_value("unicode", value_types::string_value, unicode_str);
+
+    auto grpc = container_adapter::to_grpc(*sample_container_);
+    auto restored = container_adapter::from_grpc(grpc);
+
+    ASSERT_NE(restored, nullptr);
+
+    auto str_v = restored->get_variant_value("unicode");
+    ASSERT_TRUE(str_v.has_value());
+    EXPECT_EQ(std::get<std::string>(str_v->data), unicode_str);
+}
+
+TEST_F(ContainerAdapterTest, ConvertMultipleValuesPreservesOrder) {
+    for (int i = 0; i < 10; ++i) {
+        sample_container_->add_value("value_" + std::to_string(i),
+                                      value_types::int_value, i * 10);
+    }
+
+    auto grpc = container_adapter::to_grpc(*sample_container_);
+    auto restored = container_adapter::from_grpc(grpc);
+
+    ASSERT_NE(restored, nullptr);
+
+    for (int i = 0; i < 10; ++i) {
+        auto val = restored->get_variant_value("value_" + std::to_string(i));
+        ASSERT_TRUE(val.has_value()) << "Missing value_" << i;
+        EXPECT_EQ(std::get<int>(val->data), i * 10);
+    }
+}
+
+// =============================================================================
+// Validation Tests
+// =============================================================================
+
+TEST_F(ContainerAdapterTest, CanConvertValidContainer) {
+    sample_container_->add_value("int", value_types::int_value, 42);
+    sample_container_->add_value("string", value_types::string_value,
+                                  std::string("test"));
+
+    EXPECT_TRUE(container_adapter::can_convert(*sample_container_));
+}
+
+TEST_F(ContainerAdapterTest, CanConvertEmptyContainer) {
+    auto empty = std::make_shared<value_container>();
+    EXPECT_TRUE(container_adapter::can_convert(*empty));
+}
+
+// =============================================================================
+// Type Mapping Tests
+// =============================================================================
+
+TEST_F(ContainerAdapterTest, TypeMappingRoundTrip) {
+    // Test that all supported types map correctly
+    std::vector<value_types> types = {
+        value_types::null_value,   value_types::bool_value,
+        value_types::short_value,  value_types::ushort_value,
+        value_types::int_value,    value_types::uint_value,
+        value_types::long_value,   value_types::ulong_value,
+        value_types::llong_value,  value_types::ullong_value,
+        value_types::float_value,  value_types::double_value,
+        value_types::string_value, value_types::bytes_value,
+        value_types::container_value};
+
+    for (auto type : types) {
+        auto grpc_type = container_adapter::to_grpc_type(type);
+        auto restored_type = container_adapter::from_grpc_type(grpc_type);
+        EXPECT_EQ(type, restored_type)
+            << "Type mismatch for " << value_mapper::type_name(type);
+    }
+}
+
+TEST_F(ContainerAdapterTest, ValueMapperIsSupportedCheck) {
+    EXPECT_TRUE(value_mapper::is_supported(value_types::null_value));
+    EXPECT_TRUE(value_mapper::is_supported(value_types::bool_value));
+    EXPECT_TRUE(value_mapper::is_supported(value_types::int_value));
+    EXPECT_TRUE(value_mapper::is_supported(value_types::string_value));
+    EXPECT_TRUE(value_mapper::is_supported(value_types::container_value));
+}
+
+TEST_F(ContainerAdapterTest, ValueMapperTypeNames) {
+    EXPECT_STREQ(value_mapper::type_name(value_types::null_value), "null");
+    EXPECT_STREQ(value_mapper::type_name(value_types::bool_value), "bool");
+    EXPECT_STREQ(value_mapper::type_name(value_types::int_value), "int");
+    EXPECT_STREQ(value_mapper::type_name(value_types::string_value), "string");
+    EXPECT_STREQ(value_mapper::type_name(value_types::container_value), "container");
+}
+
+// =============================================================================
+// Size Calculator Tests
+// =============================================================================
+
+TEST_F(ContainerAdapterTest, SizeCalculatorEstimations) {
+    // Verify size estimates are reasonable
+    auto null_size =
+        size_calculator::estimate_proto_size(value_types::null_value, 0);
+    EXPECT_GT(null_size, 0u);
+
+    auto string_size =
+        size_calculator::estimate_proto_size(value_types::string_value, 100);
+    EXPECT_GE(string_size, 100u);
+
+    auto container_size =
+        size_calculator::estimate_container_size(10, 20, 50);
+    EXPECT_GT(container_size, 0u);
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/grpc/tests/service_test.cpp
+++ b/grpc/tests/service_test.cpp
@@ -1,0 +1,479 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file service_test.cpp
+ * @brief Integration tests for gRPC server and client
+ *
+ * Tests verify end-to-end communication between gRPC client and server,
+ * including server lifecycle, unary calls, and error handling.
+ */
+
+#include <gtest/gtest.h>
+
+#include "client/grpc_client.h"
+#include "server/grpc_server.h"
+#include "core/container.h"
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <memory>
+#include <thread>
+
+using namespace container_grpc;
+using namespace container_module;
+
+/**
+ * Test fixture for gRPC service integration tests
+ */
+class GrpcServiceTest : public ::testing::Test {
+protected:
+    static constexpr const char* TEST_ADDRESS = "127.0.0.1:50099";
+    static constexpr int STARTUP_WAIT_MS = 100;
+    static constexpr int SHUTDOWN_WAIT_MS = 500;
+
+    void SetUp() override {
+        // Ensure clean state
+        server_.reset();
+        client_.reset();
+    }
+
+    void TearDown() override {
+        // Clean shutdown
+        if (client_) {
+            client_.reset();
+        }
+        if (server_) {
+            server_->stop(SHUTDOWN_WAIT_MS);
+            server_.reset();
+        }
+        // Allow port to be released
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+
+    void StartServer() {
+        server_ = std::make_unique<grpc_server>(TEST_ADDRESS);
+        ASSERT_TRUE(server_->start());
+        std::this_thread::sleep_for(std::chrono::milliseconds(STARTUP_WAIT_MS));
+    }
+
+    void StartServerWithProcessor(container_processor processor) {
+        server_ = std::make_unique<grpc_server>(TEST_ADDRESS);
+        server_->set_processor(std::move(processor));
+        ASSERT_TRUE(server_->start());
+        std::this_thread::sleep_for(std::chrono::milliseconds(STARTUP_WAIT_MS));
+    }
+
+    void ConnectClient() {
+        client_ = std::make_unique<grpc_client>(TEST_ADDRESS);
+    }
+
+    std::unique_ptr<grpc_server> server_;
+    std::unique_ptr<grpc_client> client_;
+};
+
+// =============================================================================
+// Server Lifecycle Tests
+// =============================================================================
+
+TEST_F(GrpcServiceTest, ServerStartAndStop) {
+    server_ = std::make_unique<grpc_server>(TEST_ADDRESS);
+
+    EXPECT_FALSE(server_->is_running());
+    ASSERT_TRUE(server_->start());
+    EXPECT_TRUE(server_->is_running());
+    EXPECT_EQ(server_->address(), TEST_ADDRESS);
+
+    server_->stop(SHUTDOWN_WAIT_MS);
+    EXPECT_FALSE(server_->is_running());
+}
+
+TEST_F(GrpcServiceTest, ServerWithConfig) {
+    server_config config;
+    config.address = TEST_ADDRESS;
+    config.max_receive_message_size = 32 * 1024 * 1024;
+    config.max_send_message_size = 32 * 1024 * 1024;
+
+    server_ = std::make_unique<grpc_server>(config);
+    ASSERT_TRUE(server_->start());
+    EXPECT_TRUE(server_->is_running());
+}
+
+TEST_F(GrpcServiceTest, ServerRequestCounting) {
+    StartServer();
+    ConnectClient();
+
+    EXPECT_EQ(server_->request_count(), 0u);
+    EXPECT_EQ(server_->error_count(), 0u);
+
+    auto container = std::make_shared<value_container>();
+    container->set_message_type("test");
+
+    auto result = client_->process(container);
+    EXPECT_TRUE(result.success);
+    EXPECT_GE(server_->request_count(), 1u);
+}
+
+// =============================================================================
+// Client Configuration Tests
+// =============================================================================
+
+TEST_F(GrpcServiceTest, ClientWithAddress) {
+    StartServer();
+
+    grpc_client client(TEST_ADDRESS);
+    EXPECT_EQ(client.target(), TEST_ADDRESS);
+}
+
+TEST_F(GrpcServiceTest, ClientWithConfig) {
+    StartServer();
+
+    client_config config;
+    config.target_address = TEST_ADDRESS;
+    config.timeout = std::chrono::milliseconds(5000);
+    config.max_retries = 2;
+    config.client_id = "test_client";
+
+    grpc_client client(config);
+    EXPECT_EQ(client.target(), TEST_ADDRESS);
+    EXPECT_EQ(client.timeout(), std::chrono::milliseconds(5000));
+}
+
+TEST_F(GrpcServiceTest, ClientTimeout) {
+    StartServer();
+    ConnectClient();
+
+    auto initial = client_->timeout();
+    client_->set_timeout(std::chrono::milliseconds(10000));
+    EXPECT_EQ(client_->timeout(), std::chrono::milliseconds(10000));
+}
+
+// =============================================================================
+// Unary RPC Tests
+// =============================================================================
+
+TEST_F(GrpcServiceTest, ProcessEmptyContainer) {
+    StartServer();
+    ConnectClient();
+
+    auto container = std::make_shared<value_container>();
+    container->set_message_type("empty_test");
+
+    auto result = client_->process(container);
+
+    EXPECT_TRUE(result.success);
+    ASSERT_NE(result.value, nullptr);
+    EXPECT_EQ(result.value->message_type(), "empty_test");
+}
+
+TEST_F(GrpcServiceTest, ProcessContainerWithValues) {
+    StartServer();
+    ConnectClient();
+
+    auto container = std::make_shared<value_container>();
+    container->set_source("client", "session1");
+    container->set_target("server", "handler1");
+    container->set_message_type("data_request");
+    container->add_value("count", value_types::int_value, 42);
+    container->add_value("name", value_types::string_value,
+                          std::string("test_name"));
+    container->add_value("flag", value_types::bool_value, true);
+
+    auto result = client_->process(container);
+
+    EXPECT_TRUE(result.success);
+    ASSERT_NE(result.value, nullptr);
+
+    // Verify values are preserved
+    auto count = result.value->get_variant_value("count");
+    ASSERT_TRUE(count.has_value());
+    EXPECT_EQ(std::get<int>(count->data), 42);
+
+    auto name = result.value->get_variant_value("name");
+    ASSERT_TRUE(name.has_value());
+    EXPECT_EQ(std::get<std::string>(name->data), "test_name");
+}
+
+TEST_F(GrpcServiceTest, ProcessWithCustomProcessor) {
+    // Set up processor that modifies containers
+    StartServerWithProcessor([](auto container) {
+        container->add_value("processed", value_types::bool_value, true);
+        container->add_value("timestamp", value_types::llong_value,
+                              static_cast<long long>(
+                                  std::chrono::system_clock::now()
+                                      .time_since_epoch()
+                                      .count()));
+        return container;
+    });
+
+    ConnectClient();
+
+    auto container = std::make_shared<value_container>();
+    container->set_message_type("process_me");
+
+    auto result = client_->process(container);
+
+    EXPECT_TRUE(result.success);
+    ASSERT_NE(result.value, nullptr);
+
+    auto processed = result.value->get_variant_value("processed");
+    ASSERT_TRUE(processed.has_value());
+    EXPECT_TRUE(std::get<bool>(processed->data));
+
+    auto timestamp = result.value->get_variant_value("timestamp");
+    EXPECT_TRUE(timestamp.has_value());
+}
+
+TEST_F(GrpcServiceTest, SendContainer) {
+    StartServer();
+    ConnectClient();
+
+    auto container = std::make_shared<value_container>();
+    container->set_message_type("send_test");
+    container->add_value("data", value_types::string_value,
+                          std::string("test data"));
+
+    auto result = client_->send(container);
+
+    EXPECT_TRUE(result.success);
+    EXPECT_TRUE(result.error_message.empty());
+}
+
+// =============================================================================
+// Ping and Health Tests
+// =============================================================================
+
+TEST_F(GrpcServiceTest, PingServer) {
+    StartServer();
+    ConnectClient();
+
+    EXPECT_TRUE(client_->ping());
+}
+
+TEST_F(GrpcServiceTest, GetStreamStatus) {
+    StartServer();
+    ConnectClient();
+
+    auto status = client_->get_status();
+
+    ASSERT_TRUE(status.has_value());
+    // Status returns (messages_sent, messages_received)
+    EXPECT_GE(status->first, 0);
+    EXPECT_GE(status->second, 0);
+}
+
+// =============================================================================
+// Error Handling Tests
+// =============================================================================
+
+TEST_F(GrpcServiceTest, ClientWithoutServer) {
+    // Connect to non-existent server
+    grpc_client client("127.0.0.1:59999");
+
+    auto container = std::make_shared<value_container>();
+    container->set_message_type("test");
+
+    auto result = client.process(container);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_FALSE(result.error_message.empty());
+}
+
+TEST_F(GrpcServiceTest, ProcessNullContainer) {
+    StartServer();
+    ConnectClient();
+
+    auto result = client_->process(nullptr);
+
+    EXPECT_FALSE(result.success);
+}
+
+// =============================================================================
+// Concurrent Request Tests
+// =============================================================================
+
+TEST_F(GrpcServiceTest, ConcurrentRequests) {
+    StartServer();
+
+    constexpr int NUM_CLIENTS = 5;
+    constexpr int REQUESTS_PER_CLIENT = 10;
+
+    std::vector<std::future<int>> futures;
+
+    for (int client_id = 0; client_id < NUM_CLIENTS; ++client_id) {
+        futures.push_back(std::async(std::launch::async, [this, client_id]() {
+            grpc_client client(TEST_ADDRESS);
+            int success_count = 0;
+
+            for (int req = 0; req < REQUESTS_PER_CLIENT; ++req) {
+                auto container = std::make_shared<value_container>();
+                container->set_message_type("concurrent_test");
+                container->add_value("client_id", value_types::int_value, client_id);
+                container->add_value("request_id", value_types::int_value, req);
+
+                auto result = client.process(container);
+                if (result.success) {
+                    ++success_count;
+                }
+            }
+
+            return success_count;
+        }));
+    }
+
+    int total_success = 0;
+    for (auto& future : futures) {
+        total_success += future.get();
+    }
+
+    EXPECT_EQ(total_success, NUM_CLIENTS * REQUESTS_PER_CLIENT);
+}
+
+// =============================================================================
+// Large Message Tests
+// =============================================================================
+
+TEST_F(GrpcServiceTest, ProcessLargeContainer) {
+    StartServer();
+    ConnectClient();
+
+    auto container = std::make_shared<value_container>();
+    container->set_message_type("large_test");
+
+    // Add 100 values
+    for (int i = 0; i < 100; ++i) {
+        container->add_value("int_" + std::to_string(i), value_types::int_value, i);
+        container->add_value("str_" + std::to_string(i), value_types::string_value,
+                              std::string(100, static_cast<char>('A' + (i % 26))));
+    }
+
+    auto result = client_->process(container);
+
+    EXPECT_TRUE(result.success);
+    ASSERT_NE(result.value, nullptr);
+
+    // Verify some values
+    auto int_50 = result.value->get_variant_value("int_50");
+    ASSERT_TRUE(int_50.has_value());
+    EXPECT_EQ(std::get<int>(int_50->data), 50);
+}
+
+TEST_F(GrpcServiceTest, ProcessContainerWithBinaryData) {
+    StartServer();
+    ConnectClient();
+
+    auto container = std::make_shared<value_container>();
+    container->set_message_type("binary_test");
+
+    // Add 64KB of binary data
+    std::vector<uint8_t> binary_data(64 * 1024);
+    for (size_t i = 0; i < binary_data.size(); ++i) {
+        binary_data[i] = static_cast<uint8_t>(i % 256);
+    }
+    container->add_value("binary", value_types::bytes_value, binary_data);
+
+    auto result = client_->process(container);
+
+    EXPECT_TRUE(result.success);
+    ASSERT_NE(result.value, nullptr);
+
+    auto restored = result.value->get_variant_value("binary");
+    ASSERT_TRUE(restored.has_value());
+    EXPECT_EQ(std::get<std::vector<uint8_t>>(restored->data).size(),
+              binary_data.size());
+}
+
+// =============================================================================
+// Nested Container Tests
+// =============================================================================
+
+TEST_F(GrpcServiceTest, ProcessNestedContainers) {
+    StartServer();
+    ConnectClient();
+
+    auto inner = std::make_shared<value_container>();
+    inner->set_message_type("inner");
+    inner->add_value("inner_val", value_types::int_value, 999);
+
+    auto container = std::make_shared<value_container>();
+    container->set_message_type("outer");
+    container->add_value("nested", value_types::container_value, inner);
+
+    auto result = client_->process(container);
+
+    EXPECT_TRUE(result.success);
+    ASSERT_NE(result.value, nullptr);
+
+    auto nested = result.value->get_variant_value("nested");
+    ASSERT_TRUE(nested.has_value());
+
+    auto nested_container =
+        std::get<std::shared_ptr<value_container>>(nested->data);
+    ASSERT_NE(nested_container, nullptr);
+    EXPECT_EQ(nested_container->message_type(), "inner");
+
+    auto inner_val = nested_container->get_variant_value("inner_val");
+    ASSERT_TRUE(inner_val.has_value());
+    EXPECT_EQ(std::get<int>(inner_val->data), 999);
+}
+
+// =============================================================================
+// Batch Operations Tests
+// =============================================================================
+
+TEST_F(GrpcServiceTest, SendBatchContainers) {
+    StartServer();
+    ConnectClient();
+
+    std::vector<std::shared_ptr<value_container>> containers;
+    for (int i = 0; i < 5; ++i) {
+        auto container = std::make_shared<value_container>();
+        container->set_message_type("batch_item_" + std::to_string(i));
+        container->add_value("index", value_types::int_value, i);
+        containers.push_back(container);
+    }
+
+    auto result = client_->send_batch(containers);
+
+    EXPECT_TRUE(result.success);
+    EXPECT_EQ(result.value.size(), containers.size());
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

- Add comprehensive unit tests for the container_adapter conversion layer
- Add integration tests for gRPC server/client communication
- Add README.md documentation with API reference and usage examples
- Update CMakeLists.txt to enable test builds

## Changes

### Tests Added
- `grpc/tests/adapter_test.cpp` - Unit tests for container_adapter
  - Round-trip conversion for all value types (bool, integers, floats, strings, bytes)
  - Nested and deeply nested container conversion
  - Edge cases: unicode strings, large binary data, special float values
  - Type mapping and validation tests
  - Size calculator tests

- `grpc/tests/service_test.cpp` - Integration tests for gRPC service
  - Server lifecycle (start/stop/wait)
  - Client configuration
  - Unary RPC operations (process, send)
  - Custom processor callback
  - Concurrent request handling (5 clients x 10 requests)
  - Large message handling
  - Batch operations

### Documentation
- `grpc/README.md` - Complete documentation
  - Architecture overview
  - Quick start guide
  - Full API reference (server, client, adapter)
  - Supported value types mapping table
  - Configuration options
  - Performance notes

### Build Configuration
- Updated `grpc/CMakeLists.txt` to enable test targets

## Test Plan
- [ ] Build with `-DCONTAINER_GRPC_BUILD_TESTS=ON`
- [ ] Run `grpc_adapter_test`
- [ ] Run `grpc_service_test`
- [ ] Verify zero changes to existing container_system code

## Related
Closes TICKET-006