### PR TITLE
refactor(serialization): integrate serializer strategies into unified API

### DIFF
--- a/core/container.h
+++ b/core/container.h
@@ -249,6 +249,7 @@ namespace container_module
 		std::string target_id(void) const noexcept;
 		std::string target_sub_id(void) const noexcept;
 		std::string message_type(void) const noexcept;
+		std::string version(void) const noexcept;
 
 		// Value management methods
 
@@ -1089,37 +1090,9 @@ namespace container_module
 		void set_unit_impl(const optimized_value& val);
 
 		// =======================================================================
-		// Internal Serialization Implementations (Issue #299)
-		// These are the core implementations used by both legacy and unified APIs.
+		// Internal Deserialization Implementation (Issue #299)
+		// Note: Serialization implementations moved to serializer strategies (Issue #315)
 		// =======================================================================
-
-		/**
-		 * @brief Internal implementation for binary serialization
-		 * @return Serialized string
-		 * @throws std::bad_alloc, std::runtime_error on failure
-		 */
-		std::string serialize_impl() const;
-
-		/**
-		 * @brief Internal implementation for JSON serialization
-		 * @return JSON string
-		 * @throws std::bad_alloc, std::runtime_error on failure
-		 */
-		std::string to_json_impl();
-
-		/**
-		 * @brief Internal implementation for XML serialization
-		 * @return XML string
-		 * @throws std::bad_alloc, std::runtime_error on failure
-		 */
-		std::string to_xml_impl();
-
-		/**
-		 * @brief Internal implementation for MessagePack serialization
-		 * @return MessagePack byte vector
-		 * @throws std::bad_alloc, std::runtime_error on failure
-		 */
-		std::vector<uint8_t> to_msgpack_impl() const;
 
 		/**
 		 * @brief Internal implementation for MessagePack deserialization

--- a/core/serializers/binary_serializer.h
+++ b/core/serializers/binary_serializer.h
@@ -67,6 +67,15 @@ namespace container_module
 		 */
 		[[nodiscard]] kcenon::common::Result<std::vector<uint8_t>>
 			serialize(const value_container& container) const noexcept override;
+
+		/**
+		 * @brief Serialize a value_container to binary string format
+		 *
+		 * @param container The container to serialize
+		 * @return Serialized binary string
+		 * @throws std::bad_alloc on memory allocation failure
+		 */
+		[[nodiscard]] std::string serialize_to_string(const value_container& container) const;
 #endif
 
 		/**

--- a/core/serializers/json_serializer.cpp
+++ b/core/serializers/json_serializer.cpp
@@ -32,6 +32,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "json_serializer.h"
 #include "container/core/container.h"
+#include "container/core/container/variant_helpers.h"
+#include "utilities/core/formatter.h"
 
 namespace container_module
 {
@@ -42,17 +44,16 @@ json_serializer::serialize(const value_container& container) const noexcept
 {
 	try
 	{
-		// Delegate to the container's existing serialize_string implementation
-		auto str_result = container.serialize_string(
-			value_container::serialization_format::json);
-		if (!str_result.is_ok())
-		{
-			return kcenon::common::Result<std::vector<uint8_t>>(str_result.error());
-		}
-
-		const auto& str = str_result.value();
-		std::vector<uint8_t> result(str.begin(), str.end());
-		return kcenon::common::ok(std::move(result));
+		auto str = serialize_to_string(container);
+		return kcenon::common::ok(std::vector<uint8_t>(str.begin(), str.end()));
+	}
+	catch (const std::bad_alloc&)
+	{
+		return kcenon::common::Result<std::vector<uint8_t>>(
+			kcenon::common::error_info{
+				-2,
+				"Memory allocation failed during JSON serialization",
+				"json_serializer"});
 	}
 	catch (const std::exception& e)
 	{
@@ -62,6 +63,76 @@ json_serializer::serialize(const value_container& container) const noexcept
 				std::string("JSON serialization failed: ") + e.what(),
 				"json_serializer"});
 	}
+}
+
+std::string json_serializer::serialize_to_string(const value_container& container) const
+{
+	// Get container data through public accessors
+	auto message_type = container.message_type();
+	auto target_id = container.target_id();
+	auto target_sub_id = container.target_sub_id();
+	auto source_id = container.source_id();
+	auto source_sub_id = container.source_sub_id();
+	auto version = container.version();
+	auto values = container.get_variant_values();
+
+	std::string result;
+	utility_module::formatter::format_to(std::back_inserter(result), "{{");
+
+	// Header section
+	utility_module::formatter::format_to(std::back_inserter(result), "\"header\":{{");
+	if (message_type != "data_container")
+	{
+		utility_module::formatter::format_to(std::back_inserter(result),
+							 "\"target_id\":\"{}\",",
+							 variant_helpers::json_escape(target_id));
+		utility_module::formatter::format_to(std::back_inserter(result),
+							 "\"target_sub_id\":\"{}\",",
+							 variant_helpers::json_escape(target_sub_id));
+		utility_module::formatter::format_to(std::back_inserter(result),
+							 "\"source_id\":\"{}\",",
+							 variant_helpers::json_escape(source_id));
+		utility_module::formatter::format_to(std::back_inserter(result),
+							 "\"source_sub_id\":\"{}\",",
+							 variant_helpers::json_escape(source_sub_id));
+	}
+	utility_module::formatter::format_to(std::back_inserter(result),
+						 "\"message_type\":\"{}\"",
+						 variant_helpers::json_escape(message_type));
+	utility_module::formatter::format_to(std::back_inserter(result), ",\"version\":\"{}\"",
+						 variant_helpers::json_escape(version));
+	utility_module::formatter::format_to(std::back_inserter(result), "}},"); // end header
+
+	// Values section
+	utility_module::formatter::format_to(std::back_inserter(result), "\"values\":{{");
+	bool first = true;
+	for (const auto& u : values)
+	{
+		if (!first)
+		{
+			utility_module::formatter::format_to(std::back_inserter(result), ",");
+		}
+		std::string value_str = variant_helpers::to_string(u.data, u.type);
+		std::string escaped_name = variant_helpers::json_escape(u.name);
+
+		// String and bytes values need quotes
+		if (u.type == value_types::string_value || u.type == value_types::bytes_value)
+		{
+			std::string escaped_value = variant_helpers::json_escape(value_str);
+			utility_module::formatter::format_to(std::back_inserter(result), "\"{}\":\"{}\"",
+								 escaped_name, escaped_value);
+		}
+		else
+		{
+			utility_module::formatter::format_to(std::back_inserter(result), "\"{}\":{}",
+								 escaped_name, value_str);
+		}
+		first = false;
+	}
+	utility_module::formatter::format_to(std::back_inserter(result), "}}"); // end values
+	utility_module::formatter::format_to(std::back_inserter(result), "}}");
+
+	return result;
 }
 #endif
 

--- a/core/serializers/json_serializer.h
+++ b/core/serializers/json_serializer.h
@@ -67,6 +67,15 @@ namespace container_module
 		 */
 		[[nodiscard]] kcenon::common::Result<std::vector<uint8_t>>
 			serialize(const value_container& container) const noexcept override;
+
+		/**
+		 * @brief Serialize a value_container to JSON string format
+		 *
+		 * @param container The container to serialize
+		 * @return Serialized JSON string
+		 * @throws std::bad_alloc on memory allocation failure
+		 */
+		[[nodiscard]] std::string serialize_to_string(const value_container& container) const;
 #endif
 
 		/**

--- a/core/serializers/msgpack_serializer.cpp
+++ b/core/serializers/msgpack_serializer.cpp
@@ -32,20 +32,199 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "msgpack_serializer.h"
 #include "container/core/container.h"
+#include "container/core/container/msgpack.h"
 
 namespace container_module
 {
 
 #if KCENON_HAS_COMMON_SYSTEM
+
+namespace
+{
+	// Helper function to serialize a value_container to msgpack
+	// This allows recursive serialization of nested containers
+	std::vector<uint8_t> serialize_container_to_msgpack(const value_container& container);
+
+	void write_value_to_encoder(msgpack_encoder& encoder, const optimized_value& unit)
+	{
+		switch (unit.type)
+		{
+		case value_types::null_value:
+			encoder.write_nil();
+			break;
+
+		case value_types::bool_value:
+			encoder.write_bool(std::get<bool>(unit.data));
+			break;
+
+		case value_types::short_value:
+			encoder.write_int(std::get<short>(unit.data));
+			break;
+
+		case value_types::ushort_value:
+			encoder.write_uint(std::get<unsigned short>(unit.data));
+			break;
+
+		case value_types::int_value:
+			encoder.write_int(std::get<int>(unit.data));
+			break;
+
+		case value_types::uint_value:
+			encoder.write_uint(std::get<unsigned int>(unit.data));
+			break;
+
+		case value_types::long_value:
+			encoder.write_int(std::get<long>(unit.data));
+			break;
+
+		case value_types::ulong_value:
+			encoder.write_uint(std::get<unsigned long>(unit.data));
+			break;
+
+		case value_types::llong_value:
+			encoder.write_int(std::get<long long>(unit.data));
+			break;
+
+		case value_types::ullong_value:
+			encoder.write_uint(std::get<unsigned long long>(unit.data));
+			break;
+
+		case value_types::float_value:
+			encoder.write_float(std::get<float>(unit.data));
+			break;
+
+		case value_types::double_value:
+			encoder.write_double(std::get<double>(unit.data));
+			break;
+
+		case value_types::string_value:
+			encoder.write_string(std::get<std::string>(unit.data));
+			break;
+
+		case value_types::bytes_value:
+			encoder.write_binary(std::get<std::vector<uint8_t>>(unit.data));
+			break;
+
+		case value_types::container_value:
+			{
+				// Nested container: serialize recursively
+				auto nested = std::get<std::shared_ptr<value_container>>(unit.data);
+				if (nested)
+				{
+					auto nested_data = serialize_container_to_msgpack(*nested);
+					encoder.write_binary(nested_data);
+				}
+				else
+				{
+					encoder.write_nil();
+				}
+			}
+			break;
+
+		case value_types::array_value:
+			// Array values are stored as containers
+			encoder.write_nil();
+			break;
+
+		default:
+			encoder.write_nil();
+			break;
+		}
+	}
+
+	std::vector<uint8_t> serialize_container_to_msgpack(const value_container& container)
+	{
+		// Get container data through public accessors
+		auto message_type = container.message_type();
+		auto target_id = container.target_id();
+		auto target_sub_id = container.target_sub_id();
+		auto source_id = container.source_id();
+		auto source_sub_id = container.source_sub_id();
+		auto version = container.version();
+		auto values = container.get_variant_values();
+
+		msgpack_encoder encoder;
+
+		// Estimate buffer size: header (~100 bytes) + values
+		encoder.reserve(200 + values.size() * 32);
+
+		// MessagePack structure:
+		// {
+		//   "header": { ... },
+		//   "values": { ... }
+		// }
+
+		// Write outer map with 2 entries (header + values)
+		encoder.write_map_header(2);
+
+		// Write "header" key
+		encoder.write_string("header");
+
+		// Calculate header entries count
+		size_t header_count = 2; // message_type and version are always present
+		if (message_type != "data_container")
+		{
+			header_count += 4; // target_id, target_sub_id, source_id, source_sub_id
+		}
+
+		// Write header map
+		encoder.write_map_header(header_count);
+
+		if (message_type != "data_container")
+		{
+			encoder.write_string("target_id");
+			encoder.write_string(target_id);
+
+			encoder.write_string("target_sub_id");
+			encoder.write_string(target_sub_id);
+
+			encoder.write_string("source_id");
+			encoder.write_string(source_id);
+
+			encoder.write_string("source_sub_id");
+			encoder.write_string(source_sub_id);
+		}
+
+		encoder.write_string("message_type");
+		encoder.write_string(message_type);
+
+		encoder.write_string("version");
+		encoder.write_string(version);
+
+		// Write "values" key
+		encoder.write_string("values");
+
+		// Write values map
+		encoder.write_map_header(values.size());
+
+		for (const auto& unit : values)
+		{
+			// Write key
+			encoder.write_string(unit.name);
+
+			// Write value based on type
+			write_value_to_encoder(encoder, unit);
+		}
+
+		return encoder.finish();
+	}
+} // anonymous namespace
+
 kcenon::common::Result<std::vector<uint8_t>>
 msgpack_serializer::serialize(const value_container& container) const noexcept
 {
 	try
 	{
-		// Delegate to the container's existing serialize implementation
-		auto result = container.serialize(
-			value_container::serialization_format::msgpack);
-		return result;
+		auto data = serialize_container_to_msgpack(container);
+		return kcenon::common::ok(std::move(data));
+	}
+	catch (const std::bad_alloc&)
+	{
+		return kcenon::common::Result<std::vector<uint8_t>>(
+			kcenon::common::error_info{
+				-2,
+				"Memory allocation failed during MessagePack serialization",
+				"msgpack_serializer"});
 	}
 	catch (const std::exception& e)
 	{

--- a/core/serializers/xml_serializer.cpp
+++ b/core/serializers/xml_serializer.cpp
@@ -32,6 +32,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "xml_serializer.h"
 #include "container/core/container.h"
+#include "container/core/container/variant_helpers.h"
+#include "utilities/core/formatter.h"
 
 namespace container_module
 {
@@ -42,17 +44,16 @@ xml_serializer::serialize(const value_container& container) const noexcept
 {
 	try
 	{
-		// Delegate to the container's existing serialize_string implementation
-		auto str_result = container.serialize_string(
-			value_container::serialization_format::xml);
-		if (!str_result.is_ok())
-		{
-			return kcenon::common::Result<std::vector<uint8_t>>(str_result.error());
-		}
-
-		const auto& str = str_result.value();
-		std::vector<uint8_t> result(str.begin(), str.end());
-		return kcenon::common::ok(std::move(result));
+		auto str = serialize_to_string(container);
+		return kcenon::common::ok(std::vector<uint8_t>(str.begin(), str.end()));
+	}
+	catch (const std::bad_alloc&)
+	{
+		return kcenon::common::Result<std::vector<uint8_t>>(
+			kcenon::common::error_info{
+				-2,
+				"Memory allocation failed during XML serialization",
+				"xml_serializer"});
 	}
 	catch (const std::exception& e)
 	{
@@ -62,6 +63,60 @@ xml_serializer::serialize(const value_container& container) const noexcept
 				std::string("XML serialization failed: ") + e.what(),
 				"xml_serializer"});
 	}
+}
+
+std::string xml_serializer::serialize_to_string(const value_container& container) const
+{
+	// Get container data through public accessors
+	auto message_type = container.message_type();
+	auto target_id = container.target_id();
+	auto target_sub_id = container.target_sub_id();
+	auto source_id = container.source_id();
+	auto source_sub_id = container.source_sub_id();
+	auto version = container.version();
+	auto values = container.get_variant_values();
+
+	std::string result;
+	utility_module::formatter::format_to(std::back_inserter(result), "<container>");
+
+	// Header section
+	utility_module::formatter::format_to(std::back_inserter(result), "<header>");
+	if (message_type != "data_container")
+	{
+		utility_module::formatter::format_to(std::back_inserter(result),
+							 "<target_id>{}</target_id>",
+							 variant_helpers::xml_encode(target_id));
+		utility_module::formatter::format_to(std::back_inserter(result),
+							 "<target_sub_id>{}</target_sub_id>",
+							 variant_helpers::xml_encode(target_sub_id));
+		utility_module::formatter::format_to(std::back_inserter(result),
+							 "<source_id>{}</source_id>",
+							 variant_helpers::xml_encode(source_id));
+		utility_module::formatter::format_to(std::back_inserter(result),
+							 "<source_sub_id>{}</source_sub_id>",
+							 variant_helpers::xml_encode(source_sub_id));
+	}
+	utility_module::formatter::format_to(std::back_inserter(result),
+						 "<message_type>{}</message_type>",
+						 variant_helpers::xml_encode(message_type));
+	utility_module::formatter::format_to(std::back_inserter(result),
+						 "<version>{}</version>",
+						 variant_helpers::xml_encode(version));
+	utility_module::formatter::format_to(std::back_inserter(result), "</header>");
+
+	// Values section
+	utility_module::formatter::format_to(std::back_inserter(result), "<values>");
+	for (const auto& u : values)
+	{
+		std::string value_str = variant_helpers::to_string(u.data, u.type);
+		utility_module::formatter::format_to(std::back_inserter(result), "<{}>{}</{}>",
+							 u.name, variant_helpers::xml_encode(value_str),
+							 u.name);
+	}
+	utility_module::formatter::format_to(std::back_inserter(result), "</values>");
+	utility_module::formatter::format_to(std::back_inserter(result), "</container>");
+
+	return result;
 }
 #endif
 

--- a/core/serializers/xml_serializer.h
+++ b/core/serializers/xml_serializer.h
@@ -67,6 +67,15 @@ namespace container_module
 		 */
 		[[nodiscard]] kcenon::common::Result<std::vector<uint8_t>>
 			serialize(const value_container& container) const noexcept override;
+
+		/**
+		 * @brief Serialize a value_container to XML string format
+		 *
+		 * @param container The container to serialize
+		 * @return Serialized XML string
+		 * @throws std::bad_alloc on memory allocation failure
+		 */
+		[[nodiscard]] std::string serialize_to_string(const value_container& container) const;
 #endif
 
 		/**


### PR DESCRIPTION
Closes #315

## Summary
- Integrate serializer strategies into serialize()/serialize_string() unified API
- Move serialization logic from container class to individual serializer strategy classes
- Remove internal *_impl() methods from container, eliminating circular dependencies
- Add version() accessor and serialize_to_string() methods for strategy classes

## Changes
### Serializer Strategy Integration
- binary_serializer: Implements binary format with header serialization
- json_serializer: Implements JSON format with proper RFC 8259 escaping
- xml_serializer: Implements XML format with proper encoding
- msgpack_serializer: Implements MessagePack binary format with nested container support

### Container Class Cleanup
- Removed serialize_impl(), to_json_impl(), to_xml_impl(), to_msgpack_impl()
- Kept from_msgpack_impl() for deserialization (to be addressed in future issue)
- Updated copy constructor, copy(), and operator<< to use binary_serializer
- Added version() accessor for serializer access

### API Improvements
- serialize() now uses serializer_factory to create appropriate serializer
- serialize_string() directly instantiates format-specific serializers
- Metrics recording added to both serialize() and serialize_string()

## Test Plan
- [x] All unit tests pass (131 tests)
- [x] All integration tests pass (21 tests total)
- [x] Binary, JSON, XML, MessagePack serialization verified
- [x] Metrics recording verified for serialize operations

## Migration Notes
This is an internal refactoring. The public API (serialize/serialize_string) remains unchanged.