### PR TITLE
fix(benchmarks): update value_operations_bench to use optimized_value

### DIFF
--- a/benchmarks/value_operations_bench.cpp
+++ b/benchmarks/value_operations_bench.cpp
@@ -35,13 +35,15 @@
 
 #include <benchmark/benchmark.h>
 #include "container/core/container.h"
-#include "tests/test_compat.h"
 
 using namespace container_module;
 
 static void BM_Value_CreateString(benchmark::State& state) {
     for (auto _ : state) {
-        auto v = std::make_shared<string_value>("test", "test_data");
+        optimized_value v;
+        v.name = "test";
+        v.data = std::string("test_data");
+        v.type = value_types::string_value;
         benchmark::DoNotOptimize(v);
     }
 }
@@ -49,25 +51,34 @@ BENCHMARK(BM_Value_CreateString);
 
 static void BM_Value_CreateNumeric(benchmark::State& state) {
     for (auto _ : state) {
-        auto v = std::make_shared<int_value>("num", 42);
+        optimized_value v;
+        v.name = "num";
+        v.data = int32_t(42);
+        v.type = value_types::int_value;
         benchmark::DoNotOptimize(v);
     }
 }
 BENCHMARK(BM_Value_CreateNumeric);
 
 static void BM_Value_GetData(benchmark::State& state) {
-    auto v = std::make_shared<string_value>("test", "test_data");
+    optimized_value v;
+    v.name = "test";
+    v.data = std::string("test_data");
+    v.type = value_types::string_value;
     for (auto _ : state) {
-        auto data = v->to_string();
+        auto data = variant_helpers::to_string(v.data, v.type);
         benchmark::DoNotOptimize(data);
     }
 }
 BENCHMARK(BM_Value_GetData);
 
 static void BM_Value_ToString(benchmark::State& state) {
-    auto v = std::make_shared<string_value>("test", "test_data");
+    optimized_value v;
+    v.name = "test";
+    v.data = std::string("test_data");
+    v.type = value_types::string_value;
     for (auto _ : state) {
-        auto str = v->to_string();
+        auto str = variant_helpers::to_string(v.data, v.type);
         benchmark::DoNotOptimize(str);
     }
 }


### PR DESCRIPTION
## Summary

Fix build failure in benchmark due to removed legacy value classes.

The legacy polymorphic value classes (`string_value`, `int_value`, etc.) were removed in #211 as part of the variant_value_v2 migration, but this benchmark file was not updated accordingly.

## Changes

- Replace `std::make_shared<string_value>(...)` with `optimized_value` struct
- Replace `std::make_shared<int_value>(...)` with `optimized_value` struct
- Remove unused `tests/test_compat.h` include

## Test plan

- [x] Local build passes
- [x] Benchmarks compile and run correctly

**Note**: This fix is required for PR #212 to pass the "Compare Performance" CI check, which builds both base (main) and PR branches.