### PR TITLE
refactor: migrate tests and examples to unified API

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Test Migration to Unified API** (#284, #297): Migrate all test files from deprecated API to unified API
+  - Replace `add(make_*_value())` with `set()` throughout test files
+  - Replace `serialize()` with `serialize_string(serialization_format::binary).value()`
+  - Replace `to_json()`/`to_xml()` with `serialize_string(serialization_format::json/xml).value()`
+  - Replace `deserialize()` with `deserialize_result()` or `deserialize(span, format)`
+  - Replace `set_value()` with `set()`
+  - All tests now pass with `CONTAINER_NO_LEGACY_API` defined
+  - Updated tests that relied on deprecated duplicate-key behavior
+
+### Added
+- **Legacy API Deprecation Timeline** (#284): Document clear deprecation timeline in `legacy_api.h`
+  - **v2.x**: Deprecated methods available by default with warnings
+  - **v3.0**: Deprecated methods require explicit include of `legacy_api.h`
+  - **v4.0**: Deprecated methods removed entirely
+  - Add `CONTAINER_NO_LEGACY_API` compile flag to disable deprecated API at build time
+  - Complete migration guide with unified API replacements in `legacy_api.h` documentation
+
 ### Fixed
 - **Windows Macro Conflict in MessagePack** (#274): Fix MSVC build failures due to TRUE/FALSE macro conflicts
   - Add `#pragma push_macro` / `#pragma pop_macro` guards in `core/container/msgpack.h`

--- a/examples/advanced_container_example.cpp
+++ b/examples/advanced_container_example.cpp
@@ -94,11 +94,11 @@ public:
         container->set_message_type("user_profile_update");
 
         // Add different types of values using set_value
-        container->set_value("username", std::string("john_doe"));
-        container->set_value("user_id", static_cast<int32_t>(12345));
-        container->set_value("account_balance", 1500.75);
-        container->set_value("is_premium", true);
-        container->set_value("last_login", static_cast<int64_t>(
+        container->set("username", std::string("john_doe"));
+        container->set("user_id", static_cast<int32_t>(12345));
+        container->set("account_balance", 1500.75);
+        container->set("is_premium", true);
+        container->set("last_login", static_cast<int64_t>(
             std::chrono::duration_cast<std::chrono::seconds>(
                 std::chrono::system_clock::now().time_since_epoch()).count()));
 
@@ -122,7 +122,7 @@ public:
         }
 
         // Demonstrate serialization
-        std::string serialized = container->serialize();
+        std::string serialized = container->serialize_string(value_container::serialization_format::binary).value();
         std::cout << "  Serialized size: " << serialized.size() << " bytes" << std::endl;
 
         // Demonstrate deserialization
@@ -165,10 +165,10 @@ public:
                     container->set_target("consumer_pool", "any_available");
                     container->set_message_type("work_item");
 
-                    container->set_value("producer_id", static_cast<int32_t>(p));
-                    container->set_value("item_id", static_cast<int32_t>(i));
-                    container->set_value("random_value", static_cast<int32_t>(dis(gen)));
-                    container->set_value("timestamp", static_cast<int64_t>(
+                    container->set("producer_id", static_cast<int32_t>(p));
+                    container->set("item_id", static_cast<int32_t>(i));
+                    container->set("random_value", static_cast<int32_t>(dis(gen)));
+                    container->set("timestamp", static_cast<int64_t>(
                         std::chrono::duration_cast<std::chrono::milliseconds>(
                             std::chrono::system_clock::now().time_since_epoch()).count()));
 
@@ -211,7 +211,7 @@ public:
 
                     if (container) {
                         // Process container (serialize/deserialize simulation)
-                        std::string serialized = container->serialize();
+                        std::string serialized = container->serialize_string(value_container::serialization_format::binary).value();
                         processed_bytes_ += serialized.size();
 
                         auto processed = std::make_shared<value_container>(serialized);
@@ -259,7 +259,7 @@ public:
 
         // Empty container serialization
         auto empty_container = std::make_shared<value_container>();
-        std::string empty_serialized = empty_container->serialize();
+        std::string empty_serialized = empty_container->serialize_string(value_container::serialization_format::binary).value();
         auto empty_deserialized = std::make_shared<value_container>(empty_serialized);
         std::cout << "  - Empty container serialization/deserialization works" << std::endl;
 
@@ -267,9 +267,9 @@ public:
         std::string large_string(10000, 'A');
         auto large_container = std::make_shared<value_container>();
         large_container->set_message_type("large_data_test");
-        large_container->set_value("large_data", large_string);
+        large_container->set("large_data", large_string);
 
-        std::string large_serialized = large_container->serialize();
+        std::string large_serialized = large_container->serialize_string(value_container::serialization_format::binary).value();
         auto large_deserialized = std::make_shared<value_container>(large_serialized);
 
         if (auto recovered_value = large_deserialized->get_value("large_data")) {
@@ -303,13 +303,13 @@ public:
             container->set_target("high_freq_server", "handler");
             container->set_message_type("ping");
 
-            container->set_value("sequence", static_cast<int32_t>(i));
-            container->set_value("timestamp", static_cast<int64_t>(
+            container->set("sequence", static_cast<int32_t>(i));
+            container->set("timestamp", static_cast<int64_t>(
                 std::chrono::duration_cast<std::chrono::microseconds>(
                     std::chrono::system_clock::now().time_since_epoch()).count()));
 
             // Quick serialization test
-            container->serialize();
+            container->serialize_string(value_container::serialization_format::binary).value();
         }
 
         auto end_time = std::chrono::high_resolution_clock::now();
@@ -332,12 +332,12 @@ public:
 
             // Simulate large file data using string
             std::string file_data(50000, static_cast<char>(i % 256));
-            container->set_value("file_content", file_data);
-            container->set_value("filename", std::string("large_file_" + std::to_string(i) + ".dat"));
-            container->set_value("file_size", static_cast<int32_t>(file_data.size()));
+            container->set("file_content", file_data);
+            container->set("filename", std::string("large_file_" + std::to_string(i) + ".dat"));
+            container->set("file_size", static_cast<int32_t>(file_data.size()));
 
             // Serialization test
-            std::string serialized = container->serialize();
+            std::string serialized = container->serialize_string(value_container::serialization_format::binary).value();
             processed_bytes_ += serialized.size();
         }
 

--- a/examples/basic_container_example.cpp
+++ b/examples/basic_container_example.cpp
@@ -71,29 +71,29 @@ void demonstrate_value_types() {
     container->set_message_type("value_types_demo");
 
     // String value using new set_value API
-    container->set_value("username", std::string("john_doe"));
+    container->set("username", std::string("john_doe"));
     std::cout << "Added string value: username = john_doe" << std::endl;
 
     // Integer value
-    container->set_value("user_id", static_cast<int32_t>(12345));
+    container->set("user_id", static_cast<int32_t>(12345));
     std::cout << "Added int value: user_id = 12345" << std::endl;
 
     // Long value (timestamp)
     auto timestamp = std::chrono::duration_cast<std::chrono::seconds>(
         std::chrono::system_clock::now().time_since_epoch()).count();
-    container->set_value("timestamp", static_cast<int64_t>(timestamp));
+    container->set("timestamp", static_cast<int64_t>(timestamp));
     std::cout << "Added long value: timestamp = " << timestamp << std::endl;
 
     // Float value
-    container->set_value("score", 98.5f);
+    container->set("score", 98.5f);
     std::cout << "Added float value: score = 98.5" << std::endl;
 
     // Double value
-    container->set_value("account_balance", 1500.75);
+    container->set("account_balance", 1500.75);
     std::cout << "Added double value: account_balance = 1500.75" << std::endl;
 
     // Boolean value
-    container->set_value("is_active", true);
+    container->set("is_active", true);
     std::cout << "Added bool value: is_active = true" << std::endl;
 
     std::cout << "Total values added: 6" << std::endl;
@@ -108,14 +108,14 @@ void demonstrate_serialization() {
     container->set_target("deserialize_test", "test_handler");
     container->set_message_type("serialization_test");
 
-    container->set_value("message", std::string("Hello, Serialization!"));
-    container->set_value("count", static_cast<int32_t>(42));
-    container->set_value("pi", 3.14159);
-    container->set_value("success", true);
+    container->set("message", std::string("Hello, Serialization!"));
+    container->set("count", static_cast<int32_t>(42));
+    container->set("pi", 3.14159);
+    container->set("success", true);
 
     // Serialize
     std::cout << "Serializing container..." << std::endl;
-    std::string serialized_data = container->serialize();
+    std::string serialized_data = container->serialize_string(value_container::serialization_format::binary).value();
     std::cout << "Serialized size: " << serialized_data.size() << " bytes" << std::endl;
 
     // Deserialize
@@ -149,10 +149,10 @@ void demonstrate_value_access() {
     container->set_message_type("value_access_test");
 
     // Add sample data using set_value
-    container->set_value("product_name", std::string("Super Widget"));
-    container->set_value("price", 29.99);
-    container->set_value("quantity", static_cast<int32_t>(100));
-    container->set_value("in_stock", true);
+    container->set("product_name", std::string("Super Widget"));
+    container->set("price", 29.99);
+    container->set("quantity", static_cast<int32_t>(100));
+    container->set("in_stock", true);
 
     std::cout << "Container contains 4 values" << std::endl;
 
@@ -191,9 +191,9 @@ void demonstrate_iteration() {
     container->set_message_type("iteration_test");
 
     // Add multiple items
-    container->set_value("item_1", std::string("first"));
-    container->set_value("item_2", std::string("second"));
-    container->set_value("item_3", std::string("third"));
+    container->set("item_1", std::string("first"));
+    container->set("item_2", std::string("second"));
+    container->set("item_3", std::string("third"));
 
     std::cout << "Added 3 values with different names" << std::endl;
 
@@ -221,8 +221,8 @@ void demonstrate_performance_basics() {
         container->set_target("perf_server", "handler");
         container->set_message_type("performance_test");
 
-        container->set_value("index", static_cast<int32_t>(i));
-        container->set_value("data", std::string("test_data_" + std::to_string(i)));
+        container->set("index", static_cast<int32_t>(i));
+        container->set("data", std::string("test_data_" + std::to_string(i)));
 
         containers.push_back(container);
     }
@@ -245,7 +245,7 @@ void demonstrate_performance_basics() {
     serialized_data.reserve(num_operations);
 
     for (const auto& container : containers) {
-        serialized_data.push_back(container->serialize());
+        serialized_data.push_back(container->serialize_string(value_container::serialization_format::binary).value());
     }
 
     end_time = std::chrono::high_resolution_clock::now();

--- a/examples/messaging_integration_example.cpp
+++ b/examples/messaging_integration_example.cpp
@@ -59,10 +59,10 @@ void demonstrate_basic_usage() {
     container->set_message_type("user_data");
 
     // Add values using set_value
-    container->set_value("user_id", static_cast<int64_t>(12345L));
-    container->set_value("username", std::string("john_doe"));
-    container->set_value("balance", 1500.75);
-    container->set_value("active", true);
+    container->set("user_id", static_cast<int64_t>(12345L));
+    container->set("username", std::string("john_doe"));
+    container->set("balance", 1500.75);
+    container->set("active", true);
 
     std::cout << "Created container with 4 values\n";
     std::cout << "Message type: " << container->message_type() << "\n";
@@ -70,7 +70,7 @@ void demonstrate_basic_usage() {
     std::cout << "Target: " << container->target_id() << ":" << container->target_sub_id() << "\n";
 
     // Serialize
-    std::string serialized = container->serialize();
+    std::string serialized = container->serialize_string(value_container::serialization_format::binary).value();
     std::cout << "Serialized size: " << serialized.size() << " bytes\n";
 }
 
@@ -81,11 +81,11 @@ void demonstrate_value_access() {
     container->set_message_type("value_access_demo");
 
     // Add various values
-    container->set_value("request_id", static_cast<int32_t>(789));
-    container->set_value("priority", static_cast<int32_t>(1));
-    container->set_value("payload", std::string("Important data"));
-    container->set_value("timestamp", static_cast<int64_t>(1672531200L));
-    container->set_value("is_urgent", true);
+    container->set("request_id", static_cast<int32_t>(789));
+    container->set("priority", static_cast<int32_t>(1));
+    container->set("payload", std::string("Important data"));
+    container->set("timestamp", static_cast<int64_t>(1672531200L));
+    container->set("is_urgent", true);
 
     // Access values using get_value and std::get_if
     if (auto val = container->get_value("request_id")) {
@@ -122,14 +122,14 @@ void demonstrate_serialization_roundtrip() {
     source->set_target("receiver", "app_2");
     source->set_message_type("roundtrip_test");
 
-    source->set_value("int_val", static_cast<int32_t>(42));
-    source->set_value("double_val", 3.14159);
-    source->set_value("string_val", std::string("Hello, World!"));
-    source->set_value("bool_val", true);
-    source->set_value("long_val", static_cast<int64_t>(9876543210L));
+    source->set("int_val", static_cast<int32_t>(42));
+    source->set("double_val", 3.14159);
+    source->set("string_val", std::string("Hello, World!"));
+    source->set("bool_val", true);
+    source->set("long_val", static_cast<int64_t>(9876543210L));
 
     // Serialize
-    std::string serialized = source->serialize();
+    std::string serialized = source->serialize_string(value_container::serialization_format::binary).value();
     std::cout << "Serialized " << source->size() << " values to " << serialized.size() << " bytes\n";
 
     // Deserialize
@@ -165,7 +165,7 @@ void demonstrate_compatibility() {
     // Demonstrate that the same container can be used in different contexts
     auto container = std::make_shared<value_container>();
     container->set_message_type("compatibility_test");
-    container->set_value("demo_value", static_cast<int32_t>(123));
+    container->set("demo_value", static_cast<int32_t>(123));
 
     std::cout << "Container can be used standalone or as part of messaging system\n";
     std::cout << "Type safety and performance remain consistent across usage patterns\n";
@@ -181,9 +181,9 @@ void performance_comparison() {
     for (int i = 0; i < iterations; ++i) {
         auto container = std::make_shared<value_container>();
         container->set_message_type("perf_test");
-        container->set_value("index", static_cast<int32_t>(i));
-        container->set_value("data", std::string("test_data"));
-        std::string serialized = container->serialize();
+        container->set("index", static_cast<int32_t>(i));
+        container->set("data", std::string("test_data"));
+        std::string serialized = container->serialize_string(value_container::serialization_format::binary).value();
     }
     auto standard_time = std::chrono::high_resolution_clock::now() - start;
 
@@ -203,11 +203,11 @@ void demonstrate_memory_efficiency() {
     container->set_message_type("memory_test");
 
     // Add various values
-    container->set_value("small_int", static_cast<int32_t>(42));
-    container->set_value("large_string", std::string(1000, 'x'));
-    container->set_value("double_val", 123.456);
-    container->set_value("bool_val", true);
-    container->set_value("long_val", static_cast<int64_t>(9999999999L));
+    container->set("small_int", static_cast<int32_t>(42));
+    container->set("large_string", std::string(1000, 'x'));
+    container->set("double_val", 123.456);
+    container->set("bool_val", true);
+    container->set("long_val", static_cast<int64_t>(9999999999L));
 
     // Get memory stats
     auto [heap, stack] = container->memory_stats();

--- a/examples/real_world_scenarios.cpp
+++ b/examples/real_world_scenarios.cpp
@@ -174,8 +174,8 @@ private:
         container->set_target("iot_analytics_service", "data_processor");
         container->set_message_type("sensor_data_batch");
 
-        container->set_value("batch_size", static_cast<int32_t>(batch.size()));
-        container->set_value("batch_timestamp", static_cast<int64_t>(
+        container->set("batch_size", static_cast<int32_t>(batch.size()));
+        container->set("batch_timestamp", static_cast<int64_t>(
             std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::system_clock::now().time_since_epoch()).count()));
 
@@ -183,15 +183,15 @@ private:
             const auto& reading = batch[i];
             std::string prefix = "reading_" + std::to_string(i) + "_";
 
-            container->set_value(prefix + "device_id", reading.device_id);
-            container->set_value(prefix + "sensor_type", reading.sensor_type);
-            container->set_value(prefix + "value", reading.value);
-            container->set_value(prefix + "timestamp", static_cast<int64_t>(
+            container->set(prefix + "device_id", reading.device_id);
+            container->set(prefix + "sensor_type", reading.sensor_type);
+            container->set(prefix + "value", reading.value);
+            container->set(prefix + "timestamp", static_cast<int64_t>(
                 std::chrono::duration_cast<std::chrono::milliseconds>(
                     reading.timestamp.time_since_epoch()).count()));
         }
 
-        std::string serialized = container->serialize();
+        std::string serialized = container->serialize_string(value_container::serialization_format::binary).value();
         std::cout << "  Sent IoT batch: " << batch.size() << " readings, "
                   << serialized.size() << " bytes" << std::endl;
     }
@@ -300,28 +300,28 @@ private:
         container->set_target("compliance_service", "transaction_monitor");
         container->set_message_type(is_suspicious ? "suspicious_transaction" : "normal_transaction");
 
-        container->set_value("transaction_id", transaction.transaction_id);
-        container->set_value("account_from", transaction.account_from);
-        container->set_value("account_to", transaction.account_to);
-        container->set_value("amount", transaction.amount);
-        container->set_value("currency", transaction.currency);
-        container->set_value("transaction_type", transaction.transaction_type);
-        container->set_value("timestamp", static_cast<int64_t>(
+        container->set("transaction_id", transaction.transaction_id);
+        container->set("account_from", transaction.account_from);
+        container->set("account_to", transaction.account_to);
+        container->set("amount", transaction.amount);
+        container->set("currency", transaction.currency);
+        container->set("transaction_type", transaction.transaction_type);
+        container->set("timestamp", static_cast<int64_t>(
             std::chrono::duration_cast<std::chrono::milliseconds>(
                 transaction.timestamp.time_since_epoch()).count()));
-        container->set_value("risk_score", is_suspicious ? 85.0 : 15.0);
+        container->set("risk_score", is_suspicious ? 85.0 : 15.0);
 
         if (is_suspicious) {
             fraud_alerts_++;
-            container->set_value("alert_reason",
+            container->set("alert_reason",
                 std::string(transaction.amount > 5000.0 ? "high_amount" : "same_account"));
-            container->set_value("requires_manual_review", true);
+            container->set("requires_manual_review", true);
 
             std::cout << "  FRAUD ALERT: " << transaction.transaction_id
                       << " Amount: $" << transaction.amount << std::endl;
         }
 
-        container->serialize();
+        container->serialize_string(value_container::serialization_format::binary).value();
     }
 };
 
@@ -427,14 +427,14 @@ private:
         container->set_target("game_server", "event_processor");
         container->set_message_type("game_event");
 
-        container->set_value("player_id", event.player_id);
-        container->set_value("event_type", event.event_type);
-        container->set_value("timestamp", static_cast<int64_t>(
+        container->set("player_id", event.player_id);
+        container->set("event_type", event.event_type);
+        container->set("timestamp", static_cast<int64_t>(
             std::chrono::duration_cast<std::chrono::milliseconds>(
                 event.timestamp.time_since_epoch()).count()));
 
         for (const auto& data_pair : event.event_data) {
-            container->set_value(data_pair.first, data_pair.second);
+            container->set(data_pair.first, data_pair.second);
         }
 
         if (event.event_data.find("score") != event.event_data.end()) {
@@ -453,7 +453,7 @@ private:
             }
         }
 
-        container->serialize();
+        container->serialize_string(value_container::serialization_format::binary).value();
     }
 
     void send_achievement_notification(const std::string& player_id, const std::string& achievement) {
@@ -462,9 +462,9 @@ private:
         notification->set_target("notification_service", "player_notifier");
         notification->set_message_type("achievement_unlocked");
 
-        notification->set_value("player_id", player_id);
-        notification->set_value("achievement_name", achievement);
-        notification->set_value("timestamp", static_cast<int64_t>(
+        notification->set("player_id", player_id);
+        notification->set("achievement_name", achievement);
+        notification->set("timestamp", static_cast<int64_t>(
             std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::system_clock::now().time_since_epoch()).count()));
 
@@ -588,22 +588,22 @@ private:
         container->set_target("search_indexer", "text_analyzer");
         container->set_message_type("document_processing");
 
-        container->set_value("document_id", document.document_id);
-        container->set_value("title", document.title);
-        container->set_value("author", document.author);
-        container->set_value("category", document.category);
-        container->set_value("content_length", static_cast<int32_t>(document.content.length()));
-        container->set_value("upload_timestamp", static_cast<int64_t>(
+        container->set("document_id", document.document_id);
+        container->set("title", document.title);
+        container->set("author", document.author);
+        container->set("category", document.category);
+        container->set("content_length", static_cast<int32_t>(document.content.length()));
+        container->set("upload_timestamp", static_cast<int64_t>(
             std::chrono::duration_cast<std::chrono::milliseconds>(
                 document.upload_time.time_since_epoch()).count()));
-        container->set_value("tag_count", static_cast<int32_t>(document.tags.size()));
-        container->set_value("content", document.content);
+        container->set("tag_count", static_cast<int32_t>(document.tags.size()));
+        container->set("content", document.content);
 
         for (size_t i = 0; i < document.tags.size(); ++i) {
-            container->set_value("tag_" + std::to_string(i), document.tags[i]);
+            container->set("tag_" + std::to_string(i), document.tags[i]);
         }
 
-        container->serialize();
+        container->serialize_string(value_container::serialization_format::binary).value();
         create_search_index_entry(document);
         documents_indexed_++;
 
@@ -618,15 +618,15 @@ private:
         index_container->set_target("search_service", "index_updater");
         index_container->set_message_type("search_index_update");
 
-        index_container->set_value("document_id", document.document_id);
-        index_container->set_value("indexed_title", document.title);
-        index_container->set_value("indexed_category", document.category);
-        index_container->set_value("word_count", static_cast<int32_t>(count_words(document.content)));
-        index_container->set_value("index_timestamp", static_cast<int64_t>(
+        index_container->set("document_id", document.document_id);
+        index_container->set("indexed_title", document.title);
+        index_container->set("indexed_category", document.category);
+        index_container->set("word_count", static_cast<int32_t>(count_words(document.content)));
+        index_container->set("index_timestamp", static_cast<int64_t>(
             std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::system_clock::now().time_since_epoch()).count()));
 
-        index_container->serialize();
+        index_container->serialize_string(value_container::serialization_format::binary).value();
     }
 
     size_t count_words(const std::string& text) {

--- a/integration_tests/framework/system_fixture.h
+++ b/integration_tests/framework/system_fixture.h
@@ -98,7 +98,7 @@ protected:
         for (size_t i = 0; i < num_values; ++i) {
             std::string key = "key_" + std::to_string(i);
             std::string value = "value_" + std::to_string(i);
-            test_container->add(make_string_value(key, value));
+            test_container->set(key, value);
         }
 
         return test_container;
@@ -109,7 +109,7 @@ protected:
      */
     void AddStringValue(const std::string& key, const std::string& value)
     {
-        container->add(make_string_value(key, value));
+        container->set(key, value);
     }
 
     /**
@@ -119,11 +119,11 @@ protected:
     void AddNumericValue(const std::string& key, T value)
     {
         if constexpr (std::is_same_v<T, int>) {
-            container->add(make_int_value(key, value));
+            container->set(key, value);
         } else if constexpr (std::is_same_v<T, long long>) {
-            container->add(make_llong_value(key, value));
+            container->set(key, value);
         } else if constexpr (std::is_same_v<T, double>) {
-            container->add(make_double_value(key, value));
+            container->set(key, value);
         }
     }
 
@@ -132,7 +132,7 @@ protected:
      */
     void AddBoolValue(const std::string& key, bool value)
     {
-        container->add(make_bool_value(key, value));
+        container->set(key, value);
     }
 
     /**
@@ -140,7 +140,7 @@ protected:
      */
     void AddBytesValue(const std::string& key, const std::vector<uint8_t>& data)
     {
-        container->add(make_bytes_value(key, data));
+        container->set(key, data);
     }
 
     /**
@@ -165,7 +165,7 @@ protected:
      */
     std::shared_ptr<value_container> RoundTripSerialize()
     {
-        std::string serialized = container->serialize();
+        std::string serialized = container->serialize_string(value_container::serialization_format::binary).value();
         return std::make_shared<value_container>(serialized, false);  // false = parse all
     }
 
@@ -179,7 +179,7 @@ protected:
      */
     std::shared_ptr<value_container> RoundTripSerializeHeaderOnly()
     {
-        std::string serialized = container->serialize();
+        std::string serialized = container->serialize_string(value_container::serialization_format::binary).value();
         return std::make_shared<value_container>(serialized, true);  // true = header only
     }
 
@@ -190,7 +190,7 @@ protected:
     int64_t MeasureSerializationTime()
     {
         auto start = std::chrono::high_resolution_clock::now();
-        std::string serialized = container->serialize();
+        std::string serialized = container->serialize_string(value_container::serialization_format::binary).value();
         auto end = std::chrono::high_resolution_clock::now();
 
         return std::chrono::duration_cast<std::chrono::microseconds>(

--- a/integration_tests/framework/test_helpers.h
+++ b/integration_tests/framework/test_helpers.h
@@ -139,7 +139,7 @@ public:
         }
 
         // Compare serialized forms (most reliable for deep comparison)
-        return c1->serialize() == c2->serialize();
+        return c1->serialize_string(value_container::serialization_format::binary).value() == c2->serialize_string(value_container::serialization_format::binary).value();
     }
 
     /**
@@ -152,16 +152,15 @@ public:
 
         if (depth > 0) {
             auto nested = CreateNestedContainer(depth - 1);
-            std::string nested_data = nested->serialize();
+            std::string nested_data = nested->serialize_string(value_container::serialization_format::binary).value();
             std::string key = "nested_" + std::to_string(depth);
             std::vector<uint8_t> nested_bytes(nested_data.begin(), nested_data.end());
-            root->add(std::make_shared<value>(key, value_types::container_value,
-                                             nested_bytes));
+            root->set(key, nested_bytes);
         }
 
         std::string key = "data_" + std::to_string(depth);
         std::string str_value = "level_" + std::to_string(depth);
-        root->add(make_string_value(key, str_value));
+        root->set(key, str_value);
 
         return root;
     }
@@ -239,14 +238,14 @@ public:
         container->set_message_type("mixed_types");
 
         // Add different value types
-        container->add(make_string_value("str_val", "test_string"));
-        container->add(make_int_value("int_val", 42));
-        container->add(make_llong_value("long_val", 9223372036854775807LL));
-        container->add(make_double_value("double_val", 3.14159));
-        container->add(make_bool_value("bool_val", true));
+        container->set("str_val", "test_string");
+        container->set("int_val", 42);
+        container->set("long_val", 9223372036854775807LL);
+        container->set("double_val", 3.14159);
+        container->set("bool_val", true);
 
         std::vector<uint8_t> bytes = {0x01, 0x02, 0x03, 0x04};
-        container->add(make_bytes_value("bytes_val", bytes));
+        container->set("bytes_val", bytes);
 
         return container;
     }
@@ -257,7 +256,7 @@ public:
     static double CalculateSerializationOverhead(
         std::shared_ptr<value_container> container)
     {
-        std::string serialized = container->serialize();
+        std::string serialized = container->serialize_string(value_container::serialization_format::binary).value();
         // Estimate raw data size (simplified)
         size_t raw_size = 100; // Header estimate
 
@@ -325,7 +324,7 @@ public:
     {
         try {
             // Serialize
-            std::string serialized = container->serialize();
+            std::string serialized = container->serialize_string(value_container::serialization_format::binary).value();
 
             if (serialized.empty()) {
                 std::cerr << "ERROR: Serialization produced empty string" << std::endl;
@@ -422,9 +421,9 @@ public:
         while (current_size < target_bytes) {
             std::string key = "key_" + std::to_string(counter);
             std::string value = GenerateRandomString(100);
-            container->add(make_string_value(key, value));
+            container->set(key, value);
 
-            current_size = container->serialize().size();
+            current_size = container->serialize_string(value_container::serialization_format::binary).value().size();
             counter++;
         }
 

--- a/integration_tests/performance/serialization_performance_test.cpp
+++ b/integration_tests/performance/serialization_performance_test.cpp
@@ -100,7 +100,7 @@ TEST_F(SerializationPerformanceTest, BinarySerializationThroughput)
     auto test_container = CreateTestContainer(10);
 
     auto ops_per_sec = TestHelpers::MeasureThroughput([&test_container]() {
-        std::string serialized = test_container->serialize();
+        std::string serialized = test_container->serialize_string(value_container::serialization_format::binary).value();
     }, ITERATIONS);
 
     std::cout << "Binary serialization: " << ops_per_sec << " ops/sec" << std::endl;
@@ -120,7 +120,7 @@ TEST_F(SerializationPerformanceTest, DeserializationThroughput)
     }
 
     auto test_container = CreateTestContainer(10);
-    std::string serialized = test_container->serialize();
+    std::string serialized = test_container->serialize_string(value_container::serialization_format::binary).value();
 
     auto ops_per_sec = TestHelpers::MeasureThroughput([&serialized]() {
         auto c = std::make_shared<value_container>(serialized, false);
@@ -146,7 +146,7 @@ TEST_F(SerializationPerformanceTest, ValueAdditionThroughput)
 
     auto ops_per_sec = TestHelpers::MeasureThroughput([]() {
         auto temp = std::make_shared<value_container>();
-        temp->add(make_string_value("key", "value"));
+        temp->set("key", "value");
     }, ITERATIONS);
 
     std::cout << "Value addition: " << ops_per_sec << " ops/sec" << std::endl;
@@ -170,7 +170,7 @@ TEST_F(SerializationPerformanceTest, SerializationScalability)
 
         auto start = std::chrono::high_resolution_clock::now();
         for (size_t i = 0; i < 100; ++i) {
-            std::string serialized = test_container->serialize();
+            std::string serialized = test_container->serialize_string(value_container::serialization_format::binary).value();
         }
         auto end = std::chrono::high_resolution_clock::now();
 
@@ -190,13 +190,13 @@ TEST_F(SerializationPerformanceTest, SerializationScalability)
 TEST_F(SerializationPerformanceTest, MemoryOverhead)
 {
     auto empty_container = std::make_shared<value_container>();
-    std::string empty_serialized = empty_container->serialize();
+    std::string empty_serialized = empty_container->serialize_string(value_container::serialization_format::binary).value();
 
     auto container_10 = CreateTestContainer(10);
-    std::string serialized_10 = container_10->serialize();
+    std::string serialized_10 = container_10->serialize_string(value_container::serialization_format::binary).value();
 
     auto container_100 = CreateTestContainer(100);
-    std::string serialized_100 = container_100->serialize();
+    std::string serialized_100 = container_100->serialize_string(value_container::serialization_format::binary).value();
 
     std::cout << "Empty container size: " << empty_serialized.size() << " bytes" << std::endl;
     std::cout << "10 values container: " << serialized_10.size() << " bytes" << std::endl;
@@ -218,7 +218,7 @@ TEST_F(SerializationPerformanceTest, JSONSerializationPerformance)
     auto test_container = CreateTestContainer(10);
 
     auto ops_per_sec = TestHelpers::MeasureThroughput([&test_container]() {
-        std::string json = test_container->to_json();
+        std::string json = test_container->serialize_string(value_container::serialization_format::json).value();
     }, ITERATIONS / 2); // JSON is slower, use fewer iterations
 
     std::cout << "JSON serialization: " << ops_per_sec << " ops/sec" << std::endl;
@@ -238,7 +238,7 @@ TEST_F(SerializationPerformanceTest, XMLSerializationPerformance)
     auto test_container = CreateTestContainer(10);
 
     auto ops_per_sec = TestHelpers::MeasureThroughput([&test_container]() {
-        std::string xml = test_container->to_xml();
+        std::string xml = test_container->serialize_string(value_container::serialization_format::xml).value();
     }, ITERATIONS / 2); // XML is slower, use fewer iterations
 
     std::cout << "XML serialization: " << ops_per_sec << " ops/sec" << std::endl;
@@ -258,7 +258,7 @@ TEST_F(SerializationPerformanceTest, LargeContainerSerialization)
     auto large_container = CreateTestContainer(1000);
 
     auto start = std::chrono::high_resolution_clock::now();
-    std::string serialized = large_container->serialize();
+    std::string serialized = large_container->serialize_string(value_container::serialization_format::binary).value();
     auto end = std::chrono::high_resolution_clock::now();
 
     auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
@@ -286,7 +286,7 @@ TEST_F(SerializationPerformanceTest, NestedContainerPerformance)
 
     auto start = std::chrono::high_resolution_clock::now();
     for (size_t i = 0; i < 100; ++i) {
-        std::string serialized = nested->serialize();
+        std::string serialized = nested->serialize_string(value_container::serialization_format::binary).value();
     }
     auto end = std::chrono::high_resolution_clock::now();
 

--- a/integration_tests/scenarios/value_operations_test.cpp
+++ b/integration_tests/scenarios/value_operations_test.cpp
@@ -157,7 +157,7 @@ TEST_F(ValueOperationsTest, DoubleValuePrecision)
     // Test serialization preserves precision
     // Note: Serialization may lose some precision due to string conversion
     // Use EXPECT_NEAR with appropriate epsilon for roundtrip tests
-    container->add(double_val);
+    container->set("pi", precise_value);
     auto restored = RoundTripSerialize();
 
     // Allow for precision loss during serialization/deserialization
@@ -189,7 +189,7 @@ TEST_F(ValueOperationsTest, LongLongValues)
 
     EXPECT_EQ(to_llong(*llong_val), large_value);
 
-    container->add(llong_val);
+    container->set("large", large_value);
     auto restored = RoundTripSerialize();
     EXPECT_EQ(ov_to_llong(restored->get_value("large")), large_value);
 }
@@ -217,9 +217,8 @@ TEST_F(ValueOperationsTest, ValueTypeIdentification)
 TEST_F(ValueOperationsTest, SpecialStringCharacters)
 {
     std::string special = "Line1\nLine2\tTab\rReturn";
-    auto str_val = make_string_value("special", special);
 
-    container->add(str_val);
+    container->set("special", special);
     auto restored = RoundTripSerialize();
 
     auto restored_val = restored->get_value("special");
@@ -232,13 +231,9 @@ TEST_F(ValueOperationsTest, SpecialStringCharacters)
  */
 TEST_F(ValueOperationsTest, EmptyAndWhitespaceStrings)
 {
-    auto empty = make_string_value("empty", "");
-    auto whitespace = make_string_value("whitespace", "   ");
-    auto mixed = make_string_value("mixed", "  text  ");
-
-    container->add(empty);
-    container->add(whitespace);
-    container->add(mixed);
+    container->set("empty", "");
+    container->set("whitespace", "   ");
+    container->set("mixed", "  text  ");
 
     auto restored = RoundTripSerialize();
 

--- a/samples/basic_usage.cpp
+++ b/samples/basic_usage.cpp
@@ -20,11 +20,11 @@ int main() {
     container->set_message_type("user_profile");
 
     // Set various types of values using new set_value API
-    container->set_value("user_id", std::string("12345"));
-    container->set_value("username", std::string("john_doe"));
-    container->set_value("age", static_cast<int32_t>(30));
-    container->set_value("is_active", true);
-    container->set_value("balance", 1000.50);
+    container->set("user_id", std::string("12345"));
+    container->set("username", std::string("john_doe"));
+    container->set("age", static_cast<int32_t>(30));
+    container->set("is_active", true);
+    container->set("balance", 1000.50);
 
     std::cout << "Container message type: " << container->message_type() << std::endl;
 

--- a/samples/performance_benchmark.cpp
+++ b/samples/performance_benchmark.cpp
@@ -40,7 +40,7 @@ private:
         for (int i = 0; i < iterations; ++i) {
             std::string key = "key_" + std::to_string(i);
             std::string value = "value_" + std::to_string(i);
-            container->set_value(key, value);
+            container->set(key, value);
         }
         auto end = std::chrono::high_resolution_clock::now();
 
@@ -114,7 +114,7 @@ private:
             auto container = std::make_shared<value_container>();
             auto start = std::chrono::high_resolution_clock::now();
             for (int i = 0; i < iterations; ++i) {
-                container->set_value("str_" + std::to_string(i), std::string("value_" + std::to_string(i)));
+                container->set("str_" + std::to_string(i), std::string("value_" + std::to_string(i)));
             }
             auto end = std::chrono::high_resolution_clock::now();
             auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
@@ -126,7 +126,7 @@ private:
             auto container = std::make_shared<value_container>();
             auto start = std::chrono::high_resolution_clock::now();
             for (int i = 0; i < iterations; ++i) {
-                container->set_value("int_" + std::to_string(i), static_cast<int32_t>(i));
+                container->set("int_" + std::to_string(i), static_cast<int32_t>(i));
             }
             auto end = std::chrono::high_resolution_clock::now();
             auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
@@ -138,7 +138,7 @@ private:
             auto container = std::make_shared<value_container>();
             auto start = std::chrono::high_resolution_clock::now();
             for (int i = 0; i < iterations; ++i) {
-                container->set_value("dbl_" + std::to_string(i), static_cast<double>(i * 1.5));
+                container->set("dbl_" + std::to_string(i), static_cast<double>(i * 1.5));
             }
             auto end = std::chrono::high_resolution_clock::now();
             auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
@@ -150,7 +150,7 @@ private:
             auto container = std::make_shared<value_container>();
             auto start = std::chrono::high_resolution_clock::now();
             for (int i = 0; i < iterations; ++i) {
-                container->set_value("bool_" + std::to_string(i), i % 2 == 0);
+                container->set("bool_" + std::to_string(i), i % 2 == 0);
             }
             auto end = std::chrono::high_resolution_clock::now();
             auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
@@ -166,7 +166,7 @@ private:
         auto container = std::make_shared<value_container>();
 
         for (int i = 0; i < iterations; ++i) {
-            container->set_value("key_" + std::to_string(i), static_cast<int32_t>(i));
+            container->set("key_" + std::to_string(i), static_cast<int32_t>(i));
         }
 
         auto [heap, stack] = container->memory_stats();
@@ -194,16 +194,16 @@ private:
 
             switch (value_type) {
                 case 0:
-                    container->set_value(key, std::string("value_" + std::to_string(i)));
+                    container->set(key, std::string("value_" + std::to_string(i)));
                     break;
                 case 1:
-                    container->set_value(key, static_cast<int32_t>(i));
+                    container->set(key, static_cast<int32_t>(i));
                     break;
                 case 2:
-                    container->set_value(key, static_cast<double>(i * 1.5));
+                    container->set(key, static_cast<double>(i * 1.5));
                     break;
                 case 3:
-                    container->set_value(key, i % 2 == 0);
+                    container->set(key, i % 2 == 0);
                     break;
             }
         }

--- a/samples/thread_safe_example.cpp
+++ b/samples/thread_safe_example.cpp
@@ -25,8 +25,8 @@ int main() {
     std::mutex container_mutex;
 
     // Initialize some shared data using new set_value API
-    container->set_value("counter", static_cast<int32_t>(0));
-    container->set_value("total_operations", static_cast<int32_t>(0));
+    container->set("counter", static_cast<int32_t>(0));
+    container->set("total_operations", static_cast<int32_t>(0));
 
     std::cout << "Container initialized for multi-threaded access" << std::endl;
 
@@ -68,7 +68,7 @@ int main() {
                         std::lock_guard<std::mutex> lock(container_mutex);
                         if (auto current = container->get_value("counter")) {
                             if (auto* val = std::get_if<int32_t>(&current->data)) {
-                                container->set_value("counter", static_cast<int32_t>(*val + 1));
+                                container->set("counter", static_cast<int32_t>(*val + 1));
                                 global_counter.fetch_add(1, std::memory_order_relaxed);
                             }
                         }
@@ -78,14 +78,14 @@ int main() {
                         std::lock_guard<std::mutex> lock(container_mutex);
                         std::string thread_key = "thread_" + std::to_string(i);
                         std::string thread_data = "data_from_thread_" + std::to_string(i) + "_op_" + std::to_string(op);
-                        container->set_value(thread_key, thread_data);
+                        container->set(thread_key, thread_data);
                         break;
                     }
                     case 3: { // Update total operations
                         std::lock_guard<std::mutex> lock(container_mutex);
                         if (auto total_ops = container->get_value("total_operations")) {
                             if (auto* val = std::get_if<int32_t>(&total_ops->data)) {
-                                container->set_value("total_operations", static_cast<int32_t>(*val + 1));
+                                container->set("total_operations", static_cast<int32_t>(*val + 1));
                             }
                         }
                         break;
@@ -141,7 +141,7 @@ int main() {
     for (int i = 0; i < perf_iterations; ++i) {
         std::string key = "perf_key_" + std::to_string(i);
         std::string value = "perf_value_" + std::to_string(i);
-        perf_container->set_value(key, value);
+        perf_container->set(key, value);
     }
 
     auto end_time = std::chrono::high_resolution_clock::now();

--- a/tests/generate_test_data.cpp
+++ b/tests/generate_test_data.cpp
@@ -42,54 +42,54 @@ int main() {
     // Null value (type 0) - not implemented in C++, skip
 
     // Bool value (type 1)
-    cont->add(make_bool_value("bool_true", true));
-    cont->add(make_bool_value("bool_false", false));
+    cont->set("bool_true", true);
+    cont->set("bool_false", false);
 
     // Short value (type 2)
-    cont->add(make_short_value("short_neg", static_cast<short>(-1000)));
-    cont->add(make_short_value("short_pos", static_cast<short>(1000)));
+    cont->set("short_neg", static_cast<short>(-1000));
+    cont->set("short_pos", static_cast<short>(1000));
 
     // UShort value (type 3)
-    cont->add(make_ushort_value("ushort", static_cast<unsigned short>(50000)));
+    cont->set("ushort", static_cast<unsigned short>(50000));
 
     // Int value (type 4)
-    cont->add(make_int_value("int_neg", -1000000));
-    cont->add(make_int_value("int_pos", 1000000));
+    cont->set("int_neg", -1000000);
+    cont->set("int_pos", 1000000);
 
     // UInt value (type 5)
-    cont->add(make_uint_value("uint", 3000000000U));
+    cont->set("uint", 3000000000U);
 
     // Long value (type 6) - 32-bit enforced
-    cont->add(make_long_value("long_32bit", 2000000000L));
+    cont->set("long_32bit", 2000000000L);
 
     // ULong value (type 7) - 32-bit enforced
-    cont->add(make_ulong_value("ulong_32bit", 3500000000UL));
+    cont->set("ulong_32bit", 3500000000UL);
 
     // LLong value (type 8) - 64-bit
-    cont->add(make_llong_value("llong_64bit", 5000000000LL));
+    cont->set("llong_64bit", 5000000000LL);
 
     // ULLong value (type 9) - 64-bit
-    cont->add(make_ullong_value("ullong_64bit", 10000000000ULL));
+    cont->set("ullong_64bit", 10000000000ULL);
 
     // Float value (type 10)
-    cont->add(make_float_value("float_pi", 3.14159f));
+    cont->set("float_pi", 3.14159f);
 
     // Double value (type 11)
-    cont->add(make_double_value("double_pi", 3.141592653589793));
+    cont->set("double_pi", 3.141592653589793);
 
     // Bytes value (type 12)
     std::vector<uint8_t> bytes_data = {0x01, 0x02, 0x03, 0xFF, 0xFE};
-    cont->add(make_bytes_value("bytes_test", bytes_data));
+    cont->set("bytes_test", bytes_data);
 
     // String value (type 13)
-    cont->add(make_string_value("string_hello", "Hello from C++!"));
-    cont->add(make_string_value("string_utf8", "UTF-8: 한글 테스트"));
+    cont->set("string_hello", "Hello from C++!");
+    cont->set("string_utf8", "UTF-8: 한글 테스트");
 
     // Container value (type 14) - nested
     auto nested = std::make_shared<value_container>();
     nested->set_message_type("nested_container");
-    nested->add(make_int_value("nested_int", 42));
-    nested->add(make_string_value("nested_str", "nested"));
+    nested->set("nested_int", 42);
+    nested->set("nested_str", "nested");
     cont->add(nested);
 
     // Serialize to file
@@ -110,7 +110,7 @@ int main() {
     // Also generate a simple test case with just one long value
     auto simple = std::make_shared<value_container>();
     simple->set_message_type("simple_test");
-    simple->add(make_long_value("timestamp", 1234567890L));
+    simple->set("timestamp", 1234567890L);
     auto simple_data = simple->serialize_array();
 
     std::ofstream simple_file("test_data_cpp_simple.bin", std::ios::binary);


### PR DESCRIPTION
## Summary

- Migrate all test files from deprecated API to unified API
- Replace `add(make_*_value())` with `set()` throughout test files
- Replace `serialize()` with `serialize_string(serialization_format::binary).value()`
- Replace `to_json()`/`to_xml()` with `serialize_string(format).value()`
- Replace `deserialize()` with `deserialize_result()` or `deserialize(span, format)`
- Replace `set_value()` with `set()`
- All tests now pass with `CONTAINER_NO_LEGACY_API` defined
- Updated tests that relied on deprecated duplicate-key behavior
- Update CHANGELOG.md with deprecation timeline

## Files Changed (20 files)

### Test Files
- `tests/unit_tests.cpp`
- `tests/performance_tests.cpp`
- `tests/benchmark_tests.cpp`
- `tests/generate_test_data.cpp`
- `tests/schema_tests.cpp`
- `tests/msgpack_tests.cpp`

### Integration Tests
- `integration_tests/framework/test_helpers.h`
- `integration_tests/framework/system_fixture.h`
- `integration_tests/scenarios/container_lifecycle_test.cpp`
- `integration_tests/scenarios/value_operations_test.cpp`
- `integration_tests/performance/serialization_performance_test.cpp`
- `integration_tests/failures/error_handling_test.cpp`

### Examples
- `examples/basic_container_example.cpp`
- `examples/advanced_container_example.cpp`
- `examples/real_world_scenarios.cpp`
- `examples/messaging_integration_example.cpp`

### Samples
- `samples/basic_usage.cpp`
- `samples/performance_benchmark.cpp`
- `samples/thread_safe_example.cpp`

### Documentation
- `docs/CHANGELOG.md`

## Test Plan

- [x] Build passes with `CONTAINER_NO_LEGACY_API` defined
- [x] All 21 tests pass in `build_no_legacy` configuration
- [x] No regression in test coverage

Closes #284
Part of #297