### PR TITLE
chore(vcpkg): add common_system dependency and standardize vcpkg.json

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,31 +1,41 @@
 {
-    "name": "container-system",
-    "version": "2.0.0",
-    "description": "Thread-safe serializable container library with advanced features",
-    "license": "BSD-3-Clause",
-    "dependencies": [
-        "benchmark"
-    ],
-    "features": {
-        "fmt-support": {
-            "description": "Use fmt library for formatting (fallback for compilers without std::format)",
-            "dependencies": [
-                "fmt"
-            ]
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "kcenon-container-system",
+  "version": "2.0.0",
+  "port-version": 0,
+  "description": "Thread-safe serializable container library with advanced features",
+  "homepage": "https://github.com/kcenon/container_system",
+  "license": "BSD-3-Clause",
+  "supports": "!(uwp | xbox)",
+  "dependencies": [
+    "kcenon-common-system"
+  ],
+  "features": {
+    "testing": {
+      "description": "Build unit tests and benchmarks",
+      "dependencies": [
+        {
+          "name": "gtest",
+          "features": ["gmock"]
         },
-        "tests": {
-            "description": "Build unit tests",
-            "dependencies": [
-                "gtest"
-            ]
-        },
-        "samples": {
-            "description": "Build sample applications",
-            "dependencies": []
-        },
-        "docs": {
-            "description": "Build documentation",
-            "dependencies": []
+        {
+          "name": "benchmark"
         }
+      ]
+    },
+    "fmt-support": {
+      "description": "Use fmt library for formatting (fallback for compilers without std::format)",
+      "dependencies": [
+        "fmt"
+      ]
+    },
+    "samples": {
+      "description": "Build sample applications",
+      "dependencies": []
+    },
+    "docs": {
+      "description": "Build documentation",
+      "dependencies": []
     }
+  }
 }


### PR DESCRIPTION
## Summary

- Add kcenon-common-system as required ecosystem dependency
- Standardize vcpkg.json to follow ecosystem conventions established in common_system
- Move benchmark from default dependencies to testing feature

## Changes

| Field | Before | After |
|-------|--------|-------|
| name | container-system | kcenon-container-system |
| $schema | missing | added |
| port-version | missing | 0 |
| supports | missing | !(uwp \| xbox) |
| homepage | missing | https://github.com/kcenon/container_system |
| common_system dependency | missing | kcenon-common-system |
| benchmark location | default deps | testing feature |
| tests feature | tests | testing (renamed) |
| gtest | basic | with gmock feature |

## Test Plan

- [x] JSON syntax validation passed
- [x] CMake configuration succeeds
- [x] Build completes successfully
- [x] Test results unchanged from main branch

Closes #202