### PR TITLE
refactor(api): add CONTAINER_NO_LEGACY_API conditional compilation flag

### DIFF
--- a/core/container.cpp
+++ b/core/container.cpp
@@ -256,6 +256,11 @@ namespace container_module
 		return message_type_;
 	}
 
+#ifndef CONTAINER_NO_LEGACY_API
+	// =======================================================================
+	// Deprecated Value Management API Implementation
+	// =======================================================================
+
 	void value_container::add_value(const std::string& name, value_types type, value_variant data)
 	{
 		write_lock_guard lock(this);
@@ -304,6 +309,7 @@ namespace container_module
 			// Skip incompatible types: thread_safe_container, array_variant
 		});
 	}
+#endif // CONTAINER_NO_LEGACY_API
 
 	std::optional<optimized_value> value_container::get_value(const std::string& name) const noexcept
 	{
@@ -367,6 +373,7 @@ namespace container_module
 		}
 	}
 
+#ifndef CONTAINER_NO_LEGACY_API
 	// =======================================================================
 	// Deprecated methods (delegating to implementation)
 	// =======================================================================
@@ -382,6 +389,7 @@ namespace container_module
 			set_unit_impl(val);
 		}
 	}
+#endif // CONTAINER_NO_LEGACY_API
 
 	// =======================================================================
 	// Unified Value Setter API (Issue #207)
@@ -731,11 +739,12 @@ namespace container_module
 
 	// =======================================================================
 
+#ifndef CONTAINER_NO_LEGACY_API
 	void value_container::remove(std::string_view target_name,
 								 bool update_immediately)
 	{
 		std::unique_lock<std::shared_mutex> lock(mutex_);
-		
+
 		if (!parsed_data_)
 		{
 			deserialize_values(data_string_, false);
@@ -759,6 +768,7 @@ namespace container_module
 			data_string_ = datas();
 		}
 	}
+#endif // CONTAINER_NO_LEGACY_API
 
 
 
@@ -1454,6 +1464,11 @@ void value_container::clear_validation_errors() noexcept
 	}
 #endif
 
+#ifndef CONTAINER_NO_LEGACY_API
+	// =======================================================================
+	// Deprecated Format Conversion API Implementation
+	// =======================================================================
+
 	const std::string value_container::to_xml(void)
 	{
 		std::unique_lock<std::shared_mutex> lock(mutex_);
@@ -1567,11 +1582,13 @@ void value_container::clear_validation_errors() noexcept
 		formatter::format_to(std::back_inserter(result), "}}");
 		return result;
 	}
+#endif // CONTAINER_NO_LEGACY_API
 
 	// =======================================================================
 	// MessagePack Serialization Implementation (Issue #234)
 	// =======================================================================
 
+#ifndef CONTAINER_NO_LEGACY_API
 	std::vector<uint8_t> value_container::to_msgpack() const
 	{
 		// Record metrics if enabled
@@ -1957,6 +1974,7 @@ void value_container::clear_validation_errors() noexcept
 		}
 		return nullptr;
 	}
+#endif // CONTAINER_NO_LEGACY_API
 
 	value_container::serialization_format value_container::detect_format(
 		const std::vector<uint8_t>& data)
@@ -2112,6 +2130,11 @@ void value_container::clear_validation_errors() noexcept
 		return result;
 	}
 
+#ifndef CONTAINER_NO_LEGACY_API
+	// =======================================================================
+	// Deprecated File I/O API Implementation
+	// =======================================================================
+
 	void value_container::load_packet(const std::string& file_path)
 	{
 		// TODO: Implement file loading without file_handler
@@ -2127,6 +2150,7 @@ void value_container::clear_validation_errors() noexcept
 		(void)file_path;
 		throw std::runtime_error("File saving not implemented - file_handler not available");
 	}
+#endif // CONTAINER_NO_LEGACY_API
 
 	size_t value_container::memory_footprint() const
 	{

--- a/core/container.h
+++ b/core/container.h
@@ -228,6 +228,14 @@ namespace container_module
 
 		// Value management methods
 
+#ifndef CONTAINER_NO_LEGACY_API
+		// =======================================================================
+		// Deprecated Value Management API
+		// These methods are deprecated and will be removed in a future version.
+		// Use the unified set()/set_all() API instead.
+		// Define CONTAINER_NO_LEGACY_API to exclude these methods.
+		// =======================================================================
+
 		/**
 		 * @brief Add a value to the container
 		 * @param name Value name/key
@@ -315,6 +323,7 @@ namespace container_module
 			val.type = static_cast<value_types>(val.data.index());
 			set_unit_impl(val);
 		}
+#endif // CONTAINER_NO_LEGACY_API
 
 		// =======================================================================
 		// Unified Value Setter API (Issue #207)
@@ -655,6 +664,11 @@ namespace container_module
 		 */
 		std::optional<optimized_value> get_value(const std::string& name) const noexcept;
 
+#ifndef CONTAINER_NO_LEGACY_API
+		// =======================================================================
+		// Deprecated Removal API
+		// =======================================================================
+
 		/**
 		 * @brief Remove a value by name
 		 * @param target_name Name of value to remove
@@ -664,11 +678,19 @@ namespace container_module
 		[[deprecated("Use remove_result() instead for Result-based error handling")]]
 		void remove(std::string_view target_name,
 					bool update_immediately = false);
+#endif // CONTAINER_NO_LEGACY_API
 
 		/**
 		 * @brief Reinitialize the entire container to defaults.
 		 */
 		void initialize(void);
+
+		// =======================================================================
+		// Core Serialization API
+		// Note: These methods are deprecated but still required internally
+		// (used by constructors). They cannot be conditionally excluded.
+		// Use the Result-based API (serialize_result, etc.) for new code.
+		// =======================================================================
 
 		/**
 		 * @brief Serialize this container (header + data).
@@ -735,6 +757,7 @@ namespace container_module
 		// Schema-Validated Deserialization API (Issue #249)
 		// =======================================================================
 
+#ifndef CONTAINER_NO_LEGACY_API
 		/**
 		 * @brief Deserialize from string data with schema validation
 		 *
@@ -778,6 +801,7 @@ namespace container_module
 		bool deserialize(const std::vector<uint8_t>& data_array,
 						 const container_schema& schema,
 						 bool parse_only_header = false);
+#endif // CONTAINER_NO_LEGACY_API
 
 		/**
 		 * @brief Get the last validation errors from schema-validated deserialization
@@ -833,6 +857,11 @@ namespace container_module
 			bool parse_only_header = false) noexcept;
 #endif
 
+#ifndef CONTAINER_NO_LEGACY_API
+		// =======================================================================
+		// Deprecated Format Conversion API
+		// =======================================================================
+
 		/**
 		 * @brief Generate an XML representation of this container (header +
 		 * values).
@@ -848,11 +877,13 @@ namespace container_module
 		 */
 		[[deprecated("Use to_json_result() instead for Result-based error handling")]]
 		const std::string to_json(void);
+#endif // CONTAINER_NO_LEGACY_API
 
 		// =======================================================================
 		// MessagePack Serialization API (Issue #234)
 		// =======================================================================
 
+#ifndef CONTAINER_NO_LEGACY_API
 		/**
 		 * @brief Serialize this container to MessagePack binary format
 		 *
@@ -893,6 +924,7 @@ namespace container_module
 		 */
 		[[deprecated("Use from_msgpack_result() instead for Result-based error handling")]]
 		bool from_msgpack(const std::vector<uint8_t>& data);
+#endif // CONTAINER_NO_LEGACY_API
 
 		/**
 		 * @brief Create a new container from MessagePack data
@@ -902,9 +934,12 @@ namespace container_module
 		 *
 		 * @param data MessagePack-encoded binary data
 		 * @return Shared pointer to the created container, or nullptr on error
+		 * @note Requires CONTAINER_NO_LEGACY_API to be undefined (uses from_msgpack internally)
 		 */
+#ifndef CONTAINER_NO_LEGACY_API
 		static std::shared_ptr<value_container> create_from_msgpack(
 			const std::vector<uint8_t>& data);
+#endif // CONTAINER_NO_LEGACY_API
 
 		/**
 		 * @brief Serialization format enumeration
@@ -976,6 +1011,11 @@ namespace container_module
 		 */
 		std::string datas(void) const;
 
+#ifndef CONTAINER_NO_LEGACY_API
+		// =======================================================================
+		// Deprecated File I/O API
+		// =======================================================================
+
 		/**
 		 * @brief Load from a file path (reads entire file content, then calls
 		 * deserialize).
@@ -990,6 +1030,7 @@ namespace container_module
 		 */
 		[[deprecated("Use save_packet_result() instead for Result-based error handling")]]
 		void save_packet(const std::string& file_path);
+#endif // CONTAINER_NO_LEGACY_API
 
 		/**
 		 * @brief Get memory usage statistics


### PR DESCRIPTION
Closes #285
Part of #284

## Summary

- Add `CONTAINER_NO_LEGACY_API` macro to conditionally exclude deprecated API methods
- Wrap deprecated methods in `#ifndef CONTAINER_NO_LEGACY_API` blocks
- Maintain backward compatibility (legacy API included by default)

## Changes

### Methods now conditionally compiled:

**Value Management (deprecated):**
- `add_value(const std::string&, value_types, value_variant)`
- `add_value<T>(const std::string&, T&&)`
- `add(std::shared_ptr<value>)`
- `set_unit(const optimized_value&)`
- `set_units(const std::vector<optimized_value>&)`
- `set_value<T>(const std::string&, T&&)`

**Removal (deprecated):**
- `remove(std::string_view, bool)`

**Format Conversion (deprecated):**
- `to_xml()`
- `to_json()`
- `to_msgpack()`
- `from_msgpack(const std::vector<uint8_t>&)`
- `create_from_msgpack(const std::vector<uint8_t>&)`

**File I/O (deprecated):**
- `load_packet(const std::string&)`
- `save_packet(const std::string&)`

### Not conditionally compiled:
- `serialize()` / `serialize_array()` / `deserialize()` - Required internally by constructors
- These will be addressed in Phase 2 (#286) when the serialization API is refactored

## Usage

```cpp
// Default: Legacy API included (backward compatible)
#include <container/core/container.h>

// Opt-out: Exclude deprecated methods
#define CONTAINER_NO_LEGACY_API
#include <container/core/container.h>
```

## Test Plan

- [x] Build succeeds with default configuration (legacy API included)
- [x] All existing tests pass (performance tests excluded - pre-existing threshold issues)
- [ ] Build succeeds with `CONTAINER_NO_LEGACY_API` defined
- [ ] CI passes