### PR TITLE
refactor(api): enable CONTAINER_NO_LEGACY_API build

### DIFF
--- a/core/container.cpp
+++ b/core/container.cpp
@@ -803,6 +803,7 @@ bool value_container::deserialize(const std::vector<uint8_t>& data_array,
 // Schema-Validated Deserialization API (Issue #249)
 // =============================================================================
 
+#ifndef CONTAINER_NO_LEGACY_API
 bool value_container::deserialize(const std::string& data_string,
 								  const container_schema& schema,
 								  bool parse_only_header)
@@ -838,6 +839,7 @@ bool value_container::deserialize(const std::vector<uint8_t>& data_array,
 	validation_errors_ = schema.validate_all(*this);
 	return validation_errors_.empty();
 }
+#endif // CONTAINER_NO_LEGACY_API
 
 const std::vector<validation_error>& value_container::get_validation_errors() const noexcept
 {
@@ -1239,7 +1241,7 @@ void value_container::clear_validation_errors() noexcept
 	{
 		try
 		{
-			auto serialize_res = serialize_result();
+			auto serialize_res = serialize_string(serialization_format::binary);
 			if (!serialize_res.is_ok())
 			{
 				return kcenon::common::VoidResult(serialize_res.error());

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Migrate Deprecated API to Unified Serialization** (#301): Update internal implementations to use unified serialization API
+  - Replace `serialize_result()` with `serialize_string(serialization_format::binary)` in `save_packet_result()`
+  - Replace `serialize_array_result()` with `serialize(serialization_format::binary)` in async operations
+  - Update `async_container.h` to use unified serialization API throughout
+  - Add `#ifndef CONTAINER_NO_LEGACY_API` guards for schema-validated `deserialize()` implementations
+  - Update test files (`result_api_tests.cpp`, `benchmark_tests.cpp`, `async_tests.cpp`) to use unified API
+  - Build and tests pass with `CONTAINER_NO_LEGACY_API` defined
+
 - **Test Migration to Unified API** (#284, #297): Migrate all test files from deprecated API to unified API
   - Replace `add(make_*_value())` with `set()` throughout test files
   - Replace `serialize()` with `serialize_string(serialization_format::binary).value()`

--- a/internal/async/async_container.h
+++ b/internal/async/async_container.h
@@ -570,7 +570,7 @@ namespace container_module::async
     {
         auto container = container_;
         auto result = co_await detail::make_async_awaitable([container]() {
-            return container->serialize_array_result();
+            return container->serialize(value_container::serialization_format::binary);
         });
         co_return result;
     }
@@ -580,7 +580,7 @@ namespace container_module::async
     {
         auto container = container_;
         auto result = co_await detail::make_async_awaitable([container]() {
-            return container->serialize_result();
+            return container->serialize_string(value_container::serialization_format::binary);
         });
         co_return result;
     }
@@ -687,7 +687,7 @@ namespace container_module::async
         std::string path_str(path);
         auto result = co_await detail::make_async_awaitable(
             [container, path_str, callback]() -> kcenon::common::VoidResult {
-                auto data_result = container->serialize_array_result();
+                auto data_result = container->serialize(value_container::serialization_format::binary);
                 if (!data_result.is_ok()) {
                     return kcenon::common::VoidResult(data_result.error());
                 }
@@ -838,7 +838,7 @@ namespace container_module::async
     inline generator<std::vector<uint8_t>>
         async_container::serialize_chunked(size_t chunk_size) const
     {
-        auto data_result = container_->serialize_array_result();
+        auto data_result = container_->serialize(value_container::serialization_format::binary);
         if (!data_result.is_ok()) {
             co_return;
         }

--- a/tests/async_tests.cpp
+++ b/tests/async_tests.cpp
@@ -362,8 +362,10 @@ TEST_F(AsyncContainerTest, SerializeStringAsyncReturnsValidData) {
 }
 
 TEST_F(AsyncContainerTest, DeserializeAsyncRestoresData) {
-    // First serialize
-    auto serialized = container_->serialize_array();
+    // First serialize using unified API
+    auto serialize_result = container_->serialize(container_module::value_container::serialization_format::binary);
+    ASSERT_TRUE(serialize_result.is_ok());
+    auto serialized = serialize_result.value();
     EXPECT_FALSE(serialized.empty());
 
     // Then deserialize async
@@ -398,8 +400,10 @@ TEST_F(AsyncContainerTest, DeserializeAsyncRestoresData) {
 }
 
 TEST_F(AsyncContainerTest, DeserializeStringAsyncRestoresData) {
-    // First serialize
-    auto serialized = container_->serialize();
+    // First serialize using unified API
+    auto serialize_result = container_->serialize_string(container_module::value_container::serialization_format::binary);
+    ASSERT_TRUE(serialize_result.is_ok());
+    auto serialized = serialize_result.value();
     EXPECT_FALSE(serialized.empty());
 
     // Then deserialize async
@@ -838,8 +842,10 @@ TEST_F(AsyncStreamingTest, SerializeChunkedEmptyContainer) {
 }
 
 TEST_F(AsyncStreamingTest, DeserializeStreamingComplete) {
-    // First serialize the container
-    auto serialized = container_->serialize_array();
+    // First serialize the container using unified API
+    auto serialize_result = container_->serialize(container_module::value_container::serialization_format::binary);
+    ASSERT_TRUE(serialize_result.is_ok());
+    auto serialized = serialize_result.value();
     EXPECT_FALSE(serialized.empty());
 
     // Deserialize with is_final=true
@@ -869,8 +875,10 @@ TEST_F(AsyncStreamingTest, DeserializeStreamingComplete) {
 }
 
 TEST_F(AsyncStreamingTest, DeserializeStreamingIncomplete) {
-    // First serialize the container
-    auto serialized = container_->serialize_array();
+    // First serialize the container using unified API
+    auto serialize_result = container_->serialize(container_module::value_container::serialization_format::binary);
+    ASSERT_TRUE(serialize_result.is_ok());
+    auto serialized = serialize_result.value();
     EXPECT_FALSE(serialized.empty());
 
     // Deserialize with is_final=false should fail/return error

--- a/tests/benchmark_tests.cpp
+++ b/tests/benchmark_tests.cpp
@@ -290,7 +290,7 @@ BENCHMARK(BM_ContainerDeserialize)->Range(1, 1000);
 static void BM_ContainerToJSON(benchmark::State& state) {
     auto container = std::make_unique<value_container>();
     container->set_message_type("benchmark");
-    
+
     // Add values
     for (int i = 0; i < state.range(0); ++i) {
         container->set(
@@ -300,8 +300,8 @@ static void BM_ContainerToJSON(benchmark::State& state) {
     }
 
     for (auto _ : state) {
-        std::string json = container->to_json();
-        benchmark::DoNotOptimize(json);
+        auto result = container->serialize_string(value_container::serialization_format::json);
+        benchmark::DoNotOptimize(result);
     }
     state.SetItemsProcessed(state.iterations() * state.range(0));
 }
@@ -310,7 +310,7 @@ BENCHMARK(BM_ContainerToJSON)->Range(1, 100);
 static void BM_ContainerToXML(benchmark::State& state) {
     auto container = std::make_unique<value_container>();
     container->set_message_type("benchmark");
-    
+
     // Add values
     for (int i = 0; i < state.range(0); ++i) {
         container->set(
@@ -320,8 +320,8 @@ static void BM_ContainerToXML(benchmark::State& state) {
     }
 
     for (auto _ : state) {
-        std::string xml = container->to_xml();
-        benchmark::DoNotOptimize(xml);
+        auto result = container->serialize_string(value_container::serialization_format::xml);
+        benchmark::DoNotOptimize(result);
     }
     state.SetItemsProcessed(state.iterations() * state.range(0));
 }


### PR DESCRIPTION
Closes #301

## Summary
- Replace deprecated serialization API with unified serialization API throughout codebase
- Enable successful build with `CONTAINER_NO_LEGACY_API` defined
- Migrate all test files to use unified API

## Changes
| File | Change |
|------|--------|
| `core/container.cpp` | Add `#ifndef` guard for schema-validated `deserialize()`; use `serialize_string()` in `save_packet_result()` |
| `internal/async/async_container.h` | Replace `serialize_array_result()` with `serialize()` in async operations |
| `tests/result_api_tests.cpp` | Migrate to `serialize_string()`, `serialize()`, unified API |
| `tests/benchmark_tests.cpp` | Use `serialize_string()` for JSON/XML benchmarks |
| `tests/async_tests.cpp` | Use unified serialization API in async tests |
| `docs/CHANGELOG.md` | Document changes |

## Test Plan
- [x] Build succeeds with `CONTAINER_NO_LEGACY_API` defined
- [x] All 21 tests pass with `CONTAINER_NO_LEGACY_API` build
- [x] Build succeeds without `CONTAINER_NO_LEGACY_API` (legacy API still available)
- [x] All 21 tests pass with normal build