### PR TITLE
test(result): add unit tests for file operation Result APIs (#240)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -79,6 +79,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - MessagePack provides 50-80% smaller output than JSON with 2-4x faster parsing
   - Full support for all container value types including nested containers
 
+- **File Operations Result API Tests** (#240): Add comprehensive unit tests for Result-returning file operation APIs
+  - Add 10 test cases covering load_packet_result() and save_packet_result() methods
+  - Test file not found error handling with error_codes::file_not_found verification
+  - Test file write error handling with error_codes::file_write_error verification
+  - Test invalid file content handling with error_codes::deserialization_failed verification
+  - Test file operation round-trip with various data types for data integrity
+  - Test empty file and empty container edge cases
+  - Test file overwrite behavior
+  - Verify error messages contain file path context and module information
+  - Completes Phase 4 of Result pattern extension for file operations
+
 - **Serialization Result API Tests** (#239): Add comprehensive unit tests for Result-returning serialization APIs
   - Add 17 test cases covering serialize_result(), serialize_array_result(), to_json_result(), to_xml_result()
   - Test deserialize_result() success, invalid data, empty data, and corrupted data paths

--- a/docs/CHANGELOG_KO.md
+++ b/docs/CHANGELOG_KO.md
@@ -79,6 +79,17 @@ Container System 프로젝트의 모든 주요 변경 사항이 이 파일에 �
   - MessagePack은 JSON보다 50-80% 작은 출력과 2-4배 빠른 파싱 제공
   - 중첩 컨테이너를 포함한 모든 컨테이너 값 타입 완전 지원
 
+- **파일 작업 Result API 테스트** (#240): Result 반환 파일 작업 API에 대한 포괄적인 단위 테스트 추가
+  - load_packet_result() 및 save_packet_result() 메서드를 커버하는 10개 테스트 케이스 추가
+  - error_codes::file_not_found 검증을 통한 파일 없음 에러 처리 테스트
+  - error_codes::file_write_error 검증을 통한 파일 쓰기 에러 처리 테스트
+  - error_codes::deserialization_failed 검증을 통한 무효 파일 콘텐츠 처리 테스트
+  - 데이터 무결성을 위한 다양한 데이터 타입의 파일 작업 왕복 테스트
+  - 빈 파일 및 빈 컨테이너 엣지 케이스 테스트
+  - 파일 덮어쓰기 동작 테스트
+  - 에러 메시지에 파일 경로 컨텍스트와 모듈 정보가 포함되는지 검증
+  - 파일 작업에 대한 Result 패턴 확장 Phase 4 완료
+
 - **직렬화 Result API 테스트** (#239): Result 반환 직렬화 API에 대한 포괄적인 단위 테스트 추가
   - serialize_result(), serialize_array_result(), to_json_result(), to_xml_result()를 커버하는 17개 테스트 케이스 추가
   - deserialize_result()의 성공, 무효 데이터, 빈 데이터, 손상된 데이터 경로 테스트


### PR DESCRIPTION
## Summary

- Add comprehensive unit tests for `load_packet_result()` and `save_packet_result()` file operation APIs
- Add `FileOperationResultAPITest` test fixture with automated temp directory management
- Test all error code paths: `file_not_found`, `file_write_error`, `deserialization_failed`
- Test success paths and round-trip data integrity

## Test plan

- [x] All 10 new file operation tests pass
- [x] All existing 32 result API tests pass (42 total)
- [x] Build succeeds on macOS

## Closes

Closes #240