### PR TITLE
refactor: remove legacy_value class and migrate tests to value API

### DIFF
--- a/integration_tests/framework/system_fixture.h
+++ b/integration_tests/framework/system_fixture.h
@@ -103,7 +103,7 @@ protected:
         for (size_t i = 0; i < num_values; ++i) {
             std::string key = "key_" + std::to_string(i);
             std::string value = "value_" + std::to_string(i);
-            test_container->add(std::make_shared<string_value>(key, value));
+            test_container->add(make_string_value(key, value));
         }
 
         return test_container;
@@ -114,7 +114,7 @@ protected:
      */
     void AddStringValue(const std::string& key, const std::string& value)
     {
-        container->add(std::make_shared<string_value>(key, value));
+        container->add(make_string_value(key, value));
     }
 
     /**
@@ -124,11 +124,11 @@ protected:
     void AddNumericValue(const std::string& key, T value)
     {
         if constexpr (std::is_same_v<T, int>) {
-            container->add(std::make_shared<int_value>(key, value));
+            container->add(make_int_value(key, value));
         } else if constexpr (std::is_same_v<T, long long>) {
-            container->add(std::make_shared<llong_value>(key, value));
+            container->add(make_llong_value(key, value));
         } else if constexpr (std::is_same_v<T, double>) {
-            container->add(std::make_shared<double_value>(key, value));
+            container->add(make_double_value(key, value));
         }
     }
 
@@ -137,7 +137,7 @@ protected:
      */
     void AddBoolValue(const std::string& key, bool value)
     {
-        container->add(std::make_shared<bool_value>(key, value));
+        container->add(make_bool_value(key, value));
     }
 
     /**
@@ -145,7 +145,7 @@ protected:
      */
     void AddBytesValue(const std::string& key, const std::vector<uint8_t>& data)
     {
-        container->add(std::make_shared<bytes_value>(key, data));
+        container->add(make_bytes_value(key, data));
     }
 
     /**

--- a/integration_tests/framework/test_helpers.h
+++ b/integration_tests/framework/test_helpers.h
@@ -166,7 +166,7 @@ public:
 
         std::string key = "data_" + std::to_string(depth);
         std::string str_value = "level_" + std::to_string(depth);
-        root->add(std::make_shared<string_value>(key, str_value));
+        root->add(make_string_value(key, str_value));
 
         return root;
     }
@@ -292,14 +292,14 @@ public:
         container->set_message_type("mixed_types");
 
         // Add different value types
-        container->add(std::make_shared<string_value>("str_val", "test_string"));
-        container->add(std::make_shared<int_value>("int_val", 42));
-        container->add(std::make_shared<llong_value>("long_val", 9223372036854775807LL));
-        container->add(std::make_shared<double_value>("double_val", 3.14159));
-        container->add(std::make_shared<bool_value>("bool_val", true));
+        container->add(make_string_value("str_val", "test_string"));
+        container->add(make_int_value("int_val", 42));
+        container->add(make_llong_value("long_val", 9223372036854775807LL));
+        container->add(make_double_value("double_val", 3.14159));
+        container->add(make_bool_value("bool_val", true));
 
         std::vector<uint8_t> bytes = {0x01, 0x02, 0x03, 0x04};
-        container->add(std::make_shared<bytes_value>("bytes_val", bytes));
+        container->add(make_bytes_value("bytes_val", bytes));
 
         return container;
     }
@@ -475,7 +475,7 @@ public:
         while (current_size < target_bytes) {
             std::string key = "key_" + std::to_string(counter);
             std::string value = GenerateRandomString(100);
-            container->add(std::make_shared<string_value>(key, value));
+            container->add(make_string_value(key, value));
 
             current_size = container->serialize().size();
             counter++;

--- a/integration_tests/performance/serialization_performance_test.cpp
+++ b/integration_tests/performance/serialization_performance_test.cpp
@@ -146,7 +146,7 @@ TEST_F(SerializationPerformanceTest, ValueAdditionThroughput)
 
     auto ops_per_sec = TestHelpers::MeasureThroughput([]() {
         auto temp = std::make_shared<value_container>();
-        temp->add(std::make_shared<string_value>("key", "value"));
+        temp->add(make_string_value("key", "value"));
     }, ITERATIONS);
 
     std::cout << "Value addition: " << ops_per_sec << " ops/sec" << std::endl;

--- a/integration_tests/scenarios/container_lifecycle_test.cpp
+++ b/integration_tests/scenarios/container_lifecycle_test.cpp
@@ -133,9 +133,9 @@ TEST_F(ContainerLifecycleTest, ValueAdditionAndRetrieval)
 TEST_F(ContainerLifecycleTest, MultipleValuesWithSameKey)
 {
     // Use add() to allow duplicate keys
-    container->add(std::make_shared<string_value>("item", "first"));
-    container->add(std::make_shared<string_value>("item", "second"));
-    container->add(std::make_shared<string_value>("item", "third"));
+    container->add(make_string_value("item", "first"));
+    container->add(make_string_value("item", "second"));
+    container->add(make_string_value("item", "third"));
 
     // Iterate through container to find all values with key "item"
     std::vector<std::string> items;
@@ -240,7 +240,7 @@ TEST_F(ContainerLifecycleTest, NestedContainerStructure)
 {
     auto nested = std::make_shared<value_container>();
     nested->set_message_type("nested_msg");
-    nested->add(std::make_shared<string_value>("nested_key", "nested_value"));
+    nested->add(make_string_value("nested_key", "nested_value"));
 
     // Serialize nested container
     std::string nested_data = nested->serialize();

--- a/tests/benchmark_tests.cpp
+++ b/tests/benchmark_tests.cpp
@@ -80,7 +80,7 @@ BENCHMARK(BM_ValueCreation_Null);
 
 static void BM_ValueCreation_Bool(benchmark::State& state) {
     for (auto _ : state) {
-        auto val = std::make_shared<bool_value>("test", true);
+        auto val = make_bool_value("test", true);
         benchmark::DoNotOptimize(val);
     }
 }
@@ -88,7 +88,7 @@ BENCHMARK(BM_ValueCreation_Bool);
 
 static void BM_ValueCreation_Int32(benchmark::State& state) {
     for (auto _ : state) {
-        auto val = std::make_shared<int_value>("test", 42);
+        auto val = make_int_value("test", 42);
         benchmark::DoNotOptimize(val);
     }
 }
@@ -96,7 +96,7 @@ BENCHMARK(BM_ValueCreation_Int32);
 
 static void BM_ValueCreation_Double(benchmark::State& state) {
     for (auto _ : state) {
-        auto val = std::make_shared<double_value>("test", 3.14159);
+        auto val = make_double_value("test", 3.14159);
         benchmark::DoNotOptimize(val);
     }
 }
@@ -105,7 +105,7 @@ BENCHMARK(BM_ValueCreation_Double);
 static void BM_ValueCreation_String(benchmark::State& state) {
     std::string data = generate_random_string(state.range(0));
     for (auto _ : state) {
-        auto val = std::make_shared<string_value>("test", data);
+        auto val = make_string_value("test", data);
         benchmark::DoNotOptimize(val);
     }
     state.SetBytesProcessed(state.iterations() * state.range(0));
@@ -116,7 +116,7 @@ static void BM_ValueCreation_Bytes(benchmark::State& state) {
     std::vector<uint8_t> data(state.range(0), 0xFF);
     
     for (auto _ : state) {
-        auto val = std::make_shared<bytes_value>("test", data);
+        auto val = make_bytes_value("test", data);
         benchmark::DoNotOptimize(val);
     }
     state.SetBytesProcessed(state.iterations() * state.range(0));
@@ -128,7 +128,7 @@ BENCHMARK(BM_ValueCreation_Bytes)->Range(8, 8<<10);
 // ============================================================================
 
 static void BM_ValueConversion_StringToInt(benchmark::State& state) {
-    auto val = std::make_shared<string_value>("test", "12345");
+    auto val = make_string_value("test", "12345");
     
     for (auto _ : state) {
         int result = val->to_int();
@@ -138,7 +138,7 @@ static void BM_ValueConversion_StringToInt(benchmark::State& state) {
 BENCHMARK(BM_ValueConversion_StringToInt);
 
 static void BM_ValueConversion_IntToString(benchmark::State& state) {
-    auto val = std::make_shared<int_value>("test", 12345);
+    auto val = make_int_value("test", 12345);
     
     for (auto _ : state) {
         std::string result = val->to_string();
@@ -148,7 +148,7 @@ static void BM_ValueConversion_IntToString(benchmark::State& state) {
 BENCHMARK(BM_ValueConversion_IntToString);
 
 static void BM_ValueConversion_DoubleToString(benchmark::State& state) {
-    auto val = std::make_shared<double_value>("test", 3.14159265358979);
+    auto val = make_double_value("test", 3.14159265358979);
     
     for (auto _ : state) {
         std::string result = val->to_string();
@@ -171,7 +171,7 @@ BENCHMARK(BM_ContainerCreation_Empty);
 
 static void BM_ContainerAddValue(benchmark::State& state) {
     auto container = std::make_unique<value_container>();
-    auto val = std::make_shared<string_value>("test", "data");
+    auto val = make_string_value("test", "data");
     
     for (auto _ : state) {
         state.PauseTiming();
@@ -192,7 +192,7 @@ static void BM_ContainerAddMultipleValues(benchmark::State& state) {
     
     // Pre-create values
     for (int i = 0; i < state.range(0); ++i) {
-        values.push_back(std::make_shared<string_value>(
+        values.push_back(make_string_value(
             "key" + std::to_string(i), 
             "value" + std::to_string(i)
         ));
@@ -217,7 +217,7 @@ static void BM_ContainerGetValue(benchmark::State& state) {
     
     // Add values
     for (int i = 0; i < state.range(0); ++i) {
-        container->add(std::make_shared<string_value>(
+        container->add(make_string_value(
             "key" + std::to_string(i), 
             "value" + std::to_string(i)
         ));
@@ -245,7 +245,7 @@ static void BM_ContainerSerialize(benchmark::State& state) {
     
     // Add values
     for (int i = 0; i < state.range(0); ++i) {
-        container->add(std::make_shared<string_value>(
+        container->add(make_string_value(
             "key" + std::to_string(i), 
             "value" + std::to_string(i)
         ));
@@ -267,7 +267,7 @@ static void BM_ContainerDeserialize(benchmark::State& state) {
     
     // Add values
     for (int i = 0; i < state.range(0); ++i) {
-        container->add(std::make_shared<string_value>(
+        container->add(make_string_value(
             "key" + std::to_string(i), 
             "value" + std::to_string(i)
         ));
@@ -293,7 +293,7 @@ static void BM_ContainerToJSON(benchmark::State& state) {
     
     // Add values
     for (int i = 0; i < state.range(0); ++i) {
-        container->add(std::make_shared<string_value>(
+        container->add(make_string_value(
             "key" + std::to_string(i), 
             "value" + std::to_string(i)
         ));
@@ -313,7 +313,7 @@ static void BM_ContainerToXML(benchmark::State& state) {
     
     // Add values
     for (int i = 0; i < state.range(0); ++i) {
-        container->add(std::make_shared<string_value>(
+        container->add(make_string_value(
             "key" + std::to_string(i), 
             "value" + std::to_string(i)
         ));
@@ -336,7 +336,7 @@ static void BM_LargeStringHandling(benchmark::State& state) {
     
     for (auto _ : state) {
         auto container = std::make_unique<value_container>();
-        container->add(std::make_shared<string_value>("large", large_data));
+        container->add(make_string_value("large", large_data));
         
         std::string serialized = container->serialize();
         auto restored = std::make_unique<value_container>(serialized);
@@ -354,7 +354,7 @@ static void BM_LargeBinaryHandling(benchmark::State& state) {
     
     for (auto _ : state) {
         auto container = std::make_unique<value_container>();
-        container->add(std::make_shared<bytes_value>("binary", binary_data));
+        container->add(make_bytes_value("binary", binary_data));
         
         std::string serialized = container->serialize();
         auto restored = std::make_unique<value_container>(serialized);
@@ -446,7 +446,7 @@ static void BM_MemoryPattern_SmallValues(benchmark::State& state) {
         values.reserve(state.range(0));
         
         for (int i = 0; i < state.range(0); ++i) {
-            values.push_back(std::make_shared<int_value>(
+            values.push_back(make_int_value(
                 "k", 1
             ));
         }
@@ -465,7 +465,7 @@ static void BM_MemoryPattern_LargeValues(benchmark::State& state) {
         values.reserve(state.range(0));
         
         for (int i = 0; i < state.range(0); ++i) {
-            values.push_back(std::make_shared<string_value>(
+            values.push_back(make_string_value(
                 "key", large_string
             ));
         }
@@ -491,7 +491,7 @@ static void BM_NestedContainer_Create(benchmark::State& state) {
         for (int i = 0; i < depth; ++i) {
             auto nested = std::make_unique<value_container>();
             nested->set_message_type("level_" + std::to_string(i));
-            nested->add(std::make_shared<string_value>("data", "value"));
+            nested->add(make_string_value("data", "value"));
             
             // Serialize nested container
             std::string nested_data = nested->serialize();
@@ -521,7 +521,7 @@ static void BM_NestedContainer_Serialize(benchmark::State& state) {
         
         auto nested = std::make_unique<value_container>();
         nested->set_message_type("level_" + std::to_string(level));
-        nested->add(std::make_shared<string_value>("data", 
+        nested->add(make_string_value("data", 
                                          "value_at_level_" + std::to_string(level)));
         
         // Serialize nested container and add as container value
@@ -547,7 +547,7 @@ static void BM_SIMD_StringSearch(benchmark::State& state) {
     
     // Add many string values
     for (int i = 0; i < 1000; ++i) {
-        container->add(std::make_shared<string_value>(
+        container->add(make_string_value(
             "key" + std::to_string(i), 
             generate_random_string(64)
         ));
@@ -574,7 +574,7 @@ static void BM_WorstCase_ManyDuplicateKeys(benchmark::State& state) {
     
     // Add many values with the same key
     for (int i = 0; i < state.range(0); ++i) {
-        container->add(std::make_shared<string_value>(
+        container->add(make_string_value(
             "duplicate_key", 
             "value_" + std::to_string(i)
         ));
@@ -597,7 +597,7 @@ static void BM_WorstCase_DeepNesting(benchmark::State& state) {
         nested->set_message_type("nested_" + std::to_string(i));
         
         for (int j = 0; j < 10; ++j) {
-            nested->add(std::make_shared<string_value>(
+            nested->add(make_string_value(
                 "data_" + std::to_string(j), 
                 "value"
             ));

--- a/tests/generate_test_data.cpp
+++ b/tests/generate_test_data.cpp
@@ -42,54 +42,54 @@ int main() {
     // Null value (type 0) - not implemented in C++, skip
 
     // Bool value (type 1)
-    cont->add(std::make_shared<bool_value>("bool_true", true));
-    cont->add(std::make_shared<bool_value>("bool_false", false));
+    cont->add(make_bool_value("bool_true", true));
+    cont->add(make_bool_value("bool_false", false));
 
     // Short value (type 2)
-    cont->add(std::make_shared<short_value>("short_neg", static_cast<short>(-1000)));
-    cont->add(std::make_shared<short_value>("short_pos", static_cast<short>(1000)));
+    cont->add(make_short_value("short_neg", static_cast<short>(-1000)));
+    cont->add(make_short_value("short_pos", static_cast<short>(1000)));
 
     // UShort value (type 3)
-    cont->add(std::make_shared<ushort_value>("ushort", static_cast<unsigned short>(50000)));
+    cont->add(make_ushort_value("ushort", static_cast<unsigned short>(50000)));
 
     // Int value (type 4)
-    cont->add(std::make_shared<int_value>("int_neg", -1000000));
-    cont->add(std::make_shared<int_value>("int_pos", 1000000));
+    cont->add(make_int_value("int_neg", -1000000));
+    cont->add(make_int_value("int_pos", 1000000));
 
     // UInt value (type 5)
-    cont->add(std::make_shared<uint_value>("uint", 3000000000U));
+    cont->add(make_uint_value("uint", 3000000000U));
 
     // Long value (type 6) - 32-bit enforced
-    cont->add(std::make_shared<long_value>("long_32bit", 2000000000L));
+    cont->add(make_long_value("long_32bit", 2000000000L));
 
     // ULong value (type 7) - 32-bit enforced
-    cont->add(std::make_shared<ulong_value>("ulong_32bit", 3500000000UL));
+    cont->add(make_ulong_value("ulong_32bit", 3500000000UL));
 
     // LLong value (type 8) - 64-bit
-    cont->add(std::make_shared<llong_value>("llong_64bit", 5000000000LL));
+    cont->add(make_llong_value("llong_64bit", 5000000000LL));
 
     // ULLong value (type 9) - 64-bit
-    cont->add(std::make_shared<ullong_value>("ullong_64bit", 10000000000ULL));
+    cont->add(make_ullong_value("ullong_64bit", 10000000000ULL));
 
     // Float value (type 10)
-    cont->add(std::make_shared<float_value>("float_pi", 3.14159f));
+    cont->add(make_float_value("float_pi", 3.14159f));
 
     // Double value (type 11)
-    cont->add(std::make_shared<double_value>("double_pi", 3.141592653589793));
+    cont->add(make_double_value("double_pi", 3.141592653589793));
 
     // Bytes value (type 12)
     std::vector<uint8_t> bytes_data = {0x01, 0x02, 0x03, 0xFF, 0xFE};
-    cont->add(std::make_shared<bytes_value>("bytes_test", bytes_data));
+    cont->add(make_bytes_value("bytes_test", bytes_data));
 
     // String value (type 13)
-    cont->add(std::make_shared<string_value>("string_hello", "Hello from C++!"));
-    cont->add(std::make_shared<string_value>("string_utf8", "UTF-8: 한글 테스트"));
+    cont->add(make_string_value("string_hello", "Hello from C++!"));
+    cont->add(make_string_value("string_utf8", "UTF-8: 한글 테스트"));
 
     // Container value (type 14) - nested
     auto nested = std::make_shared<value_container>();
     nested->set_message_type("nested_container");
-    nested->add(std::make_shared<int_value>("nested_int", 42));
-    nested->add(std::make_shared<string_value>("nested_str", "nested"));
+    nested->add(make_int_value("nested_int", 42));
+    nested->add(make_string_value("nested_str", "nested"));
     cont->add(nested);
 
     // Serialize to file
@@ -110,7 +110,7 @@ int main() {
     // Also generate a simple test case with just one long value
     auto simple = std::make_shared<value_container>();
     simple->set_message_type("simple_test");
-    simple->add(std::make_shared<long_value>("timestamp", 1234567890L));
+    simple->add(make_long_value("timestamp", 1234567890L));
     auto simple_data = simple->serialize_array();
 
     std::ofstream simple_file("test_data_cpp_simple.bin", std::ios::binary);

--- a/tests/performance_tests.cpp
+++ b/tests/performance_tests.cpp
@@ -173,7 +173,7 @@ TEST_F(PerformanceTest, ValueAdditionPerformance) {
 
                 for (int j = 0; j < values_per_container; ++j) {
                     std::string key = "key_" + std::to_string(j);
-                    auto value = std::make_shared<int_value>(key, i * j);
+                    auto value = make_int_value(key, i * j);
                     container->add(value);
                 }
             }
@@ -199,15 +199,15 @@ TEST_F(PerformanceTest, SerializationPerformance) {
     container->set_message_type("serialization_benchmark");
 
     // Add various types of values
-    container->add(std::make_shared<string_value>("string_data", "Lorem ipsum dolor sit amet, consectetur adipiscing elit"));
-    container->add(std::make_shared<int_value>("int_data", 123456789));
-    container->add(std::make_shared<llong_value>("long_data", 9223372036854775807LL));
-    container->add(std::make_shared<double_value>("double_data", 3.141592653589793));
-    container->add(std::make_shared<bool_value>("bool_data", true));
+    container->add(make_string_value("string_data", "Lorem ipsum dolor sit amet, consectetur adipiscing elit"));
+    container->add(make_int_value("int_data", 123456789));
+    container->add(make_llong_value("long_data", 9223372036854775807LL));
+    container->add(make_double_value("double_data", 3.141592653589793));
+    container->add(make_bool_value("bool_data", true));
 
     // Add binary data
     std::vector<uint8_t> binary_data(1024, 0xAB);
-    container->add(std::make_shared<bytes_value>("bytes_data", binary_data));
+    container->add(make_bytes_value("bytes_data", binary_data));
 
     std::vector<double> serialization_rates;
     const int num_runs = 10;
@@ -241,9 +241,9 @@ TEST_F(PerformanceTest, DeserializationPerformance) {
     original->set_target("deserialization_target", "perf_handler");
     original->set_message_type("deserialization_benchmark");
 
-    original->add(std::make_shared<string_value>("test_string", "Performance test data"));
-    original->add(std::make_shared<int_value>("test_int", 42));
-    original->add(std::make_shared<double_value>("test_double", 2.71828));
+    original->add(make_string_value("test_string", "Performance test data"));
+    original->add(make_int_value("test_int", 42));
+    original->add(make_double_value("test_double", 2.71828));
 
     std::string serialized_data = original->serialize();
 
@@ -312,9 +312,9 @@ TEST_F(PerformanceTest, ThreadSafetyStressTest) {
                 container->set_message_type("stress_test");
 
                 // Add random values
-                container->add(std::make_shared<int_value>("iteration", i));
-                container->add(std::make_shared<int_value>("thread_id", t));
-                container->add(std::make_shared<string_value>("data", "stress_test_data_" + std::to_string(i)));
+                container->add(make_int_value("iteration", i));
+                container->add(make_int_value("thread_id", t));
+                container->add(make_string_value("data", "stress_test_data_" + std::to_string(i)));
 
                 // Serialize occasionally
                 if (i % 100 == 0) {
@@ -375,9 +375,9 @@ TEST_F(PerformanceTest, MemoryUsageTest) {
         container->set_message_type("memory_benchmark");
 
         // Add some values
-        container->add(std::make_shared<int_value>("index", i));
-        container->add(std::make_shared<string_value>("description", "Memory test container " + std::to_string(i)));
-        container->add(std::make_shared<double_value>("value", i * 3.14159));
+        container->add(make_int_value("index", i));
+        container->add(make_string_value("description", "Memory test container " + std::to_string(i)));
+        container->add(make_double_value("value", i * 3.14159));
 
         containers.push_back(container);
     }
@@ -512,19 +512,19 @@ TEST_F(PerformanceTest, LargeScaleStressTest) {
             std::string key = "key_" + std::to_string(j);
             switch (j % 5) {
                 case 0:
-                    container->add(std::make_shared<string_value>(key, "stress_test_" + std::to_string(i)));
+                    container->add(make_string_value(key, "stress_test_" + std::to_string(i)));
                     break;
                 case 1:
-                    container->add(std::make_shared<int_value>(key, i + j));
+                    container->add(make_int_value(key, i + j));
                     break;
                 case 2:
-                    container->add(std::make_shared<double_value>(key, (i + j) * 0.001));
+                    container->add(make_double_value(key, (i + j) * 0.001));
                     break;
                 case 3:
-                    container->add(std::make_shared<bool_value>(key, (i + j) % 2 == 0));
+                    container->add(make_bool_value(key, (i + j) % 2 == 0));
                     break;
                 case 4:
-                    container->add(std::make_shared<int_value>(key, (i * 1000 + j) % 2147483647));
+                    container->add(make_int_value(key, (i * 1000 + j) % 2147483647));
                     break;
             }
         }

--- a/tests/test_long_range_checking.cpp
+++ b/tests/test_long_range_checking.cpp
@@ -40,36 +40,36 @@ protected:
 
 TEST_F(LongRangeCheckingTest, LongValueAcceptsValidPositiveValue) {
     EXPECT_NO_THROW({
-        long_value lv("test", static_cast<int64_t>(1000000));
-        EXPECT_EQ(lv.to_long(), 1000000);
+        value lv("test", static_cast<int64_t>(1000000));
+        EXPECT_EQ(to_long(lv), 1000000);
     });
 }
 
 TEST_F(LongRangeCheckingTest, LongValueAcceptsValidNegativeValue) {
     EXPECT_NO_THROW({
-        long_value lv("test", static_cast<int64_t>(-1000000));
-        EXPECT_EQ(lv.to_long(), -1000000);
+        value lv("test", static_cast<int64_t>(-1000000));
+        EXPECT_EQ(to_long(lv), -1000000);
     });
 }
 
 TEST_F(LongRangeCheckingTest, LongValueAcceptsZero) {
     EXPECT_NO_THROW({
-        long_value lv("test", static_cast<int64_t>(0));
-        EXPECT_EQ(lv.to_long(), 0);
+        value lv("test", static_cast<int64_t>(0));
+        EXPECT_EQ(to_long(lv), 0);
     });
 }
 
 TEST_F(LongRangeCheckingTest, LongValueAcceptsInt32Max) {
     EXPECT_NO_THROW({
-        long_value lv("test", static_cast<int64_t>(kInt32Max));
-        EXPECT_EQ(lv.to_long(), kInt32Max);
+        value lv("test", static_cast<int64_t>(kInt32Max));
+        EXPECT_EQ(to_long(lv), kInt32Max);
     });
 }
 
 TEST_F(LongRangeCheckingTest, LongValueAcceptsInt32Min) {
     EXPECT_NO_THROW({
-        long_value lv("test", static_cast<int64_t>(kInt32Min));
-        EXPECT_EQ(lv.to_long(), kInt32Min);
+        value lv("test", static_cast<int64_t>(kInt32Min));
+        EXPECT_EQ(to_long(lv), kInt32Min);
     });
 }
 
@@ -79,25 +79,25 @@ TEST_F(LongRangeCheckingTest, LongValueAcceptsInt32Min) {
 
 TEST_F(LongRangeCheckingTest, DISABLED_LongValueRejectsInt32MaxPlusOne) {
     EXPECT_THROW({
-        long_value lv("test", static_cast<long>(kInt32Max) + 1);
+        value lv("test", static_cast<long>(kInt32Max) + 1);
     }, std::overflow_error);
 }
 
 TEST_F(LongRangeCheckingTest, DISABLED_LongValueRejectsInt32MinMinusOne) {
     EXPECT_THROW({
-        long_value lv("test", static_cast<long>(kInt32Min) - 1);
+        value lv("test", static_cast<long>(kInt32Min) - 1);
     }, std::overflow_error);
 }
 
 TEST_F(LongRangeCheckingTest, DISABLED_LongValueRejectsLargePositiveValue) {
     EXPECT_THROW({
-        long_value lv("test", 5000000000L); // 5 billion
+        value lv("test", 5000000000L); // 5 billion
     }, std::overflow_error);
 }
 
 TEST_F(LongRangeCheckingTest, DISABLED_LongValueRejectsLargeNegativeValue) {
     EXPECT_THROW({
-        long_value lv("test", -5000000000L); // -5 billion
+        value lv("test", -5000000000L); // -5 billion
     }, std::overflow_error);
 }
 
@@ -109,22 +109,22 @@ TEST_F(LongRangeCheckingTest, DISABLED_LongValueRejectsLargeNegativeValue) {
 
 TEST_F(LongRangeCheckingTest, ULongValueAcceptsValidValue) {
     EXPECT_NO_THROW({
-        ulong_value ulv("test", static_cast<uint64_t>(1000000));
-        EXPECT_EQ(ulv.to_ulong(), 1000000);
+        value ulv("test", static_cast<uint64_t>(1000000));
+        EXPECT_EQ(to_ulong(ulv), 1000000u);
     });
 }
 
 TEST_F(LongRangeCheckingTest, ULongValueAcceptsZero) {
     EXPECT_NO_THROW({
-        ulong_value ulv("test", static_cast<uint64_t>(0));
-        EXPECT_EQ(ulv.to_ulong(), 0);
+        value ulv("test", static_cast<uint64_t>(0));
+        EXPECT_EQ(to_ulong(ulv), 0u);
     });
 }
 
 TEST_F(LongRangeCheckingTest, ULongValueAcceptsUInt32Max) {
     EXPECT_NO_THROW({
-        ulong_value ulv("test", static_cast<uint64_t>(kUInt32Max));
-        EXPECT_EQ(ulv.to_ulong(), kUInt32Max);
+        value ulv("test", static_cast<uint64_t>(kUInt32Max));
+        EXPECT_EQ(to_ulong(ulv), kUInt32Max);
     });
 }
 
@@ -133,13 +133,13 @@ TEST_F(LongRangeCheckingTest, ULongValueAcceptsUInt32Max) {
 
 TEST_F(LongRangeCheckingTest, DISABLED_ULongValueRejectsUInt32MaxPlusOne) {
     EXPECT_THROW({
-        ulong_value ulv("test", static_cast<unsigned long>(kUInt32Max) + 1);
+        value ulv("test", static_cast<unsigned long>(kUInt32Max) + 1);
     }, std::overflow_error);
 }
 
 TEST_F(LongRangeCheckingTest, DISABLED_ULongValueRejectsLargeValue) {
     EXPECT_THROW({
-        ulong_value ulv("test", 10000000000UL); // 10 billion
+        value ulv("test", 10000000000UL); // 10 billion
     }, std::overflow_error);
 }
 
@@ -150,17 +150,17 @@ TEST_F(LongRangeCheckingTest, DISABLED_ULongValueRejectsLargeValue) {
 // ============================================================================
 
 TEST_F(LongRangeCheckingTest, LongValueSerializesCorrectly) {
-    long_value lv("test", static_cast<int64_t>(12345));
-    std::string serialized = lv.serialize();
+    value lv("test", static_cast<int64_t>(12345));
+    auto serialized = lv.serialize();
     // Serialized format includes type info, so we just verify it doesn't throw
-    EXPECT_FALSE(serialized.empty()) << "long_value must serialize to non-empty string";
+    EXPECT_FALSE(serialized.empty()) << "value with long must serialize to non-empty data";
 }
 
 TEST_F(LongRangeCheckingTest, ULongValueSerializesCorrectly) {
-    ulong_value ulv("test", static_cast<uint64_t>(12345));
-    std::string serialized = ulv.serialize();
+    value ulv("test", static_cast<uint64_t>(12345));
+    auto serialized = ulv.serialize();
     // Serialized format includes type info, so we just verify it doesn't throw
-    EXPECT_FALSE(serialized.empty()) << "ulong_value must serialize to non-empty string";
+    EXPECT_FALSE(serialized.empty()) << "value with ulong must serialize to non-empty data";
 }
 
 // ============================================================================
@@ -168,19 +168,19 @@ TEST_F(LongRangeCheckingTest, ULongValueSerializesCorrectly) {
 // ============================================================================
 
 TEST_F(LongRangeCheckingTest, LongValueCompatibleWithLLongValue) {
-    // A long_value should be safely convertible to llong_value
-    long_value lv("test", static_cast<int64_t>(12345));
-    llong_value llv("test2", lv.to_llong());
+    // A value with int64_t should be safely convertible
+    value lv("test", static_cast<int64_t>(12345));
+    value llv("test2", to_llong(lv));
 
-    EXPECT_EQ(llv.to_llong(), 12345LL);
+    EXPECT_EQ(to_llong(llv), 12345LL);
 }
 
 TEST_F(LongRangeCheckingTest, ULongValueCompatibleWithULLongValue) {
-    // A ulong_value should be safely convertible to ullong_value
-    ulong_value ulv("test", static_cast<uint64_t>(12345));
-    ullong_value ullv("test2", ulv.to_ullong());
+    // A value with uint64_t should be safely convertible
+    value ulv("test", static_cast<uint64_t>(12345));
+    value ullv("test2", to_ullong(ulv));
 
-    EXPECT_EQ(ullv.to_ullong(), 12345ULL);
+    EXPECT_EQ(to_ullong(ullv), 12345ULL);
 }
 
 // ============================================================================
@@ -191,7 +191,7 @@ TEST_F(LongRangeCheckingTest, ULongValueCompatibleWithULLongValue) {
 
 TEST_F(LongRangeCheckingTest, DISABLED_LongValueErrorMessageIsDescriptive) {
     try {
-        long_value lv("test", 5000000000L);
+        value lv("test", 5000000000L);
         FAIL() << "Expected std::overflow_error";
     } catch (const std::overflow_error& e) {
         std::string msg = e.what();
@@ -203,7 +203,7 @@ TEST_F(LongRangeCheckingTest, DISABLED_LongValueErrorMessageIsDescriptive) {
 
 TEST_F(LongRangeCheckingTest, DISABLED_ULongValueErrorMessageIsDescriptive) {
     try {
-        ulong_value ulv("test", 10000000000UL);
+        value ulv("test", 10000000000UL);
         FAIL() << "Expected std::overflow_error";
     } catch (const std::overflow_error& e) {
         std::string msg = e.what();

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -82,89 +82,89 @@ protected:
 
 TEST_F(ValueTest, NullValueCreation) {
     std::string key = "test_null";
-    auto null_val = std::make_shared<legacy_value>(key);
+    auto null_val = std::make_shared<value>(key);
 
     EXPECT_EQ(null_val->name(), "test_null");
     EXPECT_EQ(null_val->type(), value_types::null_value);
     EXPECT_TRUE(null_val->is_null());
-    EXPECT_FALSE(null_val->is_boolean());
-    EXPECT_FALSE(null_val->is_numeric());
-    EXPECT_FALSE(null_val->is_string());
-    EXPECT_FALSE(null_val->is_container());
+    EXPECT_FALSE(is_boolean(*null_val));
+    EXPECT_FALSE(is_numeric(*null_val));
+    EXPECT_FALSE(is_string(*null_val));
+    EXPECT_FALSE(is_container(*null_val));
 }
 
 TEST_F(ValueTest, BooleanValueCreation) {
     // Test true value
     std::string key1 = "test_bool";
-    auto true_val = make_legacy_bool_value(key1, true);
+    auto true_val = make_bool_value(key1, true);
     EXPECT_EQ(true_val->name(), "test_bool");
     EXPECT_EQ(true_val->type(), value_types::bool_value);
-    EXPECT_TRUE(true_val->is_boolean());
-    EXPECT_TRUE(true_val->to_boolean());
+    EXPECT_TRUE(is_boolean(*true_val));
+    EXPECT_TRUE(to_boolean(*true_val));
 
     // Test false value
     std::string key2 = "test_bool2";
-    auto false_val = make_legacy_bool_value(key2, false);
-    EXPECT_FALSE(false_val->to_boolean());
+    auto false_val = make_bool_value(key2, false);
+    EXPECT_FALSE(to_boolean(*false_val));
 
     // Test string that converts to boolean (via helper)
     std::string key3 = "test_str_true";
-    auto str_true_val = make_legacy_string_value(key3, "true");
-    EXPECT_TRUE(str_true_val->to_boolean());
+    auto str_true_val = make_string_value(key3, "true");
+    EXPECT_TRUE(to_boolean(*str_true_val));
 
     std::string key4 = "test_str_false";
-    auto str_false_val = make_legacy_string_value(key4, "false");
-    EXPECT_FALSE(str_false_val->to_boolean());
+    auto str_false_val = make_string_value(key4, "false");
+    EXPECT_FALSE(to_boolean(*str_false_val));
 }
 
 TEST_F(ValueTest, NumericValueCreation) {
     // Test int
     std::string key_int = "test_int";
-    auto int_val = make_legacy_int_value(key_int, 42);
+    auto int_val = make_int_value(key_int, 42);
     EXPECT_EQ(int_val->type(), value_types::int_value);
-    EXPECT_TRUE(int_val->is_numeric());
-    EXPECT_EQ(int_val->to_int(), 42);
-    EXPECT_EQ(int_val->to_long(), 42L);
-    EXPECT_DOUBLE_EQ(int_val->to_double(), 42.0);
+    EXPECT_TRUE(is_numeric(*int_val));
+    EXPECT_EQ(to_int(*int_val), 42);
+    EXPECT_EQ(to_long(*int_val), 42L);
+    EXPECT_DOUBLE_EQ(to_double(*int_val), 42.0);
 
     // Test long long
     std::string key_llong = "test_llong";
-    auto llong_val = make_legacy_llong_value(key_llong, 9223372036854775807LL);
-    EXPECT_EQ(llong_val->to_llong(), 9223372036854775807LL);
+    auto llong_val = make_llong_value(key_llong, 9223372036854775807LL);
+    EXPECT_EQ(to_llong(*llong_val), 9223372036854775807LL);
 
     // Test double
     std::string key_double = "test_double";
-    auto double_val = make_legacy_double_value(key_double, 3.14159);
-    EXPECT_DOUBLE_EQ(double_val->to_double(), 3.14159);
+    auto double_val = make_double_value(key_double, 3.14159);
+    EXPECT_DOUBLE_EQ(to_double(*double_val), 3.14159);
 
     // Test negative values
     std::string key_neg = "test_neg";
-    auto neg_val = make_legacy_int_value(key_neg, -100);
-    EXPECT_EQ(neg_val->to_int(), -100);
+    auto neg_val = make_int_value(key_neg, -100);
+    EXPECT_EQ(to_int(*neg_val), -100);
 }
 
 TEST_F(ValueTest, StringValueCreation) {
     std::string key = "test_string";
     std::string val = "Hello, World!";
-    auto str_val = make_legacy_string_value(key, val);
+    auto str_val = make_string_value(key, val);
 
     EXPECT_EQ(str_val->type(), value_types::string_value);
-    EXPECT_TRUE(str_val->is_string());
+    EXPECT_TRUE(is_string(*str_val));
     EXPECT_EQ(str_val->to_string(), "Hello, World!");
-    // Note: size() returns internal data size after conversion, not original string length
-    EXPECT_GT(str_val->size(), 0); // Just verify data exists
+    // Note: value_size() returns internal data size after conversion, not original string length
+    EXPECT_GT(value_size(*str_val), 0); // Just verify data exists
 }
 
 TEST_F(ValueTest, BytesValueCreation) {
     std::vector<uint8_t> test_data = {0x01, 0x02, 0x03, 0x04, 0xFF};
 
     std::string key = "test_bytes";
-    auto bytes_val = make_legacy_bytes_value(key, test_data);
+    auto bytes_val = make_bytes_value(key, test_data);
 
     EXPECT_EQ(bytes_val->type(), value_types::bytes_value);
-    EXPECT_TRUE(bytes_val->is_bytes());
+    EXPECT_TRUE(is_bytes(*bytes_val));
 
-    auto retrieved_bytes = bytes_val->to_bytes();
+    auto retrieved_bytes = to_bytes(*bytes_val);
     EXPECT_EQ(retrieved_bytes.size(), test_data.size());
     EXPECT_EQ(retrieved_bytes, test_data);
 }
@@ -172,12 +172,12 @@ TEST_F(ValueTest, BytesValueCreation) {
 TEST_F(ValueTest, ValueTypeSerialization) {
     // Test each value type serialization
     std::string key1 = "bool";
-    auto bool_val = make_legacy_bool_value(key1, true);
+    auto bool_val = make_bool_value(key1, true);
     std::string key2 = "int";
-    auto int_val = make_legacy_int_value(key2, 42);
+    auto int_val = make_int_value(key2, 42);
     std::string key3 = "str";
     std::string val3 = "test";
-    auto str_val = make_legacy_string_value(key3, val3);
+    auto str_val = make_string_value(key3, val3);
 
     // Serialize values (returns vector<uint8_t>)
     auto bool_ser = bool_val->serialize();
@@ -459,23 +459,23 @@ TEST(ErrorHandlingTest, InvalidSerializationHandling) {
 TEST(ErrorHandlingTest, TypeConversionErrors) {
     std::string key = "test";
     std::string val = "not_a_number";
-    auto str_val = make_legacy_string_value(key, val);
+    auto str_val = make_string_value(key, val);
 
     // String to int conversion should handle gracefully
-    EXPECT_EQ(str_val->to_int(), 0); // Default value for failed conversion
+    EXPECT_EQ(to_int(*str_val), 0); // Default value for failed conversion
 }
 
 // Disabled: Value class doesn't throw on null conversions - returns defaults instead
 // TODO: Consider implementing exception throwing for null value conversions
 TEST(ErrorHandlingTest, DISABLED_NullValueConversions) {
     std::string key = "null";
-    auto null_val = std::make_shared<legacy_value>(key);
+    auto null_val = std::make_shared<value>(key);
 
-    // With legacy_value, null conversions return default values rather than throwing
+    // With value class, null conversions return default values rather than throwing
     // This test is disabled as the current implementation doesn't throw
-    EXPECT_EQ(null_val->to_boolean(), false);
-    EXPECT_EQ(null_val->to_int(), 0);
-    EXPECT_EQ(null_val->to_double(), 0.0);
+    EXPECT_EQ(to_boolean(*null_val), false);
+    EXPECT_EQ(to_int(*null_val), 0);
+    EXPECT_EQ(to_double(*null_val), 0.0);
 }
 
 // ============================================================================
@@ -595,13 +595,13 @@ TEST(EdgeCaseTest, MaximumValues) {
     std::string min_int_key = "min_int";
     std::string max_llong_key = "max_llong";
 
-    auto max_int = make_legacy_int_value(max_int_key, std::numeric_limits<int>::max());
-    auto min_int = make_legacy_int_value(min_int_key, std::numeric_limits<int>::min());
-    auto max_llong = make_legacy_llong_value(max_llong_key, std::numeric_limits<long long>::max());
+    auto max_int = make_int_value(max_int_key, std::numeric_limits<int>::max());
+    auto min_int = make_int_value(min_int_key, std::numeric_limits<int>::min());
+    auto max_llong = make_llong_value(max_llong_key, std::numeric_limits<long long>::max());
 
-    EXPECT_EQ(max_int->to_int(), std::numeric_limits<int>::max());
-    EXPECT_EQ(min_int->to_int(), std::numeric_limits<int>::min());
-    EXPECT_EQ(max_llong->to_llong(), std::numeric_limits<long long>::max());
+    EXPECT_EQ(to_int(*max_int), std::numeric_limits<int>::max());
+    EXPECT_EQ(to_int(*min_int), std::numeric_limits<int>::min());
+    EXPECT_EQ(to_llong(*max_llong), std::numeric_limits<long long>::max());
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Remove `legacy_value` wrapper class from `test_compat.h`
- Remove deprecated type aliases (`int_value`, `string_value`, etc.)
- Remove `make_legacy_*` factory functions
- Migrate all tests to use `value` class with free functions

## Changes

### Removed from test_compat.h
- `legacy_value` class (wrapper that provided member function API)
- Deprecated type aliases: `int_value`, `bool_value`, `string_value`, `llong_value`, `long_value`, `ulong_value`, `bytes_value`, `double_value`, `float_value`, `short_value`, `ushort_value`, `uint_value`, `ullong_value`
- Factory functions: `make_legacy_int_value`, `make_legacy_bool_value`, etc.

### Migration Pattern
```cpp
// Before
auto val = std::make_shared<int_value>("key", 42);
EXPECT_EQ(val->to_int(), 42);
EXPECT_TRUE(val->is_numeric());

// After
auto val = make_int_value("key", 42);
EXPECT_EQ(to_int(*val), 42);
EXPECT_TRUE(is_numeric(*val));
```

## Files Modified
- `tests/test_compat.h` - Removed legacy_value and related code
- `tests/unit_tests.cpp` - Migrated to new API
- `tests/performance_tests.cpp` - Migrated to new API
- `tests/benchmark_tests.cpp` - Migrated to new API
- `tests/test_long_range_checking.cpp` - Migrated to new API
- `integration_tests/framework/test_helpers.h` - Migrated to new API
- `integration_tests/framework/system_fixture.h` - Migrated to new API
- And other test files

## Test plan
- [x] All 15 unit tests pass
- [x] Build succeeds without errors
- [x] No legacy_value references remain in test code

Closes #208