### PR TITLE
refactor(core): deprecate optimized_container and rename typed_container to simd_batch

### DIFF
--- a/core/concepts.h
+++ b/core/concepts.h
@@ -95,7 +95,7 @@ concept UnsignedIntegral = std::unsigned_integral<T>;
  * Example usage:
  * @code
  * template<TriviallyCopyable T>
- * class typed_container { ... };
+ * class simd_batch { ... };  // Renamed from typed_container (Issue #328)
  * @endcode
  */
 template<typename T>

--- a/core/container.h
+++ b/core/container.h
@@ -58,7 +58,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "container/core/container/msgpack.h"
 
 #include "container/core/value_types.h"
-#include "container/core/typed_container.h"
+#include "container/core/simd_batch.h"  // Renamed from typed_container.h (Issue #328)
 #include "container/internal/value.h"
 #include "container/internal/value_view.h"
 

--- a/core/optimized_container.h
+++ b/core/optimized_container.h
@@ -17,6 +17,24 @@ namespace container_module {
  * @class optimized_container
  * @brief Performance-optimized value_container with zero-copy operations
  *
+ * @deprecated Use `basic_value_container<indexed_storage_policy>` (alias: `fast_policy_container`)
+ *             from `policy_container.h` instead. This class will be removed in the next major version.
+ *
+ * Migration example:
+ * @code
+ * // Old code:
+ * optimized_container oc;
+ * oc.get_value_fast("key");
+ *
+ * // New code:
+ * #include "core/policy_container.h"
+ * fast_policy_container fc;  // or: basic_value_container<indexed_storage_policy>
+ * fc.get("key");
+ * @endcode
+ *
+ * @see basic_value_container<indexed_storage_policy> for the replacement
+ * @see Issue #320, #328 for migration details
+ *
  * Improvements over value_container:
  * - std::string_view for accessors (zero-copy)
  * - Move semantics for all modifiers
@@ -44,6 +62,7 @@ namespace container_module {
  * auto value = container.get_value_fast("key");  // O(1) instead of O(n)
  * @endcode
  */
+[[deprecated("Use fast_policy_container (basic_value_container<indexed_storage_policy>) from policy_container.h instead. See Issue #328 for migration guide.")]]
 class optimized_container : public value_container {
 public:
     using value_container::value_container;

--- a/core/simd_batch.h
+++ b/core/simd_batch.h
@@ -1,0 +1,76 @@
+// BSD 3-Clause License
+//
+// High-level SIMD-friendly batch container for trivially copyable types.
+// Renamed from typed_container.h for clarity (Issue #328).
+
+#pragma once
+
+#include "container/core/concepts.h"
+#include <type_traits>
+#include <vector>
+#include <cstddef>
+#include <utility>
+#include <concepts>
+
+namespace container_module::core {
+
+/**
+ * @brief Lightweight container enforcing trivially copyable payloads.
+ *
+ * Designed for SIMD optimized serialization paths where deterministic layout is required.
+ * This class was renamed from `typed_container` for clarity - the name `simd_batch`
+ * better reflects its purpose as a batch container for SIMD operations.
+ *
+ * @tparam TValue Type that must satisfy the TriviallyCopyable concept
+ *
+ * @code
+ * simd_batch<float> batch;
+ * batch.push(1.0f);
+ * batch.push(2.0f);
+ * // Use batch.values() for SIMD processing
+ * @endcode
+ *
+ * @see Issue #320, #328 for the rename rationale
+ */
+template<container_module::concepts::TriviallyCopyable TValue>
+class simd_batch {
+
+public:
+    using value_type = TValue;
+
+    explicit simd_batch(std::size_t reserve = 0) {
+        values_.reserve(reserve);
+    }
+
+    void push(const TValue& value) {
+        values_.push_back(value);
+    }
+
+    void push(TValue&& value) {
+        values_.push_back(std::move(value));
+    }
+
+    [[nodiscard]] const std::vector<TValue>& values() const noexcept {
+        return values_;
+    }
+
+    [[nodiscard]] std::size_t size() const noexcept {
+        return values_.size();
+    }
+
+    void clear() {
+        values_.clear();
+    }
+
+private:
+    std::vector<TValue> values_;
+};
+
+/**
+ * @brief Deprecated alias for simd_batch
+ * @deprecated Use simd_batch instead. This alias will be removed in the next major version.
+ */
+template<container_module::concepts::TriviallyCopyable TValue>
+using typed_container [[deprecated("Use simd_batch instead. See Issue #328.")]] = simd_batch<TValue>;
+
+} // namespace container_module::core

--- a/core/typed_container.h
+++ b/core/typed_container.h
@@ -1,55 +1,19 @@
 // BSD 3-Clause License
 //
-// High-level typed container helper for SIMD-friendly batches.
+// DEPRECATED: This header is deprecated. Use simd_batch.h instead.
+// This file now redirects to simd_batch.h for backward compatibility.
+// See Issue #328 for migration details.
 
 #pragma once
 
-#include "container/core/concepts.h"
-#include <type_traits>
-#include <vector>
-#include <cstddef>
-#include <utility>
-#include <concepts>
+#if defined(__GNUC__) || defined(__clang__)
+    #pragma message("Warning: typed_container.h is deprecated. Use simd_batch.h instead. See Issue #328.")
+#elif defined(_MSC_VER)
+    #pragma message("Warning: typed_container.h is deprecated. Use simd_batch.h instead. See Issue #328.")
+#endif
 
-namespace container_module::core {
+// Include the new header which provides the deprecated alias
+#include "container/core/simd_batch.h"
 
-/**
- * @brief Lightweight container enforcing trivially copyable payloads.
- *
- * Designed for SIMD optimized serialization paths where deterministic layout is required.
- *
- * @tparam TValue Type that must satisfy the TriviallyCopyable concept
- */
-template<container_module::concepts::TriviallyCopyable TValue>
-class typed_container {
-
-public:
-    explicit typed_container(std::size_t reserve = 0) {
-        values_.reserve(reserve);
-    }
-
-    void push(const TValue& value) {
-        values_.push_back(value);
-    }
-
-    void push(TValue&& value) {
-        values_.push_back(std::move(value));
-    }
-
-    [[nodiscard]] const std::vector<TValue>& values() const noexcept {
-        return values_;
-    }
-
-    [[nodiscard]] std::size_t size() const noexcept {
-        return values_.size();
-    }
-
-    void clear() {
-        values_.clear();
-    }
-
-private:
-    std::vector<TValue> values_;
-};
-
-} // namespace container_module::core
+// Note: typed_container is now a deprecated alias for simd_batch
+// defined in simd_batch.h

--- a/docs/API_REFERENCE.kr.md
+++ b/docs/API_REFERENCE.kr.md
@@ -84,18 +84,18 @@ concept TriviallyCopyable = std::is_trivially_copyable_v<T>;
 #include <container/core/concepts.h>
 using namespace container_module::concepts;
 
-// SIMD 친화적 배치를 위한 typed_container에서 사용
+// SIMD 친화적 배치를 위한 simd_batch에서 사용 (Issue #328에서 typed_container에서 이름 변경)
 template<TriviallyCopyable TValue>
-class typed_container {
+class simd_batch {
     std::vector<TValue> values_;
 public:
     void push(const TValue& value) { values_.push_back(value); }
 };
 
 // 사용법
-typed_container<int> int_container;       // OK: int는 trivially copyable
-typed_container<double> double_container; // OK: double은 trivially copyable
-// typed_container<std::string> str_container; // 오류: std::string은 trivially copyable이 아님
+simd_batch<int> int_container;       // OK: int는 trivially copyable
+simd_batch<double> double_container; // OK: double은 trivially copyable
+// simd_batch<std::string> str_container; // 오류: std::string은 trivially copyable이 아님
 ```
 
 ### 값 타입 Concepts
@@ -146,7 +146,7 @@ container.for_each([](const std::string& key, const value& val) {
 | `Arithmetic` | 정수 또는 부동소수점 타입 | 숫자 값 생성을 위한 템플릿 제약 |
 | `IntegralType` | 정수 타입 | 메시징 통합에서 타입 검사 |
 | `FloatingPointType` | 부동소수점 타입 | 메시징 통합에서 타입 검사 |
-| `TriviallyCopyable` | memcpy/SIMD 안전 타입 | `typed_container` 템플릿 제약 |
+| `TriviallyCopyable` | memcpy/SIMD 안전 타입 | `simd_batch` 템플릿 제약 |
 | `ValueVariantType` | `ValueVariant`에 유효한 타입 | 타입 안전 값 연산 |
 | `StringLike` | 문자열 변환 가능 타입 | 문자열 값 처리 |
 | `KeyValueCallback` | const 반복 콜백 | `for_each()` 함수 |

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -120,18 +120,18 @@ concept TriviallyCopyable = std::is_trivially_copyable_v<T>;
 #include <container/core/concepts.h>
 using namespace container_module::concepts;
 
-// Used in typed_container for SIMD-friendly batches
+// Used in simd_batch for SIMD-friendly batches (renamed from typed_container in Issue #328)
 template<TriviallyCopyable TValue>
-class typed_container {
+class simd_batch {
     std::vector<TValue> values_;
 public:
     void push(const TValue& value) { values_.push_back(value); }
 };
 
 // Usage
-typed_container<int> int_container;       // OK: int is trivially copyable
-typed_container<double> double_container; // OK: double is trivially copyable
-// typed_container<std::string> str_container; // Error: std::string is not trivially copyable
+simd_batch<int> int_container;       // OK: int is trivially copyable
+simd_batch<double> double_container; // OK: double is trivially copyable
+// simd_batch<std::string> str_container; // Error: std::string is not trivially copyable
 ```
 
 ### Value Type Concepts
@@ -346,7 +346,7 @@ concept ContainerValue =
 | `FloatingPointType` | Floating-point types | Type checking in messaging integration |
 | `SignedIntegral` | Signed integral types | Numeric validation |
 | `UnsignedIntegral` | Unsigned integral types | Numeric validation |
-| `TriviallyCopyable` | Types safe for memcpy/SIMD | `typed_container` template constraint |
+| `TriviallyCopyable` | Types safe for memcpy/SIMD | `simd_batch` template constraint |
 | `ValueVariantType` | Types valid for `ValueVariant` | Type-safe value operations |
 | `NumericValueType` | Numeric types excluding bool | Value factory operations |
 | `StringLike` | String-convertible types | String value handling |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -192,7 +192,7 @@ value make_numeric_value(std::string_view name, T value);
 
 // TriviallyCopyable - SIMD-friendly types
 template<TriviallyCopyable T>
-class typed_container { /* ... */ };
+class simd_batch { /* ... */ };  // Renamed from typed_container (Issue #328)
 
 // KeyValueCallback - Iteration function signatures
 template<KeyValueCallback Func>

--- a/docs/PROJECT_STRUCTURE.kr.md
+++ b/docs/PROJECT_STRUCTURE.kr.md
@@ -16,7 +16,8 @@ container_system/
 │   ├── concepts.h                  # 타입 검증을 위한 C++20 concepts (신규)
 │   ├── container.h                 # 메인 컨테이너 클래스
 │   ├── container.cpp               # 컨테이너 구현
-│   ├── typed_container.h           # SIMD 친화적 타입 컨테이너 (TriviallyCopyable concept 사용)
+│   ├── simd_batch.h                # SIMD 친화적 배치 컨테이너 (typed_container에서 이름 변경, TriviallyCopyable concept 사용)
+│   ├── typed_container.h           # Deprecated: simd_batch.h로 리다이렉트
 │   ├── value_types.h               # Value 타입 열거형
 │   ├── value_types.cpp             # Value 타입 구현
 │   ├── value_store.h               # Value 저장소 추상화
@@ -203,7 +204,7 @@ using namespace container_module::concepts;
 
 // SIMD 친화적 컨테이너를 위한 TriviallyCopyable 사용
 template<TriviallyCopyable TValue>
-class typed_container { /* ... */ };
+class simd_batch { /* ... */ };  // typed_container에서 이름 변경 (Issue #328)
 
 // 반복을 위한 KeyValueCallback 사용
 template<KeyValueCallback Func>
@@ -211,7 +212,7 @@ void for_each(Func&& func) const;
 ```
 
 **통합 지점**:
-- `typed_container.h` - `TriviallyCopyable` concept 사용
+- `simd_batch.h` - `TriviallyCopyable` concept 사용
 - `thread_safe_container.h` - `KeyValueCallback`, `MutableKeyValueCallback`, `ValueMapCallback`, `ConstValueMapCallback` 사용
 - `value.h` - `ValueVariantType`, `ValueVisitor` 사용
 - `variant_value_factory.h` - `Arithmetic` 사용

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -14,7 +14,8 @@ container_system/
 │   ├── concepts.h                  # C++20 concepts for type validation (NEW)
 │   ├── container.h                 # Main container class
 │   ├── container.cpp               # Container implementation
-│   ├── typed_container.h           # SIMD-friendly typed container (uses TriviallyCopyable concept)
+│   ├── simd_batch.h                # SIMD-friendly batch container (renamed from typed_container, uses TriviallyCopyable concept)
+│   ├── typed_container.h           # Deprecated: redirects to simd_batch.h
 │   ├── value_types.h               # Value type enumerations
 │   ├── value_types.cpp             # Value type implementation
 │   ├── value_store.h               # Value storage abstraction
@@ -201,7 +202,7 @@ using namespace container_module::concepts;
 
 // Using TriviallyCopyable for SIMD-friendly containers
 template<TriviallyCopyable TValue>
-class typed_container { /* ... */ };
+class simd_batch { /* ... */ };  // Renamed from typed_container (Issue #328)
 
 // Using KeyValueCallback for iteration
 template<KeyValueCallback Func>
@@ -209,7 +210,7 @@ void for_each(Func&& func) const;
 ```
 
 **Integration Points**:
-- `typed_container.h` - Uses `TriviallyCopyable` concept
+- `simd_batch.h` - Uses `TriviallyCopyable` concept
 - `thread_safe_container.h` - Uses `KeyValueCallback`, `MutableKeyValueCallback`, `ValueMapCallback`, `ConstValueMapCallback`
 - `value.h` - Uses `ValueVariantType`, `ValueVisitor`
 - `variant_value_factory.h` - Uses `Arithmetic`


### PR DESCRIPTION
Closes #328

## Summary

- Mark `optimized_container` as deprecated with `[[deprecated]]` attribute and clear migration path to `fast_policy_container`
- Rename `core::typed_container` to `core::simd_batch` for better clarity about its purpose
- Update all documentation to reflect the name changes
- Maintain backward compatibility through deprecated aliases

## Changes

### Code Changes
- `core/optimized_container.h`: Added `[[deprecated]]` attribute with migration guide in docstring
- `core/simd_batch.h`: New file with renamed class and `value_type` typedef
- `core/typed_container.h`: Now redirects to `simd_batch.h` with compiler warning
- `core/container.h`: Updated include from `typed_container.h` to `simd_batch.h`
- `core/concepts.h`: Updated example in TriviallyCopyable concept documentation

### Documentation Updates
- `docs/API_REFERENCE.md` & `docs/API_REFERENCE.kr.md`: Updated examples and tables
- `docs/PROJECT_STRUCTURE.md` & `docs/PROJECT_STRUCTURE.kr.md`: Updated directory tree and usage examples
- `docs/FEATURES.md`: Updated concept usage example

## Test Plan

- [x] Build passes with all changes
- [x] 130/131 unit tests pass (LargeDataHandling failure is pre-existing)
- [x] Deprecated warnings appear when using old class names
- [x] Backward compatibility: existing code using `typed_container` still compiles

## Migration Path

```cpp
// Old code:
optimized_container oc;
oc.get_value_fast("key");

// New code:
#include "core/policy_container.h"
fast_policy_container fc;
fc.get("key");
```

```cpp
// Old code:
#include "core/typed_container.h"
core::typed_container<float> batch;

// New code:
#include "core/simd_batch.h"
core::simd_batch<float> batch;
```

Part of #320