### PR TITLE
refactor(serialization): remove deprecated serialize/deserialize methods

### DIFF
--- a/benchmarks/container_operations_bench.cpp
+++ b/benchmarks/container_operations_bench.cpp
@@ -86,7 +86,8 @@ static void BM_Container_Clone(benchmark::State& state) {
     }
 
     for (auto _ : state) {
-        auto serialized = c->serialize();
+        auto result = c->serialize_string(value_container::serialization_format::binary);
+        auto serialized = result.is_ok() ? result.value() : "";
         auto cloned = std::make_shared<value_container>(serialized);
         benchmark::DoNotOptimize(cloned);
     }

--- a/benchmarks/serialization_bench.cpp
+++ b/benchmarks/serialization_bench.cpp
@@ -45,7 +45,8 @@ static void BM_Serialize_Small(benchmark::State& state) {
     c->set("key2", 42);
 
     for (auto _ : state) {
-        auto data = c->serialize();
+        auto result = c->serialize_string(value_container::serialization_format::binary);
+        auto data = result.is_ok() ? result.value() : "";
         benchmark::DoNotOptimize(data);
         state.SetBytesProcessed(data.size());
     }
@@ -59,7 +60,8 @@ static void BM_Serialize_Large(benchmark::State& state) {
     }
 
     for (auto _ : state) {
-        auto data = c->serialize();
+        auto result = c->serialize_string(value_container::serialization_format::binary);
+        auto data = result.is_ok() ? result.value() : "";
         benchmark::DoNotOptimize(data);
         state.SetBytesProcessed(data.size());
     }
@@ -71,7 +73,8 @@ static void BM_Deserialize(benchmark::State& state) {
     for (int i = 0; i < 100; ++i) {
         c->set("key_" + std::to_string(i), i);
     }
-    auto data = c->serialize();
+    auto result = c->serialize_string(value_container::serialization_format::binary);
+    auto data = result.is_ok() ? result.value() : "";
 
     for (auto _ : state) {
         auto deserialized = std::make_shared<value_container>(data);
@@ -86,7 +89,8 @@ static void BM_SerializeDeserialize_RoundTrip(benchmark::State& state) {
         auto c = std::make_shared<value_container>();
         c->set("test", std::string("data"));
 
-        auto data = c->serialize();
+        auto result = c->serialize_string(value_container::serialization_format::binary);
+        auto data = result.is_ok() ? result.value() : "";
         auto c2 = std::make_shared<value_container>(data);
 
         benchmark::DoNotOptimize(c2);

--- a/core/container.cpp
+++ b/core/container.cpp
@@ -110,7 +110,7 @@ namespace container_module
 		{
 			metrics_manager::get().operations.copies.fetch_add(1, std::memory_order_relaxed);
 		}
-		deserialize(other.serialize(), parse_only_header);
+		deserialize(other.serialize_impl(), parse_only_header);
 	}
 
 	value_container::value_container(std::shared_ptr<value_container> other,
@@ -119,7 +119,7 @@ namespace container_module
 	{
 		if (other)
 		{
-			deserialize(other->serialize(), parse_only_header);
+			deserialize(other->serialize_impl(), parse_only_header);
 		}
 	}
 
@@ -216,7 +216,7 @@ namespace container_module
 	std::shared_ptr<value_container> value_container::copy(
 		bool containing_values)
 	{
-		auto newC = std::make_shared<value_container>(serialize(),
+		auto newC = std::make_shared<value_container>(serialize_impl(),
 													  !containing_values);
 		if (!containing_values && newC)
 		{
@@ -724,21 +724,6 @@ namespace container_module
 		result.append(ds);
 
 		return result;
-	}
-
-	std::string value_container::serialize(void) const
-	{
-		return serialize_impl();
-	}
-
-	std::vector<uint8_t> value_container::serialize_array(void) const
-	{
-		auto [arr, err] = convert_string::to_array(serialize_impl());
-		if (!err.empty())
-		{
-			return {};
-		}
-		return arr;
 	}
 
 	bool value_container::deserialize(const std::string& data_str,
@@ -2149,7 +2134,7 @@ void value_container::clear_validation_errors() noexcept
 
 	std::ostream& operator<<(std::ostream& out, value_container& other)
 	{
-		out << other.serialize();
+		out << other.serialize_impl();
 		return out;
 	}
 
@@ -2157,13 +2142,13 @@ void value_container::clear_validation_errors() noexcept
 							 std::shared_ptr<value_container> other)
 	{
 		if (other)
-			out << other->serialize();
+			out << other->serialize_impl();
 		return out;
 	}
 
 	std::string& operator<<(std::string& out, value_container& other)
 	{
-		out = other.serialize();
+		out = other.serialize_impl();
 		return out;
 	}
 
@@ -2171,7 +2156,7 @@ void value_container::clear_validation_errors() noexcept
 							std::shared_ptr<value_container> other)
 	{
 		if (other)
-			out = other->serialize();
+			out = other->serialize_impl();
 		else
 			out.clear();
 		return out;

--- a/core/container.h
+++ b/core/container.h
@@ -540,56 +540,6 @@ namespace container_module
 		 */
 		void initialize(void);
 
-		// =======================================================================
-		// Core Serialization API
-		// Note: These methods are deprecated but still required internally
-		// (used by constructors). They cannot be conditionally excluded.
-		// Use the Result-based API (serialize_result, etc.) for new code.
-		// =======================================================================
-
-		/**
-		 * @brief Serialize this container (header + data).
-		 * @return The string form.
-		 * @exception_safety Strong guarantee - no changes on exception
-		 * @throws std::bad_alloc if memory allocation fails
-		 * @throws std::runtime_error if value cannot be serialized
-		 * @deprecated Use serialize_result() instead for Result-based error handling
-		 */
-		[[deprecated("Use serialize_result() instead for Result-based error handling")]]
-		std::string serialize(void) const;
-
-		/**
-		 * @brief Serialize to a raw byte array.
-		 * @exception_safety Strong guarantee - no changes on exception
-		 * @throws std::bad_alloc if memory allocation fails
-		 * @throws std::runtime_error if value cannot be serialized
-		 * @deprecated Use serialize_array_result() instead for Result-based error handling
-		 */
-		[[deprecated("Use serialize_array_result() instead for Result-based error handling")]]
-		std::vector<uint8_t> serialize_array(void) const;
-
-		/**
-		 * @brief Deserialize from string. If parse_only_header is true, child
-		 * values are not fully parsed yet.
-		 * @exception_safety Basic guarantee - container may be partially modified
-		 * @return true on success, false on parse error (no exceptions thrown)
-		 * @deprecated Use deserialize_result() instead for Result-based error handling
-		 */
-		[[deprecated("Use deserialize_result() instead for Result-based error handling")]]
-		bool deserialize(const std::string& data_string,
-					 bool parse_only_header = true);
-
-		/**
-		 * @brief Deserialize from a raw byte array. If parse_only_header is
-		 * true, child values are not fully parsed.
-		 * @exception_safety Basic guarantee - container may be partially modified
-		 * @return true on success, false on parse error (no exceptions thrown)
-		 * @deprecated Use deserialize_result() instead for Result-based error handling
-		 */
-		[[deprecated("Use deserialize_result() instead for Result-based error handling")]]
-		bool deserialize(const std::vector<uint8_t>& data_array,
-					 bool parse_only_header = true);
-
 #if KCENON_HAS_COMMON_SYSTEM
 		/**
 		 * @brief Deserialize returning common_system result to carry error context.
@@ -1000,6 +950,29 @@ namespace container_module
 	/** @} */
 
 	private:
+		// =======================================================================
+		// Internal Deserialization Methods
+		// Used by constructors - not part of public API
+		// =======================================================================
+
+		/**
+		 * @brief Internal deserialize from string
+		 * @param data_string Serialized data string
+		 * @param parse_only_header If true, only parse header (lazy parsing)
+		 * @return true on success, false on parse error
+		 */
+		bool deserialize(const std::string& data_string,
+						 bool parse_only_header = true);
+
+		/**
+		 * @brief Internal deserialize from byte array
+		 * @param data_array Serialized data as bytes
+		 * @param parse_only_header If true, only parse header (lazy parsing)
+		 * @return true on success, false on parse error
+		 */
+		bool deserialize(const std::vector<uint8_t>& data_array,
+						 bool parse_only_header = true);
+
 		bool deserialize_values(const std::string& data,
 								bool parse_only_header);
 		void parsing(std::string_view source_name,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Breaking Changes
+- **Remove Deprecated Serialization Methods** (#307): Complete removal of deprecated serialization API
+  - **BREAKING**: Remove `serialize()` (void return) - Use `serialize_string(serialization_format::binary)` instead
+  - **BREAKING**: Remove `serialize_array()` - Use `serialize(serialization_format::binary)` instead
+  - **BREAKING**: Remove public `deserialize(string)` and `deserialize(vector<uint8_t>)` - Use `deserialize_result()` instead
+  - **BREAKING**: Remove deprecated `add_value()` from `messaging_container_builder` - Use `set()` instead
+  - Internal `deserialize()` methods moved to private (used by constructors)
+  - Update internal usages: ostream operators now use `serialize_impl()`
+  - Update samples, examples, and benchmarks to use Result-based API
+  - Async container operations now use `serialize(format)` / `serialize_string(format)`
+
 - **Enable CONTAINER_NO_LEGACY_API by Default** (#305): Remove deprecated serialization methods
   - **BREAKING**: `CONTAINER_NO_LEGACY_API` is now enabled by default in CMakeLists.txt
   - **Migration Required**: If you use deprecated methods, set `CONTAINER_LEGACY_API=ON` in CMake, or migrate to unified API

--- a/examples/asio_integration_example.cpp
+++ b/examples/asio_integration_example.cpp
@@ -115,7 +115,7 @@ public:
                       std::function<void(std::vector<uint8_t>)> callback) {
         // Post work to the strand for thread-safe execution
         asio::post(strand_, [this, container, callback]() {
-            auto serialized = container->serialize_array();
+            auto serialized = container->serialize(value_container::serialization_format::binary).value_or(std::vector<uint8_t>{});
             print_info("Processed container: " + std::to_string(serialized.size()) + " bytes");
             if (callback) {
                 callback(std::move(serialized));
@@ -200,7 +200,7 @@ void demonstrate_scheduled_processing() {
     timer.expires_after(std::chrono::milliseconds(100));
     timer.async_wait([container](const asio::error_code& ec) {
         if (!ec) {
-            auto serialized = container->serialize_array();
+            auto serialized = container->serialize(value_container::serialization_format::binary).value_or(std::vector<uint8_t>{});
             print_success("Timer triggered! Serialized " +
                          std::to_string(serialized.size()) + " bytes");
         }
@@ -239,7 +239,7 @@ void demonstrate_concurrent_processing() {
             container->set("task_id", static_cast<int32_t>(i));
             container->set("data", std::string("Task data " + std::to_string(i)));
 
-            auto serialized = container->serialize_array();
+            auto serialized = container->serialize(value_container::serialization_format::binary).value_or(std::vector<uint8_t>{});
 
             int count = completed_count.fetch_add(1) + 1;
             std::cout << "  Task " << i << " completed (" << count << "/" << total_tasks << ")" << std::endl;
@@ -280,7 +280,7 @@ void demonstrate_message_queue() {
             container->set("seq", static_cast<int32_t>(i));
             container->set("body", std::string("Message " + std::to_string(i)));
 
-            auto serialized = container->serialize_array();
+            auto serialized = container->serialize(value_container::serialization_format::binary).value_or(std::vector<uint8_t>{});
 
             {
                 std::lock_guard<std::mutex> lock(queue_mutex);

--- a/integration/messaging_integration.cpp
+++ b/integration/messaging_integration.cpp
@@ -82,7 +82,8 @@ std::string messaging_integration::serialize_for_messaging(
     auto start = std::chrono::high_resolution_clock::now();
 #endif
 
-    std::string result = container->serialize();
+    auto serialize_result = container->serialize_string(value_container::serialization_format::binary);
+    std::string result = serialize_result.is_ok() ? serialize_result.value() : "";
 
     // TODO: Add compression support when ENABLE_COMPRESSION is available
     if (compress) {

--- a/integration/messaging_integration.h
+++ b/integration/messaging_integration.h
@@ -133,14 +133,6 @@ public:
     messaging_container_builder& message_type(const std::string& type);
 
     /**
-     * @brief Add value using deprecated API
-     * @deprecated Use set() instead for unified API
-     */
-    template<typename T>
-    [[deprecated("Use set() instead")]]
-    messaging_container_builder& add_value(const std::string& key, T&& value);
-
-    /**
      * @brief Set a value by key (unified API)
      * @param key The value key/name
      * @param value The value to store
@@ -188,43 +180,12 @@ messaging_container_builder& messaging_container_builder::set(const std::string&
 
     if constexpr (std::is_same_v<DecayedT, std::shared_ptr<value_container>>) {
         // Handle nested containers by serializing and storing as bytes
-        std::string serialized_data = value->serialize();
-        std::vector<uint8_t> bytes(serialized_data.begin(), serialized_data.end());
-        container_->set(key, bytes);
-    } else if constexpr (std::is_same_v<DecayedT, bool>) {
-        container_->set(key, value);
-    } else if constexpr (concepts::IntegralType<DecayedT>) {
-        if constexpr (sizeof(DecayedT) <= 4) {
-            container_->set(key, static_cast<int32_t>(value));
-        } else {
-            container_->set(key, static_cast<int64_t>(value));
+        auto result = value->serialize_string(value_container::serialization_format::binary);
+        if (result.is_ok()) {
+            std::string serialized_data = result.value();
+            std::vector<uint8_t> bytes(serialized_data.begin(), serialized_data.end());
+            container_->set(key, bytes);
         }
-    } else if constexpr (concepts::FloatingPointType<DecayedT>) {
-        if constexpr (std::is_same_v<DecayedT, float>) {
-            container_->set(key, value);
-        } else {
-            container_->set(key, value);
-        }
-    } else if constexpr (std::is_same_v<DecayedT, std::string>) {
-        container_->set(key, std::string(value));
-    } else if constexpr (concepts::StringLike<DecayedT>) {
-        container_->set(key, std::string(value));
-    }
-
-    return *this;
-}
-
-// Template implementation for add_value (deprecated)
-// Uses concepts to provide clearer error messages for unsupported types
-template<typename T>
-messaging_container_builder& messaging_container_builder::add_value(const std::string& key, T&& value) {
-    using DecayedT = std::decay_t<T>;
-
-    if constexpr (std::is_same_v<DecayedT, std::shared_ptr<value_container>>) {
-        // Handle nested containers by serializing and storing as bytes
-        std::string serialized_data = value->serialize();
-        std::vector<uint8_t> bytes(serialized_data.begin(), serialized_data.end());
-        container_->set(key, bytes);
     } else if constexpr (std::is_same_v<DecayedT, bool>) {
         container_->set(key, value);
     } else if constexpr (concepts::IntegralType<DecayedT>) {

--- a/samples/basic_usage.cpp
+++ b/samples/basic_usage.cpp
@@ -71,7 +71,8 @@ int main() {
     // 4. Container serialization
     std::cout << "\n4. Serialization:" << std::endl;
 
-    std::string serialized = container->serialize();
+    auto serialize_result = container->serialize_string(value_container::serialization_format::binary);
+    std::string serialized = serialize_result.is_ok() ? serialize_result.value() : "";
     std::cout << "Serialized container size: " << serialized.length() << " bytes" << std::endl;
 
     // 5. Container deserialization

--- a/samples/performance_benchmark.cpp
+++ b/samples/performance_benchmark.cpp
@@ -83,7 +83,8 @@ private:
 
             // Benchmark serialization
             auto start = std::chrono::high_resolution_clock::now();
-            std::string serialized = container->serialize();
+            auto result = container->serialize_string(value_container::serialization_format::binary);
+            std::string serialized = result.is_ok() ? result.value() : "";
             auto end = std::chrono::high_resolution_clock::now();
 
             auto serialize_duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);

--- a/samples/thread_safe_example.cpp
+++ b/samples/thread_safe_example.cpp
@@ -157,7 +157,8 @@ int main() {
     std::string serialized;
     {
         std::lock_guard<std::mutex> lock(container_mutex);
-        serialized = container->serialize();
+        auto result = container->serialize_string(value_container::serialization_format::binary);
+        serialized = result.is_ok() ? result.value() : "";
     }
 
     std::cout << "Container serialized successfully" << std::endl;

--- a/tests/generate_test_data.cpp
+++ b/tests/generate_test_data.cpp
@@ -93,7 +93,8 @@ int main() {
     cont->add(nested);
 
     // Serialize to file
-    auto serialized = cont->serialize_array();
+    auto serialize_result = cont->serialize(value_container::serialization_format::binary);
+    auto serialized = serialize_result.is_ok() ? serialize_result.value() : std::vector<uint8_t>{};
 
     std::ofstream outfile("test_data_cpp.bin", std::ios::binary);
     if (!outfile) {
@@ -111,7 +112,8 @@ int main() {
     auto simple = std::make_shared<value_container>();
     simple->set_message_type("simple_test");
     simple->set("timestamp", 1234567890L);
-    auto simple_data = simple->serialize_array();
+    auto simple_result = simple->serialize(value_container::serialization_format::binary);
+    auto simple_data = simple_result.is_ok() ? simple_result.value() : std::vector<uint8_t>{};
 
     std::ofstream simple_file("test_data_cpp_simple.bin", std::ios::binary);
     simple_file.write(reinterpret_cast<const char*>(simple_data.data()), simple_data.size());


### PR DESCRIPTION
## Summary
- Remove deprecated `serialize()` and `serialize_array()` methods from value_container public API
- Move `deserialize(string/vector)` methods to private (still used internally by constructors)
- Remove deprecated `add_value()` template from `messaging_container_builder`
- Update internal usages to use `serialize_impl()` or Result-based API
- Migrate samples, examples, benchmarks, and tests to use Result-based serialization API

## Changes
### Breaking Changes
- `value_container::serialize()` (void return) removed - use `serialize_string(serialization_format::binary)`
- `value_container::serialize_array()` removed - use `serialize(serialization_format::binary)`
- `value_container::deserialize(string)` and `deserialize(vector<uint8_t>)` moved to private
- `messaging_container_builder::add_value()` removed - use `set()` instead

### Internal Changes
- ostream operators now use `serialize_impl()` directly
- `value_container::copy()` uses `serialize_impl()`
- `async_container` operations use `serialize(format)` / `serialize_string(format)`
- `messaging_integration` uses Result-based API

### Files Modified
- `core/container.h` - Remove deprecated method declarations, add private deserialize methods
- `core/container.cpp` - Remove deprecated implementations, update internal calls
- `integration/messaging_integration.h` - Remove add_value, update set() template
- `integration/messaging_integration.cpp` - Use Result-based serialize
- `internal/async/async_container.h` - Use new serialize API
- `samples/*` - Migrate to Result-based API
- `examples/*` - Migrate to Result-based API
- `benchmarks/*` - Migrate to Result-based API
- `tests/generate_test_data.cpp` - Migrate to Result-based API

## Test Plan
- [x] Build passes with Release configuration
- [x] Core unit tests pass (130/131 tests)
- [x] All other test suites pass
- [ ] LargeDataHandling test hangs (pre-existing issue, not related to this change)

Closes #307