### PR TITLE
feat(api): add deprecated attribute to legacy void/bool methods (#241)

### DIFF
--- a/core/container.h
+++ b/core/container.h
@@ -659,7 +659,9 @@ namespace container_module
 		 * @brief Remove a value by name
 		 * @param target_name Name of value to remove
 		 * @param update_immediately Whether to update serialized data immediately
+		 * @deprecated Use remove_result() instead for Result-based error handling
 		 */
+		[[deprecated("Use remove_result() instead for Result-based error handling")]]
 		void remove(std::string_view target_name,
 					bool update_immediately = false);
 
@@ -674,7 +676,9 @@ namespace container_module
 		 * @exception_safety Strong guarantee - no changes on exception
 		 * @throws std::bad_alloc if memory allocation fails
 		 * @throws std::runtime_error if value cannot be serialized
+		 * @deprecated Use serialize_result() instead for Result-based error handling
 		 */
+		[[deprecated("Use serialize_result() instead for Result-based error handling")]]
 		std::string serialize(void) const;
 
 		/**
@@ -682,7 +686,9 @@ namespace container_module
 		 * @exception_safety Strong guarantee - no changes on exception
 		 * @throws std::bad_alloc if memory allocation fails
 		 * @throws std::runtime_error if value cannot be serialized
+		 * @deprecated Use serialize_array_result() instead for Result-based error handling
 		 */
+		[[deprecated("Use serialize_array_result() instead for Result-based error handling")]]
 		std::vector<uint8_t> serialize_array(void) const;
 
 		/**
@@ -690,7 +696,9 @@ namespace container_module
 		 * values are not fully parsed yet.
 		 * @exception_safety Basic guarantee - container may be partially modified
 		 * @return true on success, false on parse error (no exceptions thrown)
+		 * @deprecated Use deserialize_result() instead for Result-based error handling
 		 */
+		[[deprecated("Use deserialize_result() instead for Result-based error handling")]]
 		bool deserialize(const std::string& data_string,
 					 bool parse_only_header = true);
 
@@ -699,7 +707,9 @@ namespace container_module
 		 * true, child values are not fully parsed.
 		 * @exception_safety Basic guarantee - container may be partially modified
 		 * @return true on success, false on parse error (no exceptions thrown)
+		 * @deprecated Use deserialize_result() instead for Result-based error handling
 		 */
+		[[deprecated("Use deserialize_result() instead for Result-based error handling")]]
 		bool deserialize(const std::vector<uint8_t>& data_array,
 					 bool parse_only_header = true);
 
@@ -736,6 +746,7 @@ namespace container_module
 		 * @param parse_only_header If true, child values are not fully parsed
 		 * @return true on success and validation pass, false on parse error or validation failure
 		 * @exception_safety Basic guarantee - container may be partially modified
+		 * @deprecated Use deserialize_result() with schema parameter instead for Result-based error handling
 		 *
 		 * @code
 		 * auto schema = container_schema()
@@ -748,6 +759,7 @@ namespace container_module
 		 * }
 		 * @endcode
 		 */
+		[[deprecated("Use deserialize_result() with schema parameter instead for Result-based error handling")]]
 		bool deserialize(const std::string& data_string,
 						 const container_schema& schema,
 						 bool parse_only_header = false);
@@ -760,7 +772,9 @@ namespace container_module
 		 * @param parse_only_header If true, child values are not fully parsed
 		 * @return true on success and validation pass, false on parse error or validation failure
 		 * @exception_safety Basic guarantee - container may be partially modified
+		 * @deprecated Use deserialize_result() with schema parameter instead for Result-based error handling
 		 */
+		[[deprecated("Use deserialize_result() with schema parameter instead for Result-based error handling")]]
 		bool deserialize(const std::vector<uint8_t>& data_array,
 						 const container_schema& schema,
 						 bool parse_only_header = false);
@@ -822,13 +836,17 @@ namespace container_module
 		/**
 		 * @brief Generate an XML representation of this container (header +
 		 * values).
+		 * @deprecated Use to_xml_result() instead for Result-based error handling
 		 */
+		[[deprecated("Use to_xml_result() instead for Result-based error handling")]]
 		const std::string to_xml(void);
 
 		/**
 		 * @brief Generate a JSON representation of this container (header +
 		 * values).
+		 * @deprecated Use to_json_result() instead for Result-based error handling
 		 */
+		[[deprecated("Use to_json_result() instead for Result-based error handling")]]
 		const std::string to_json(void);
 
 		// =======================================================================
@@ -845,6 +863,7 @@ namespace container_module
 		 * @return Vector of bytes containing the MessagePack-encoded data
 		 * @exception_safety Strong guarantee - no changes on exception
 		 * @throws std::bad_alloc if memory allocation fails
+		 * @deprecated Use to_msgpack_result() instead for Result-based error handling
 		 *
 		 * @code
 		 * auto container = std::make_shared<value_container>();
@@ -853,6 +872,7 @@ namespace container_module
 		 * // msgpack_data contains compact binary representation
 		 * @endcode
 		 */
+		[[deprecated("Use to_msgpack_result() instead for Result-based error handling")]]
 		std::vector<uint8_t> to_msgpack() const;
 
 		/**
@@ -861,6 +881,7 @@ namespace container_module
 		 * @param data MessagePack-encoded binary data
 		 * @return true on success, false on parse error
 		 * @exception_safety Basic guarantee - container may be partially modified
+		 * @deprecated Use from_msgpack_result() instead for Result-based error handling
 		 *
 		 * @code
 		 * std::vector<uint8_t> msgpack_data = get_received_data();
@@ -870,6 +891,7 @@ namespace container_module
 		 * }
 		 * @endcode
 		 */
+		[[deprecated("Use from_msgpack_result() instead for Result-based error handling")]]
 		bool from_msgpack(const std::vector<uint8_t>& data);
 
 		/**
@@ -957,12 +979,16 @@ namespace container_module
 		/**
 		 * @brief Load from a file path (reads entire file content, then calls
 		 * deserialize).
+		 * @deprecated Use load_packet_result() instead for Result-based error handling
 		 */
+		[[deprecated("Use load_packet_result() instead for Result-based error handling")]]
 		void load_packet(const std::string& file_path);
 
 		/**
 		 * @brief Save to a file path (serialize to bytes, then write to file).
+		 * @deprecated Use save_packet_result() instead for Result-based error handling
 		 */
+		[[deprecated("Use save_packet_result() instead for Result-based error handling")]]
 		void save_packet(const std::string& file_path);
 
 		/**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+- **Legacy void/bool API Methods** (#241): Mark legacy methods as deprecated in favor of Result-returning APIs
+  - Deprecate `serialize()` in favor of `serialize_result()`
+  - Deprecate `serialize_array()` in favor of `serialize_array_result()`
+  - Deprecate `deserialize()` in favor of `deserialize_result()`
+  - Deprecate `to_json()` in favor of `to_json_result()`
+  - Deprecate `to_xml()` in favor of `to_xml_result()`
+  - Deprecate `to_msgpack()` in favor of `to_msgpack_result()`
+  - Deprecate `from_msgpack()` in favor of `from_msgpack_result()`
+  - Deprecate `load_packet()` in favor of `load_packet_result()`
+  - Deprecate `save_packet()` in favor of `save_packet_result()`
+  - Deprecate `remove()` in favor of `remove_result()`
+  - Add `docs/guides/RESULT_API_MIGRATION_GUIDE.md` with migration instructions and examples
+  - Part of Issue #231 Phase 5: Backward Compatible Deprecated Wrappers
+
 ### Added
 - **Schema-Validated Deserialization** (#249): Add schema validation support for deserialize operations (Phase 5)
   - Add `deserialize(data, schema)` overloads for string and byte array inputs

--- a/docs/CHANGELOG_KO.md
+++ b/docs/CHANGELOG_KO.md
@@ -11,6 +11,21 @@ Container System 프로젝트의 모든 주요 변경 사항이 이 파일에 �
 
 ## [Unreleased]
 
+### Deprecated
+- **레거시 void/bool API 메서드** (#241): Result 반환 API를 위해 레거시 메서드를 deprecated로 표시
+  - `serialize()`를 `serialize_result()` 대신 사용 권장
+  - `serialize_array()`를 `serialize_array_result()` 대신 사용 권장
+  - `deserialize()`를 `deserialize_result()` 대신 사용 권장
+  - `to_json()`을 `to_json_result()` 대신 사용 권장
+  - `to_xml()`을 `to_xml_result()` 대신 사용 권장
+  - `to_msgpack()`을 `to_msgpack_result()` 대신 사용 권장
+  - `from_msgpack()`을 `from_msgpack_result()` 대신 사용 권장
+  - `load_packet()`을 `load_packet_result()` 대신 사용 권장
+  - `save_packet()`을 `save_packet_result()` 대신 사용 권장
+  - `remove()`를 `remove_result()` 대신 사용 권장
+  - 마이그레이션 지침 및 예제가 포함된 `docs/guides/RESULT_API_MIGRATION_GUIDE.md` 추가
+  - Issue #231 Phase 5: 하위 호환 Deprecated 래퍼의 일부
+
 ### Added
 - **스키마 검증 역직렬화** (#249): 역직렬화 작업에 스키마 검증 지원 추가 (Phase 5)
   - 문자열 및 바이트 배열 입력을 위한 `deserialize(data, schema)` 오버로드 추가

--- a/docs/guides/RESULT_API_MIGRATION_GUIDE.md
+++ b/docs/guides/RESULT_API_MIGRATION_GUIDE.md
@@ -1,0 +1,497 @@
+# Result API Migration Guide
+
+> **Status**: Ready for Production
+> **Version**: 2.0.0
+> **Last Updated**: 2025-01-11
+>
+> **IMPORTANT**: As of this version, the void/bool returning methods are **DEPRECATED**
+> and will be removed in the next major version. Please migrate to Result-returning APIs.
+
+---
+
+## Deprecation Notice
+
+### What's Deprecated?
+
+Starting from this version, the following methods are marked as `[[deprecated]]` and will trigger compiler warnings:
+
+| Deprecated Method | Replacement Method |
+|------------------|-------------------|
+| `serialize()` | `serialize_result()` |
+| `serialize_array()` | `serialize_array_result()` |
+| `deserialize()` | `deserialize_result()` |
+| `to_json()` | `to_json_result()` |
+| `to_xml()` | `to_xml_result()` |
+| `to_msgpack()` | `to_msgpack_result()` |
+| `from_msgpack()` | `from_msgpack_result()` |
+| `load_packet()` | `load_packet_result()` |
+| `save_packet()` | `save_packet_result()` |
+| `remove()` | `remove_result()` |
+
+### Timeline
+
+| Date | Version | Action |
+|------|---------|--------|
+| **2025-01-11** | v2.0.0 | Deprecation warnings added |
+| **TBD** | v2.x.x | Last version supporting deprecated methods |
+| **TBD** | v3.0.0 | Deprecated methods removed, `_result` suffix removed |
+
+**Recommendation**: Complete migration to benefit from proper error handling.
+
+---
+
+## Table of Contents
+
+- [Executive Summary](#executive-summary)
+- [Why Migrate?](#why-migrate)
+- [Migration Strategy](#migration-strategy)
+- [API Comparison](#api-comparison)
+- [Step-by-Step Migration](#step-by-step-migration)
+- [Error Handling Patterns](#error-handling-patterns)
+- [Testing Strategy](#testing-strategy)
+- [FAQ](#faq)
+
+---
+
+## Executive Summary
+
+The Result-based API provides:
+
+- **Type-safe error handling** without exceptions at API boundaries
+- **Detailed error information** with error codes and messages
+- **Consistent API pattern** across all operations
+- **No-throw guarantee** for noexcept methods
+- **Better integration** with C code and other languages
+
+### Benefits
+
+| Aspect | Old API | Result API |
+|--------|---------|------------|
+| Error context | None (bool) or exception | Error code + message |
+| Exception safety | May throw | noexcept (no-throw) |
+| Error propagation | Manual | Built-in chaining |
+| Type safety | Weak | Strong |
+
+---
+
+## Why Migrate?
+
+### Problems with Legacy API
+
+**Problem 1: Lost Error Context**
+
+```cpp
+// OLD: No information about why it failed
+if (!container->deserialize(data)) {
+    // What went wrong? Invalid format? Corrupted data? Version mismatch?
+    std::cerr << "Deserialization failed" << std::endl;
+}
+```
+
+**Problem 2: Exception Handling Required**
+
+```cpp
+// OLD: Must catch exceptions
+try {
+    auto result = container->serialize();
+    // Use result...
+} catch (const std::exception& e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+}
+```
+
+**Problem 3: No Standardized Error Codes**
+
+```cpp
+// OLD: Ad-hoc error handling
+if (!container->deserialize(data)) {
+    // Is it safe to retry? Is the data corrupted?
+    // No way to programmatically distinguish error types
+}
+```
+
+### Solution: Result-based API
+
+```cpp
+// NEW: Rich error information
+auto result = container->deserialize_result(data);
+if (!result.is_ok()) {
+    auto& err = result.error();
+    switch (err.code) {
+        case error_codes::corrupted_data:
+            // Data is corrupted, don't retry
+            break;
+        case error_codes::version_mismatch:
+            // Try legacy format
+            break;
+        default:
+            log_error("Error {}: {}", err.code, err.message);
+    }
+}
+```
+
+---
+
+## Migration Strategy
+
+### Phase 1: Suppress Warnings (Optional)
+
+If you need time before migrating, you can suppress deprecation warnings:
+
+```cpp
+// Suppress warning for a single call
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+container->serialize();  // No warning
+#pragma GCC diagnostic pop
+```
+
+**Note**: This is a temporary measure. We recommend migrating as soon as possible.
+
+### Phase 2: Incremental Migration
+
+Migrate one method at a time:
+
+```cpp
+// Before
+std::string data = container->serialize();
+
+// After
+auto result = container->serialize_result();
+if (result.is_ok()) {
+    std::string data = result.value();
+} else {
+    // Handle error
+}
+```
+
+### Phase 3: Complete Migration
+
+After all methods are migrated, your code will be warning-free and benefit from proper error handling.
+
+---
+
+## API Comparison
+
+### Serialization
+
+```cpp
+// OLD
+std::string serialize();
+std::vector<uint8_t> serialize_array();
+
+// NEW
+[[nodiscard]] Result<std::string> serialize_result() noexcept;
+[[nodiscard]] Result<std::vector<uint8_t>> serialize_array_result() noexcept;
+```
+
+### Deserialization
+
+```cpp
+// OLD
+bool deserialize(const std::string& data, bool parse_only_header = true);
+bool deserialize(const std::vector<uint8_t>& data, bool parse_only_header = true);
+
+// NEW
+[[nodiscard]] VoidResult deserialize_result(const std::string& data,
+                                            bool parse_only_header = true) noexcept;
+[[nodiscard]] VoidResult deserialize_result(const std::vector<uint8_t>& data,
+                                            bool parse_only_header = true) noexcept;
+```
+
+### Value Operations
+
+```cpp
+// OLD (these were already migrated)
+template<typename T>
+void set_value(const std::string& key, T&& value);  // DEPRECATED
+void remove(std::string_view key, bool update_immediately = false);
+
+// NEW
+template<typename T>
+[[nodiscard]] VoidResult set_result(std::string_view key, T&& value) noexcept;
+[[nodiscard]] Result<T> get(std::string_view key) noexcept;  // Already uses Result
+[[nodiscard]] VoidResult remove_result(std::string_view key) noexcept;
+```
+
+### File Operations
+
+```cpp
+// OLD
+void load_packet(const std::string& path);  // Throws on error
+void save_packet(const std::string& path);  // Throws on error
+
+// NEW
+[[nodiscard]] VoidResult load_packet_result(const std::string& path) noexcept;
+[[nodiscard]] VoidResult save_packet_result(const std::string& path) noexcept;
+```
+
+### Format Conversion
+
+```cpp
+// OLD
+const std::string to_json();
+const std::string to_xml();
+std::vector<uint8_t> to_msgpack();
+bool from_msgpack(const std::vector<uint8_t>& data);
+
+// NEW
+[[nodiscard]] Result<std::string> to_json_result() noexcept;
+[[nodiscard]] Result<std::string> to_xml_result() noexcept;
+[[nodiscard]] Result<std::vector<uint8_t>> to_msgpack_result() noexcept;
+[[nodiscard]] VoidResult from_msgpack_result(const std::vector<uint8_t>& data) noexcept;
+```
+
+---
+
+## Step-by-Step Migration
+
+### Example 1: Serialization
+
+```cpp
+// BEFORE
+void save_data(std::shared_ptr<value_container> container) {
+    try {
+        std::string data = container->serialize();
+        write_to_file(data);
+    } catch (const std::exception& e) {
+        std::cerr << "Failed to serialize: " << e.what() << std::endl;
+    }
+}
+
+// AFTER
+void save_data(std::shared_ptr<value_container> container) {
+    auto result = container->serialize_result();
+    if (result.is_ok()) {
+        write_to_file(result.value());
+    } else {
+        std::cerr << "Failed to serialize: " << result.error().message << std::endl;
+    }
+}
+```
+
+### Example 2: Deserialization
+
+```cpp
+// BEFORE
+bool load_data(std::shared_ptr<value_container> container, const std::string& data) {
+    if (!container->deserialize(data)) {
+        std::cerr << "Failed to deserialize" << std::endl;
+        return false;
+    }
+    return true;
+}
+
+// AFTER
+bool load_data(std::shared_ptr<value_container> container, const std::string& data) {
+    auto result = container->deserialize_result(data);
+    if (!result.is_ok()) {
+        auto& err = result.error();
+        std::cerr << "Failed to deserialize (code " << err.code << "): "
+                  << err.message << std::endl;
+        return false;
+    }
+    return true;
+}
+```
+
+### Example 3: File Operations
+
+```cpp
+// BEFORE
+void process_file(std::shared_ptr<value_container> container, const std::string& path) {
+    try {
+        container->load_packet(path);
+        // Process...
+        container->save_packet(path + ".out");
+    } catch (const std::exception& e) {
+        std::cerr << "File operation failed: " << e.what() << std::endl;
+    }
+}
+
+// AFTER
+void process_file(std::shared_ptr<value_container> container, const std::string& path) {
+    if (auto result = container->load_packet_result(path); !result.is_ok()) {
+        std::cerr << "Failed to load: " << result.error().message << std::endl;
+        return;
+    }
+
+    // Process...
+
+    if (auto result = container->save_packet_result(path + ".out"); !result.is_ok()) {
+        std::cerr << "Failed to save: " << result.error().message << std::endl;
+    }
+}
+```
+
+---
+
+## Error Handling Patterns
+
+### Pattern 1: Simple Check
+
+```cpp
+auto result = container->serialize_result();
+if (result.is_ok()) {
+    use_data(result.value());
+} else {
+    handle_error(result.error());
+}
+```
+
+### Pattern 2: Error Code Switch
+
+```cpp
+auto result = container->deserialize_result(data);
+if (!result.is_ok()) {
+    switch (result.error().code) {
+        case error_codes::corrupted_data:
+            log_warning("Data corruption detected");
+            break;
+        case error_codes::version_mismatch:
+            return try_legacy_format(data);
+        case error_codes::invalid_format:
+            return use_default_container();
+        default:
+            throw std::runtime_error(result.error().message);
+    }
+}
+```
+
+### Pattern 3: Early Return
+
+```cpp
+VoidResult process(std::shared_ptr<value_container> container, const std::string& data) {
+    if (auto r = container->deserialize_result(data); !r.is_ok()) {
+        return r;  // Propagate error
+    }
+
+    if (auto r = container->set_result("processed", true); !r.is_ok()) {
+        return r;  // Propagate error
+    }
+
+    return container->serialize_result();  // Return final result
+}
+```
+
+### Pattern 4: Value or Default
+
+```cpp
+// Get value or use default
+auto name = container->get<std::string>("name");
+std::string actual_name = name.is_ok() ? name.value() : "Unknown";
+
+// Using value_or helper (if available)
+std::string actual_name = kcenon::common::value_or(
+    container->get<std::string>("name"),
+    "Unknown"
+);
+```
+
+---
+
+## Error Codes Reference
+
+| Code | Name | Description |
+|------|------|-------------|
+| 100 | `key_not_found` | Requested key does not exist |
+| 101 | `type_mismatch` | Value type doesn't match requested type |
+| 102 | `value_out_of_range` | Value exceeds valid range |
+| 103 | `invalid_value` | Value is invalid |
+| 104 | `empty_key` | Key is empty |
+| 200 | `serialization_failed` | Serialization operation failed |
+| 201 | `deserialization_failed` | Deserialization operation failed |
+| 202 | `invalid_format` | Data format is invalid |
+| 203 | `version_mismatch` | Version incompatibility |
+| 204 | `corrupted_data` | Data is corrupted |
+| 300 | `schema_validation_failed` | Schema validation failed |
+| 301 | `missing_required_field` | Required field is missing |
+| 302 | `constraint_violated` | Constraint was violated |
+| 400 | `memory_allocation_failed` | Memory allocation failed |
+| 401 | `file_not_found` | File does not exist |
+| 402 | `file_read_error` | Error reading file |
+| 403 | `file_write_error` | Error writing file |
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+```cpp
+TEST(ResultApiMigration, DeserializeErrorHandling) {
+    auto container = std::make_shared<value_container>();
+
+    // Test invalid data
+    auto result = container->deserialize_result("invalid_data");
+    ASSERT_FALSE(result.is_ok());
+    EXPECT_EQ(result.error().code, error_codes::invalid_format);
+}
+
+TEST(ResultApiMigration, SerializeSuccess) {
+    auto container = std::make_shared<value_container>();
+    container->set("key", "value");
+
+    auto result = container->serialize_result();
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_FALSE(result.value().empty());
+}
+```
+
+### Integration Tests
+
+```cpp
+TEST(ResultApiMigration, FileRoundTrip) {
+    auto container = std::make_shared<value_container>();
+    container->set("test", 42);
+
+    // Save
+    auto save_result = container->save_packet_result("/tmp/test.bin");
+    ASSERT_TRUE(save_result.is_ok());
+
+    // Load
+    auto new_container = std::make_shared<value_container>();
+    auto load_result = new_container->load_packet_result("/tmp/test.bin");
+    ASSERT_TRUE(load_result.is_ok());
+
+    // Verify
+    auto value = new_container->get<int>("test");
+    ASSERT_TRUE(value.is_ok());
+    EXPECT_EQ(value.value(), 42);
+}
+```
+
+---
+
+## FAQ
+
+### Q: Can I still use the old API?
+
+**A**: Yes, but you will see deprecation warnings. The old API will be removed in version 3.0.0.
+
+### Q: What if I have a large codebase?
+
+**A**: Migrate incrementally. Start with the most critical paths (error handling, file I/O) and work outward.
+
+### Q: Are the Result APIs thread-safe?
+
+**A**: Yes, the Result-returning methods have the same thread-safety guarantees as their deprecated counterparts.
+
+### Q: Why `_result` suffix instead of just replacing the old methods?
+
+**A**: This allows for gradual migration without breaking existing code. In version 3.0.0, the `_result` suffix will be removed and these will become the primary APIs.
+
+### Q: What happens to error handling for `set()` methods?
+
+**A**: The unified `set()` API returns `value_container&` for chaining. Use `set_result()` if you need error information.
+
+---
+
+## Summary
+
+1. **Update method calls** from deprecated methods to `_result` versions
+2. **Handle errors** using `is_ok()` and `error()` methods
+3. **Use error codes** for programmatic error handling
+4. **Test thoroughly** before deploying
+
+For questions or issues, please open a GitHub issue.


### PR DESCRIPTION
## Summary

- Add `[[deprecated]]` attribute to legacy void/bool returning methods in favor of Result-returning APIs
- Add comprehensive migration documentation with examples and error code reference
- Update CHANGELOG (English and Korean versions)

## Changes

### Deprecated Methods

| Old Method | New Method |
|------------|-----------|
| `serialize()` | `serialize_result()` |
| `serialize_array()` | `serialize_array_result()` |
| `deserialize()` | `deserialize_result()` |
| `to_json()` | `to_json_result()` |
| `to_xml()` | `to_xml_result()` |
| `to_msgpack()` | `to_msgpack_result()` |
| `from_msgpack()` | `from_msgpack_result()` |
| `load_packet()` | `load_packet_result()` |
| `save_packet()` | `save_packet_result()` |
| `remove()` | `remove_result()` |

### Documentation

- Add `docs/guides/RESULT_API_MIGRATION_GUIDE.md` with:
  - Migration timeline and deprecation notice
  - Step-by-step migration examples
  - Error handling patterns
  - Error codes reference
  - FAQ

## Test plan

- [x] All existing tests pass (21/21)
- [x] Build succeeds with deprecation warnings (expected)
- [x] No new compile errors introduced

## Related Issues

- Closes #241
- Part of #231 Phase 5: Backward Compatible Deprecated Wrappers