### PR TITLE
chore: add missing build artifact directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,12 @@ Thumbs.db
 documents/
 
 # Embedded system dependencies (use Sources/ directory instead)
+# These are CMake build artifacts, not source copies
 common_system/
 thread_system/
+database_system/
+logger_system/
+monitoring_system/
+network_system/
+container_system/
 .npm-cache/


### PR DESCRIPTION
## Summary
- Add database_system, logger_system, monitoring_system, network_system, and container_system directories to .gitignore
- These directories are CMake build artifacts generated during in-source builds, not source code copies
- Clarify in comments that these are build artifacts, not embedded dependencies

## Background
TICKET-005 identified what appeared to be duplicate system directories within container_system. Investigation revealed these are CMake build artifacts from in-source builds, not actual source code copies.

## Changes
- Updated .gitignore to exclude additional build artifact directories
- Added clarifying comment about the nature of these directories

## Test plan
- [x] Verify CMake configuration still works after cleanup
- [x] Confirm no source files were affected