### PR TITLE
refactor(core): deprecate value_container_ptr for message_buffer migration

### DIFF
--- a/core/container/fwd.h
+++ b/core/container/fwd.h
@@ -64,7 +64,9 @@ namespace container_module
 	struct pool_stats;
 
 	// Type alias for container shared pointer
-	using value_container_ptr = std::shared_ptr<value_container>;
+	// Note: Prefer message_buffer_ptr for new code (see Issue #321)
+	using value_container_ptr [[deprecated("Use message_buffer_ptr instead (Issue #321)")]]
+		= std::shared_ptr<value_container>;
 
 	// Forward declaration of value_variant (full definition in types.h)
 	// Note: std::variant cannot be forward declared, so we provide a comment

--- a/docs/guides/MIGRATION.md
+++ b/docs/guides/MIGRATION.md
@@ -308,6 +308,72 @@ make
 
 ---
 
+## value_container → message_buffer Migration (v2.0+)
+
+Starting from v2.0.0, we recommend using `message_buffer` instead of `value_container`.
+The `message_buffer` name better describes the class's purpose: a serializable message
+buffer for network transmission, avoiding confusion with STL containers.
+
+### Why the Name Change?
+
+| Issue | Old Name | Problem |
+|-------|----------|---------|
+| Naming conflict | `container` | Confuses with `std::vector`, `std::map` |
+| Purpose unclear | `value_container` | Doesn't reveal serialization purpose |
+| Redundant namespace | `container_module::container` | `container::container` is redundant |
+
+### Quick Migration
+
+**Before**:
+```cpp
+#include <container/container.h>
+
+container_module::value_container msg;
+container_module::value_container_ptr ptr = std::make_shared<container_module::value_container>();
+```
+
+**After**:
+```cpp
+#include <container/container.h>
+
+container_module::message_buffer msg;
+container_module::message_buffer_ptr ptr = std::make_shared<container_module::message_buffer>();
+```
+
+### Migration Steps
+
+1. **Replace type names**:
+   - `value_container` → `message_buffer`
+   - `value_container_ptr` → `message_buffer_ptr`
+
+2. **Namespace remains the same**: `container_module` (for now)
+
+3. **API is unchanged**: All methods work identically
+
+### Deprecation Timeline
+
+| Version | Status |
+|---------|--------|
+| v2.0.0 | `message_buffer` alias introduced |
+| v2.1.0 | `value_container_ptr` deprecated warning |
+| v3.0.0 | `value_container` name removed (planned) |
+
+### Compatibility
+
+Both names can be used interchangeably during the migration period:
+
+```cpp
+// These are equivalent
+container_module::value_container c1;
+container_module::message_buffer c2;
+
+// Type alias - both refer to the same class
+static_assert(std::is_same_v<container_module::value_container,
+                             container_module::message_buffer>);
+```
+
+---
+
 ## Support
 
 Need help with migration?
@@ -318,5 +384,5 @@ Need help with migration?
 
 ---
 
-**Last Updated**: 2025-10-22
-**Migration Script Version**: 1.0.0
+**Last Updated**: 2026-01-22
+**Migration Script Version**: 1.1.0


### PR DESCRIPTION
## Summary
- Add `[[deprecated]]` attribute to `value_container_ptr` typedef to guide users toward `message_buffer_ptr`
- Add comprehensive migration guide section in docs/guides/MIGRATION.md
- Document deprecation timeline: v2.0 alias → v2.1 warning → v3.0 removal

## Related Issue
Closes #321 (Phase 1 - backward compatibility preparation)

## Changes Made
| File | Change |
|------|--------|
| `core/container/fwd.h` | Add `[[deprecated]]` to `value_container_ptr` |
| `docs/guides/MIGRATION.md` | Add `value_container → message_buffer` migration section |

## Test Plan
- [x] Build passes (verified deprecation warning appears for `value_container_ptr` usage)
- [x] Existing test failures are pre-existing (same failures on main branch)
- [x] No new test failures introduced

## Notes
This PR implements Phase 1 of Issue #321:
- `message_buffer` alias was already added in PR #333
- This PR adds deprecation warning and migration documentation
- Full rename to `message_buffer` with namespace change to `messaging` is planned for future major version