### PR TITLE
refactor(simd): add compile-time SIMD policy infrastructure

### DIFF
--- a/internal/simd_policies.h
+++ b/internal/simd_policies.h
@@ -1,0 +1,715 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file simd_policies.h
+ * @brief Compile-time SIMD policy selection for vectorized operations.
+ *
+ * This header provides policy classes for SIMD operations that are selected
+ * at compile time based on the target platform. This eliminates runtime
+ * branching overhead and enables full compiler optimization.
+ *
+ * Usage:
+ * @code
+ * // Default usage - automatically uses best policy for platform
+ * simd_ops<> ops;
+ * float result = ops.sum_floats(data, count);
+ *
+ * // Explicit policy (for testing or special cases)
+ * simd_ops<scalar_simd_policy> scalar_ops;
+ * @endcode
+ *
+ * @see Issue #338 for design rationale
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <numeric>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <concepts>
+
+// Platform-specific SIMD headers
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+    #define CONTAINER_HAS_X86_SIMD 1
+    #if defined(__AVX512F__) || defined(HAS_AVX512)
+        #ifndef CONTAINER_HAS_AVX512
+            #define CONTAINER_HAS_AVX512 1
+        #endif
+        #ifndef CONTAINER_HAS_AVX2
+            #define CONTAINER_HAS_AVX2 1
+        #endif
+        #include <immintrin.h>
+    #elif defined(__AVX2__) || defined(HAS_AVX2)
+        #ifndef CONTAINER_HAS_AVX2
+            #define CONTAINER_HAS_AVX2 1
+        #endif
+        #include <immintrin.h>
+    #elif defined(__SSE4_2__) || defined(HAS_SSE42)
+        #ifndef CONTAINER_HAS_SSE42
+            #define CONTAINER_HAS_SSE42 1
+        #endif
+        #include <nmmintrin.h>
+        #include <smmintrin.h>
+        #include <tmmintrin.h>
+    #elif defined(__SSE2__)
+        #ifndef CONTAINER_HAS_SSE2
+            #define CONTAINER_HAS_SSE2 1
+        #endif
+        #include <emmintrin.h>
+    #endif
+    #if defined(CONTAINER_HAS_SSE42) || defined(CONTAINER_HAS_SSE2)
+        #include <xmmintrin.h>
+        #include <emmintrin.h>
+        #include <pmmintrin.h>
+    #endif
+#elif defined(__ARM_NEON) || defined(__aarch64__)
+    #define CONTAINER_HAS_ARM_NEON 1
+    #include <arm_neon.h>
+#endif
+
+namespace container_module::simd {
+
+/**
+ * @brief Concept for SIMD policy classes.
+ *
+ * A valid SIMD policy must provide:
+ * - name() -> string_view: Returns the policy name
+ * - simd_width -> size_t: SIMD register width in floats
+ * - sum_floats(data, count) -> float: Sum float array
+ * - min_float(data, count) -> float: Find minimum
+ * - max_float(data, count) -> float: Find maximum
+ */
+template<typename T>
+concept SimdPolicy = requires(const T& policy, const float* data, size_t count) {
+    { T::name() } -> std::convertible_to<std::string_view>;
+    { T::simd_width } -> std::convertible_to<size_t>;
+    { policy.sum_floats(data, count) } -> std::same_as<float>;
+    { policy.min_float(data, count) } -> std::same_as<float>;
+    { policy.max_float(data, count) } -> std::same_as<float>;
+};
+
+// ============================================================================
+// Scalar Policy (Fallback)
+// ============================================================================
+
+/**
+ * @brief Scalar (non-SIMD) implementation of operations.
+ *
+ * Used as fallback when no SIMD instructions are available,
+ * or for testing/comparison purposes.
+ */
+struct scalar_simd_policy {
+    static constexpr std::string_view name() noexcept { return "scalar"; }
+    static constexpr size_t simd_width = 1;
+
+    [[nodiscard]] float sum_floats(const float* data, size_t count) const noexcept {
+        float sum = 0.0f;
+        for (size_t i = 0; i < count; ++i) {
+            sum += data[i];
+        }
+        return sum;
+    }
+
+    [[nodiscard]] float min_float(const float* data, size_t count) const noexcept {
+        if (count == 0) return std::numeric_limits<float>::max();
+        float min_val = data[0];
+        for (size_t i = 1; i < count; ++i) {
+            if (data[i] < min_val) {
+                min_val = data[i];
+            }
+        }
+        return min_val;
+    }
+
+    [[nodiscard]] float max_float(const float* data, size_t count) const noexcept {
+        if (count == 0) return std::numeric_limits<float>::lowest();
+        float max_val = data[0];
+        for (size_t i = 1; i < count; ++i) {
+            if (data[i] > max_val) {
+                max_val = data[i];
+            }
+        }
+        return max_val;
+    }
+
+    [[nodiscard]] double sum_doubles(const double* data, size_t count) const noexcept {
+        double sum = 0.0;
+        for (size_t i = 0; i < count; ++i) {
+            sum += data[i];
+        }
+        return sum;
+    }
+};
+
+// ============================================================================
+// SSE Policy (x86)
+// ============================================================================
+
+#if defined(CONTAINER_HAS_SSE42) || defined(CONTAINER_HAS_SSE2)
+/**
+ * @brief SSE implementation of SIMD operations (128-bit).
+ */
+struct sse_simd_policy {
+    static constexpr std::string_view name() noexcept { return "sse"; }
+    static constexpr size_t simd_width = 4;
+
+    [[nodiscard]]
+#if defined(__GNUC__) || defined(__clang__)
+    __attribute__((target("sse3")))
+#endif
+    float sum_floats(const float* data, size_t count) const noexcept {
+        __m128 sum_vec = _mm_setzero_ps();
+        size_t simd_end = count - (count % 4);
+
+        for (size_t i = 0; i < simd_end; i += 4) {
+            __m128 vec = _mm_loadu_ps(&data[i]);
+            sum_vec = _mm_add_ps(sum_vec, vec);
+        }
+
+        // Horizontal sum using hadd
+        sum_vec = _mm_hadd_ps(sum_vec, sum_vec);
+        sum_vec = _mm_hadd_ps(sum_vec, sum_vec);
+
+        float sum = _mm_cvtss_f32(sum_vec);
+
+        // Handle remaining elements
+        for (size_t i = simd_end; i < count; ++i) {
+            sum += data[i];
+        }
+
+        return sum;
+    }
+
+    [[nodiscard]]
+#if defined(__GNUC__) || defined(__clang__)
+    __attribute__((target("sse2")))
+#endif
+    float min_float(const float* data, size_t count) const noexcept {
+        if (count == 0) return std::numeric_limits<float>::max();
+
+        __m128 min_vec = _mm_set1_ps(std::numeric_limits<float>::max());
+        size_t simd_end = count - (count % 4);
+
+        for (size_t i = 0; i < simd_end; i += 4) {
+            __m128 vec = _mm_loadu_ps(&data[i]);
+            min_vec = _mm_min_ps(min_vec, vec);
+        }
+
+        // Extract minimum from vector
+        alignas(16) float result[4];
+        _mm_store_ps(result, min_vec);
+        float min_val = result[0];
+        for (int i = 1; i < 4; ++i) {
+            if (result[i] < min_val) min_val = result[i];
+        }
+
+        // Handle remaining elements
+        for (size_t i = simd_end; i < count; ++i) {
+            if (data[i] < min_val) min_val = data[i];
+        }
+
+        return min_val;
+    }
+
+    [[nodiscard]]
+#if defined(__GNUC__) || defined(__clang__)
+    __attribute__((target("sse2")))
+#endif
+    float max_float(const float* data, size_t count) const noexcept {
+        if (count == 0) return std::numeric_limits<float>::lowest();
+
+        __m128 max_vec = _mm_set1_ps(std::numeric_limits<float>::lowest());
+        size_t simd_end = count - (count % 4);
+
+        for (size_t i = 0; i < simd_end; i += 4) {
+            __m128 vec = _mm_loadu_ps(&data[i]);
+            max_vec = _mm_max_ps(max_vec, vec);
+        }
+
+        // Extract maximum from vector
+        alignas(16) float result[4];
+        _mm_store_ps(result, max_vec);
+        float max_val = result[0];
+        for (int i = 1; i < 4; ++i) {
+            if (result[i] > max_val) max_val = result[i];
+        }
+
+        // Handle remaining elements
+        for (size_t i = simd_end; i < count; ++i) {
+            if (data[i] > max_val) max_val = data[i];
+        }
+
+        return max_val;
+    }
+
+    [[nodiscard]] double sum_doubles(const double* data, size_t count) const noexcept {
+        // Use scalar for doubles in SSE (simpler)
+        double sum = 0.0;
+        for (size_t i = 0; i < count; ++i) {
+            sum += data[i];
+        }
+        return sum;
+    }
+};
+#endif
+
+// ============================================================================
+// AVX2 Policy (x86)
+// ============================================================================
+
+#if defined(CONTAINER_HAS_AVX2)
+/**
+ * @brief AVX2 implementation of SIMD operations (256-bit).
+ */
+struct avx2_simd_policy {
+    static constexpr std::string_view name() noexcept { return "avx2"; }
+    static constexpr size_t simd_width = 8;
+
+    [[nodiscard]]
+#if defined(__GNUC__) || defined(__clang__)
+    __attribute__((target("avx2")))
+#endif
+    float sum_floats(const float* data, size_t count) const noexcept {
+        __m256 sum_vec = _mm256_setzero_ps();
+        size_t simd_end = count - (count % 8);
+
+        for (size_t i = 0; i < simd_end; i += 8) {
+            __m256 vec = _mm256_loadu_ps(&data[i]);
+            sum_vec = _mm256_add_ps(sum_vec, vec);
+        }
+
+        // Horizontal sum
+        __m128 low = _mm256_castps256_ps128(sum_vec);
+        __m128 high = _mm256_extractf128_ps(sum_vec, 1);
+        __m128 sum128 = _mm_add_ps(low, high);
+        sum128 = _mm_hadd_ps(sum128, sum128);
+        sum128 = _mm_hadd_ps(sum128, sum128);
+
+        float sum = _mm_cvtss_f32(sum128);
+
+        // Handle remaining elements
+        for (size_t i = simd_end; i < count; ++i) {
+            sum += data[i];
+        }
+
+        return sum;
+    }
+
+    [[nodiscard]]
+#if defined(__GNUC__) || defined(__clang__)
+    __attribute__((target("avx2")))
+#endif
+    float min_float(const float* data, size_t count) const noexcept {
+        if (count == 0) return std::numeric_limits<float>::max();
+
+        __m256 min_vec = _mm256_set1_ps(std::numeric_limits<float>::max());
+        size_t simd_end = count - (count % 8);
+
+        for (size_t i = 0; i < simd_end; i += 8) {
+            __m256 vec = _mm256_loadu_ps(&data[i]);
+            min_vec = _mm256_min_ps(min_vec, vec);
+        }
+
+        // Extract minimum from vector
+        alignas(32) float result[8];
+        _mm256_store_ps(result, min_vec);
+        float min_val = result[0];
+        for (int i = 1; i < 8; ++i) {
+            if (result[i] < min_val) min_val = result[i];
+        }
+
+        // Handle remaining elements
+        for (size_t i = simd_end; i < count; ++i) {
+            if (data[i] < min_val) min_val = data[i];
+        }
+
+        return min_val;
+    }
+
+    [[nodiscard]]
+#if defined(__GNUC__) || defined(__clang__)
+    __attribute__((target("avx2")))
+#endif
+    float max_float(const float* data, size_t count) const noexcept {
+        if (count == 0) return std::numeric_limits<float>::lowest();
+
+        __m256 max_vec = _mm256_set1_ps(std::numeric_limits<float>::lowest());
+        size_t simd_end = count - (count % 8);
+
+        for (size_t i = 0; i < simd_end; i += 8) {
+            __m256 vec = _mm256_loadu_ps(&data[i]);
+            max_vec = _mm256_max_ps(max_vec, vec);
+        }
+
+        // Extract maximum from vector
+        alignas(32) float result[8];
+        _mm256_store_ps(result, max_vec);
+        float max_val = result[0];
+        for (int i = 1; i < 8; ++i) {
+            if (result[i] > max_val) max_val = result[i];
+        }
+
+        // Handle remaining elements
+        for (size_t i = simd_end; i < count; ++i) {
+            if (data[i] > max_val) max_val = data[i];
+        }
+
+        return max_val;
+    }
+
+    [[nodiscard]] double sum_doubles(const double* data, size_t count) const noexcept {
+        double sum = 0.0;
+        for (size_t i = 0; i < count; ++i) {
+            sum += data[i];
+        }
+        return sum;
+    }
+};
+#endif
+
+// ============================================================================
+// AVX-512 Policy (x86)
+// ============================================================================
+
+#if defined(CONTAINER_HAS_AVX512)
+/**
+ * @brief AVX-512 implementation of SIMD operations (512-bit).
+ */
+struct avx512_simd_policy {
+    static constexpr std::string_view name() noexcept { return "avx512"; }
+    static constexpr size_t simd_width = 16;
+
+    [[nodiscard]]
+#if defined(__GNUC__) || defined(__clang__)
+    __attribute__((target("avx512f")))
+#endif
+    float sum_floats(const float* data, size_t count) const noexcept {
+        __m512 sum_vec = _mm512_setzero_ps();
+        size_t simd_end = count - (count % 16);
+
+        for (size_t i = 0; i < simd_end; i += 16) {
+            __m512 vec = _mm512_loadu_ps(&data[i]);
+            sum_vec = _mm512_add_ps(sum_vec, vec);
+        }
+
+        float sum = _mm512_reduce_add_ps(sum_vec);
+
+        for (size_t i = simd_end; i < count; ++i) {
+            sum += data[i];
+        }
+
+        return sum;
+    }
+
+    [[nodiscard]]
+#if defined(__GNUC__) || defined(__clang__)
+    __attribute__((target("avx512f")))
+#endif
+    float min_float(const float* data, size_t count) const noexcept {
+        if (count == 0) return std::numeric_limits<float>::max();
+
+        __m512 min_vec = _mm512_set1_ps(std::numeric_limits<float>::max());
+        size_t simd_end = count - (count % 16);
+
+        for (size_t i = 0; i < simd_end; i += 16) {
+            __m512 vec = _mm512_loadu_ps(&data[i]);
+            min_vec = _mm512_min_ps(min_vec, vec);
+        }
+
+        float min_val = _mm512_reduce_min_ps(min_vec);
+
+        for (size_t i = simd_end; i < count; ++i) {
+            if (data[i] < min_val) min_val = data[i];
+        }
+
+        return min_val;
+    }
+
+    [[nodiscard]]
+#if defined(__GNUC__) || defined(__clang__)
+    __attribute__((target("avx512f")))
+#endif
+    float max_float(const float* data, size_t count) const noexcept {
+        if (count == 0) return std::numeric_limits<float>::lowest();
+
+        __m512 max_vec = _mm512_set1_ps(std::numeric_limits<float>::lowest());
+        size_t simd_end = count - (count % 16);
+
+        for (size_t i = 0; i < simd_end; i += 16) {
+            __m512 vec = _mm512_loadu_ps(&data[i]);
+            max_vec = _mm512_max_ps(max_vec, vec);
+        }
+
+        float max_val = _mm512_reduce_max_ps(max_vec);
+
+        for (size_t i = simd_end; i < count; ++i) {
+            if (data[i] > max_val) max_val = data[i];
+        }
+
+        return max_val;
+    }
+
+    [[nodiscard]]
+#if defined(__GNUC__) || defined(__clang__)
+    __attribute__((target("avx512f")))
+#endif
+    double sum_doubles(const double* data, size_t count) const noexcept {
+        __m512d sum_vec = _mm512_setzero_pd();
+        size_t simd_end = count - (count % 8);
+
+        for (size_t i = 0; i < simd_end; i += 8) {
+            __m512d vec = _mm512_loadu_pd(&data[i]);
+            sum_vec = _mm512_add_pd(sum_vec, vec);
+        }
+
+        double sum = _mm512_reduce_add_pd(sum_vec);
+
+        for (size_t i = simd_end; i < count; ++i) {
+            sum += data[i];
+        }
+
+        return sum;
+    }
+};
+#endif
+
+// ============================================================================
+// NEON Policy (ARM)
+// ============================================================================
+
+#if defined(CONTAINER_HAS_ARM_NEON)
+/**
+ * @brief ARM NEON implementation of SIMD operations (128-bit).
+ */
+struct neon_simd_policy {
+    static constexpr std::string_view name() noexcept { return "neon"; }
+    static constexpr size_t simd_width = 4;
+
+    [[nodiscard]] float sum_floats(const float* data, size_t count) const noexcept {
+        float32x4_t sum_vec = vdupq_n_f32(0.0f);
+        size_t simd_end = count - (count % 4);
+
+        for (size_t i = 0; i < simd_end; i += 4) {
+            float32x4_t vec = vld1q_f32(&data[i]);
+            sum_vec = vaddq_f32(sum_vec, vec);
+        }
+
+        // Horizontal sum
+        float32x2_t sum_low = vget_low_f32(sum_vec);
+        float32x2_t sum_high = vget_high_f32(sum_vec);
+        float32x2_t sum_pair = vadd_f32(sum_low, sum_high);
+        float sum = vget_lane_f32(sum_pair, 0) + vget_lane_f32(sum_pair, 1);
+
+        for (size_t i = simd_end; i < count; ++i) {
+            sum += data[i];
+        }
+
+        return sum;
+    }
+
+    [[nodiscard]] float min_float(const float* data, size_t count) const noexcept {
+        if (count == 0) return std::numeric_limits<float>::max();
+
+        float32x4_t min_vec = vdupq_n_f32(std::numeric_limits<float>::max());
+        size_t simd_end = count - (count % 4);
+
+        for (size_t i = 0; i < simd_end; i += 4) {
+            float32x4_t vec = vld1q_f32(&data[i]);
+            min_vec = vminq_f32(min_vec, vec);
+        }
+
+        // Extract minimum from vector
+        float result[4];
+        vst1q_f32(result, min_vec);
+        float min_val = result[0];
+        for (int i = 1; i < 4; ++i) {
+            if (result[i] < min_val) min_val = result[i];
+        }
+
+        for (size_t i = simd_end; i < count; ++i) {
+            if (data[i] < min_val) min_val = data[i];
+        }
+
+        return min_val;
+    }
+
+    [[nodiscard]] float max_float(const float* data, size_t count) const noexcept {
+        if (count == 0) return std::numeric_limits<float>::lowest();
+
+        float32x4_t max_vec = vdupq_n_f32(std::numeric_limits<float>::lowest());
+        size_t simd_end = count - (count % 4);
+
+        for (size_t i = 0; i < simd_end; i += 4) {
+            float32x4_t vec = vld1q_f32(&data[i]);
+            max_vec = vmaxq_f32(max_vec, vec);
+        }
+
+        // Extract maximum from vector
+        float result[4];
+        vst1q_f32(result, max_vec);
+        float max_val = result[0];
+        for (int i = 1; i < 4; ++i) {
+            if (result[i] > max_val) max_val = result[i];
+        }
+
+        for (size_t i = simd_end; i < count; ++i) {
+            if (data[i] > max_val) max_val = data[i];
+        }
+
+        return max_val;
+    }
+
+    [[nodiscard]] double sum_doubles(const double* data, size_t count) const noexcept {
+        double sum = 0.0;
+        for (size_t i = 0; i < count; ++i) {
+            sum += data[i];
+        }
+        return sum;
+    }
+};
+#endif
+
+// ============================================================================
+// Compile-Time Policy Selection
+// ============================================================================
+
+/**
+ * @brief Default SIMD policy selected at compile time based on platform.
+ *
+ * Selection priority (highest to lowest):
+ * 1. AVX-512 (x86-64 with AVX-512F support)
+ * 2. AVX2 (x86-64 with AVX2 support)
+ * 3. SSE (x86 with SSE4.2/SSE2 support)
+ * 4. NEON (ARM with NEON support)
+ * 5. Scalar (fallback for all platforms)
+ */
+#if defined(CONTAINER_HAS_AVX512)
+    using default_simd_policy = avx512_simd_policy;
+#elif defined(CONTAINER_HAS_AVX2)
+    using default_simd_policy = avx2_simd_policy;
+#elif defined(CONTAINER_HAS_SSE42) || defined(CONTAINER_HAS_SSE2)
+    using default_simd_policy = sse_simd_policy;
+#elif defined(CONTAINER_HAS_ARM_NEON)
+    using default_simd_policy = neon_simd_policy;
+#else
+    using default_simd_policy = scalar_simd_policy;
+#endif
+
+/**
+ * @brief SIMD operations wrapper with compile-time policy selection.
+ *
+ * @tparam Policy SIMD policy class (must satisfy SimdPolicy concept)
+ *
+ * Usage:
+ * @code
+ * // Use default (best) policy for platform
+ * simd_ops<> ops;
+ *
+ * // Use explicit scalar policy for testing
+ * simd_ops<scalar_simd_policy> scalar_ops;
+ * @endcode
+ */
+template<SimdPolicy Policy = default_simd_policy>
+class simd_ops {
+public:
+    explicit simd_ops(Policy policy = Policy{}) noexcept
+        : policy_(std::move(policy)) {}
+
+    /**
+     * @brief Get the name of the active SIMD policy
+     */
+    static constexpr std::string_view policy_name() noexcept {
+        return Policy::name();
+    }
+
+    /**
+     * @brief Get the SIMD width (number of floats per operation)
+     */
+    static constexpr size_t simd_width() noexcept {
+        return Policy::simd_width;
+    }
+
+    /**
+     * @brief Sum all floats in an array
+     */
+    [[nodiscard]] float sum_floats(const float* data, size_t count) const noexcept {
+        return policy_.sum_floats(data, count);
+    }
+
+    /**
+     * @brief Find minimum float in an array
+     */
+    [[nodiscard]] float min_float(const float* data, size_t count) const noexcept {
+        return policy_.min_float(data, count);
+    }
+
+    /**
+     * @brief Find maximum float in an array
+     */
+    [[nodiscard]] float max_float(const float* data, size_t count) const noexcept {
+        return policy_.max_float(data, count);
+    }
+
+    /**
+     * @brief Sum all doubles in an array
+     */
+    [[nodiscard]] double sum_doubles(const double* data, size_t count) const noexcept {
+        return policy_.sum_doubles(data, count);
+    }
+
+private:
+    [[no_unique_address]] Policy policy_;
+};
+
+// Static assertions to verify policy compliance
+static_assert(SimdPolicy<scalar_simd_policy>, "scalar_simd_policy must satisfy SimdPolicy");
+#if defined(CONTAINER_HAS_SSE42) || defined(CONTAINER_HAS_SSE2)
+static_assert(SimdPolicy<sse_simd_policy>, "sse_simd_policy must satisfy SimdPolicy");
+#endif
+#if defined(CONTAINER_HAS_AVX2)
+static_assert(SimdPolicy<avx2_simd_policy>, "avx2_simd_policy must satisfy SimdPolicy");
+#endif
+#if defined(CONTAINER_HAS_AVX512)
+static_assert(SimdPolicy<avx512_simd_policy>, "avx512_simd_policy must satisfy SimdPolicy");
+#endif
+#if defined(CONTAINER_HAS_ARM_NEON)
+static_assert(SimdPolicy<neon_simd_policy>, "neon_simd_policy must satisfy SimdPolicy");
+#endif
+
+} // namespace container_module::simd

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ set(TEST_SOURCES
     variant_value_factory_tests.cpp
     memory_pool_tests.cpp
     simd_tests.cpp
+    simd_policies_tests.cpp
     schema_tests.cpp
     error_codes_tests.cpp
     result_api_tests.cpp

--- a/tests/simd_policies_tests.cpp
+++ b/tests/simd_policies_tests.cpp
@@ -1,0 +1,474 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2024, kcenon
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file simd_policies_tests.cpp
+ * @brief Unit tests for compile-time SIMD policy selection
+ *
+ * Tests verify:
+ * - Policy concept compliance
+ * - Scalar policy correctness (baseline)
+ * - Platform-specific policy correctness
+ * - Result consistency across policies
+ * - Edge cases (empty arrays, single element, non-aligned sizes)
+ *
+ * @see Issue #338 for design rationale
+ */
+
+#include <gtest/gtest.h>
+#include <container/internal/simd_policies.h>
+#include <vector>
+#include <random>
+#include <numeric>
+#include <cmath>
+#include <limits>
+
+using namespace container_module::simd;
+
+// ============================================================================
+// Scalar Policy Tests (Baseline)
+// ============================================================================
+
+class ScalarPolicyTest : public ::testing::Test {
+protected:
+    simd_ops<scalar_simd_policy> ops;
+    std::vector<float> test_data;
+    std::mt19937 rng{42};
+
+    void SetUp() override {
+        test_data.clear();
+        for (int i = 1; i <= 100; ++i) {
+            test_data.push_back(static_cast<float>(i));
+        }
+    }
+};
+
+TEST_F(ScalarPolicyTest, PolicyName) {
+    EXPECT_EQ(simd_ops<scalar_simd_policy>::policy_name(), "scalar");
+}
+
+TEST_F(ScalarPolicyTest, SimdWidth) {
+    EXPECT_EQ(simd_ops<scalar_simd_policy>::simd_width(), 1u);
+}
+
+TEST_F(ScalarPolicyTest, SumFloatsBasic) {
+    float sum = ops.sum_floats(test_data.data(), test_data.size());
+    // Sum of 1 to 100 = 100 * 101 / 2 = 5050
+    EXPECT_FLOAT_EQ(sum, 5050.0f);
+}
+
+TEST_F(ScalarPolicyTest, SumFloatsEmpty) {
+    float sum = ops.sum_floats(nullptr, 0);
+    EXPECT_FLOAT_EQ(sum, 0.0f);
+}
+
+TEST_F(ScalarPolicyTest, SumFloatsSingleElement) {
+    float val = 42.0f;
+    float sum = ops.sum_floats(&val, 1);
+    EXPECT_FLOAT_EQ(sum, 42.0f);
+}
+
+TEST_F(ScalarPolicyTest, MinFloatBasic) {
+    float min_val = ops.min_float(test_data.data(), test_data.size());
+    EXPECT_FLOAT_EQ(min_val, 1.0f);
+}
+
+TEST_F(ScalarPolicyTest, MinFloatEmpty) {
+    float min_val = ops.min_float(nullptr, 0);
+    EXPECT_FLOAT_EQ(min_val, std::numeric_limits<float>::max());
+}
+
+TEST_F(ScalarPolicyTest, MinFloatWithNegatives) {
+    std::vector<float> data = {-100.0f, 50.0f, -200.0f, 0.0f};
+    float min_val = ops.min_float(data.data(), data.size());
+    EXPECT_FLOAT_EQ(min_val, -200.0f);
+}
+
+TEST_F(ScalarPolicyTest, MaxFloatBasic) {
+    float max_val = ops.max_float(test_data.data(), test_data.size());
+    EXPECT_FLOAT_EQ(max_val, 100.0f);
+}
+
+TEST_F(ScalarPolicyTest, MaxFloatEmpty) {
+    float max_val = ops.max_float(nullptr, 0);
+    EXPECT_FLOAT_EQ(max_val, std::numeric_limits<float>::lowest());
+}
+
+TEST_F(ScalarPolicyTest, MaxFloatWithNegatives) {
+    std::vector<float> data = {-100.0f, 50.0f, -200.0f, 0.0f};
+    float max_val = ops.max_float(data.data(), data.size());
+    EXPECT_FLOAT_EQ(max_val, 50.0f);
+}
+
+TEST_F(ScalarPolicyTest, SumDoublesBasic) {
+    std::vector<double> doubles;
+    for (int i = 1; i <= 100; ++i) {
+        doubles.push_back(static_cast<double>(i));
+    }
+    double sum = ops.sum_doubles(doubles.data(), doubles.size());
+    EXPECT_DOUBLE_EQ(sum, 5050.0);
+}
+
+// ============================================================================
+// Default Policy Tests
+// ============================================================================
+
+class DefaultPolicyTest : public ::testing::Test {
+protected:
+    simd_ops<> ops;  // Uses default_simd_policy
+    std::vector<float> test_data;
+    std::mt19937 rng{42};
+
+    void SetUp() override {
+        test_data.clear();
+        for (int i = 1; i <= 100; ++i) {
+            test_data.push_back(static_cast<float>(i));
+        }
+    }
+};
+
+TEST_F(DefaultPolicyTest, PolicyNameNotEmpty) {
+    std::string_view name = simd_ops<>::policy_name();
+    EXPECT_FALSE(name.empty());
+    std::cout << "Default SIMD policy: " << name << std::endl;
+}
+
+TEST_F(DefaultPolicyTest, SimdWidthPositive) {
+    size_t width = simd_ops<>::simd_width();
+    EXPECT_GE(width, 1u);
+    EXPECT_LE(width, 16u);
+    std::cout << "Default SIMD width: " << width << std::endl;
+}
+
+TEST_F(DefaultPolicyTest, SumFloatsBasic) {
+    float sum = ops.sum_floats(test_data.data(), test_data.size());
+    EXPECT_FLOAT_EQ(sum, 5050.0f);
+}
+
+TEST_F(DefaultPolicyTest, SumFloatsLargeDataset) {
+    std::vector<float> large_data(10000, 1.0f);
+    float sum = ops.sum_floats(large_data.data(), large_data.size());
+    EXPECT_NEAR(sum, 10000.0f, 0.01f);
+}
+
+TEST_F(DefaultPolicyTest, MinFloatBasic) {
+    float min_val = ops.min_float(test_data.data(), test_data.size());
+    EXPECT_FLOAT_EQ(min_val, 1.0f);
+}
+
+TEST_F(DefaultPolicyTest, MaxFloatBasic) {
+    float max_val = ops.max_float(test_data.data(), test_data.size());
+    EXPECT_FLOAT_EQ(max_val, 100.0f);
+}
+
+TEST_F(DefaultPolicyTest, NonAlignedSizeSum) {
+    // Test with size that doesn't align to any SIMD width
+    std::vector<float> data;
+    for (int i = 1; i <= 17; ++i) {
+        data.push_back(static_cast<float>(i));
+    }
+    float sum = ops.sum_floats(data.data(), data.size());
+    // Sum of 1 to 17 = 17 * 18 / 2 = 153
+    EXPECT_FLOAT_EQ(sum, 153.0f);
+}
+
+TEST_F(DefaultPolicyTest, MinMaxLargeDataset) {
+    std::vector<float> large_data;
+    large_data.reserve(10000);
+
+    std::uniform_real_distribution<float> dist(-1000.0f, 1000.0f);
+
+    float expected_min = std::numeric_limits<float>::max();
+    float expected_max = std::numeric_limits<float>::lowest();
+
+    for (int i = 0; i < 10000; ++i) {
+        float val = dist(rng);
+        large_data.push_back(val);
+        expected_min = std::min(expected_min, val);
+        expected_max = std::max(expected_max, val);
+    }
+
+    float min_val = ops.min_float(large_data.data(), large_data.size());
+    float max_val = ops.max_float(large_data.data(), large_data.size());
+
+    EXPECT_FLOAT_EQ(min_val, expected_min);
+    EXPECT_FLOAT_EQ(max_val, expected_max);
+}
+
+// ============================================================================
+// Cross-Policy Consistency Tests
+// ============================================================================
+
+class CrossPolicyConsistencyTest : public ::testing::Test {
+protected:
+    std::vector<float> test_data;
+    std::mt19937 rng{42};
+
+    void SetUp() override {
+        test_data.clear();
+        std::uniform_real_distribution<float> dist(-1000.0f, 1000.0f);
+        for (int i = 0; i < 1000; ++i) {
+            test_data.push_back(dist(rng));
+        }
+    }
+};
+
+TEST_F(CrossPolicyConsistencyTest, SumFloatsConsistency) {
+    simd_ops<scalar_simd_policy> scalar_ops;
+    simd_ops<> default_ops;
+
+    float scalar_sum = scalar_ops.sum_floats(test_data.data(), test_data.size());
+    float default_sum = default_ops.sum_floats(test_data.data(), test_data.size());
+
+    // Allow small floating-point differences due to operation order
+    EXPECT_NEAR(scalar_sum, default_sum, std::abs(scalar_sum) * 1e-5f);
+}
+
+TEST_F(CrossPolicyConsistencyTest, MinFloatConsistency) {
+    simd_ops<scalar_simd_policy> scalar_ops;
+    simd_ops<> default_ops;
+
+    float scalar_min = scalar_ops.min_float(test_data.data(), test_data.size());
+    float default_min = default_ops.min_float(test_data.data(), test_data.size());
+
+    EXPECT_FLOAT_EQ(scalar_min, default_min);
+}
+
+TEST_F(CrossPolicyConsistencyTest, MaxFloatConsistency) {
+    simd_ops<scalar_simd_policy> scalar_ops;
+    simd_ops<> default_ops;
+
+    float scalar_max = scalar_ops.max_float(test_data.data(), test_data.size());
+    float default_max = default_ops.max_float(test_data.data(), test_data.size());
+
+    EXPECT_FLOAT_EQ(scalar_max, default_max);
+}
+
+// ============================================================================
+// Edge Cases Tests
+// ============================================================================
+
+class EdgeCasesTest : public ::testing::Test {
+protected:
+    simd_ops<> ops;
+};
+
+TEST_F(EdgeCasesTest, SingleElement) {
+    float val = 42.0f;
+
+    EXPECT_FLOAT_EQ(ops.sum_floats(&val, 1), 42.0f);
+    EXPECT_FLOAT_EQ(ops.min_float(&val, 1), 42.0f);
+    EXPECT_FLOAT_EQ(ops.max_float(&val, 1), 42.0f);
+}
+
+TEST_F(EdgeCasesTest, TwoElements) {
+    std::vector<float> data = {10.0f, 20.0f};
+
+    EXPECT_FLOAT_EQ(ops.sum_floats(data.data(), data.size()), 30.0f);
+    EXPECT_FLOAT_EQ(ops.min_float(data.data(), data.size()), 10.0f);
+    EXPECT_FLOAT_EQ(ops.max_float(data.data(), data.size()), 20.0f);
+}
+
+TEST_F(EdgeCasesTest, AllSameValues) {
+    std::vector<float> data(100, 5.0f);
+
+    EXPECT_FLOAT_EQ(ops.sum_floats(data.data(), data.size()), 500.0f);
+    EXPECT_FLOAT_EQ(ops.min_float(data.data(), data.size()), 5.0f);
+    EXPECT_FLOAT_EQ(ops.max_float(data.data(), data.size()), 5.0f);
+}
+
+TEST_F(EdgeCasesTest, VeryLargeValues) {
+    std::vector<float> data = {1e38f, 1e37f, 1e36f};
+
+    // Should not overflow for min/max
+    EXPECT_FLOAT_EQ(ops.min_float(data.data(), data.size()), 1e36f);
+    EXPECT_FLOAT_EQ(ops.max_float(data.data(), data.size()), 1e38f);
+}
+
+TEST_F(EdgeCasesTest, VerySmallValues) {
+    std::vector<float> data = {1e-38f, 1e-37f, 1e-36f};
+
+    EXPECT_FLOAT_EQ(ops.min_float(data.data(), data.size()), 1e-38f);
+    EXPECT_FLOAT_EQ(ops.max_float(data.data(), data.size()), 1e-36f);
+}
+
+TEST_F(EdgeCasesTest, MixedPositiveNegative) {
+    std::vector<float> data;
+    for (int i = -50; i <= 50; ++i) {
+        data.push_back(static_cast<float>(i));
+    }
+
+    // Sum of -50 to 50 = 0
+    EXPECT_FLOAT_EQ(ops.sum_floats(data.data(), data.size()), 0.0f);
+    EXPECT_FLOAT_EQ(ops.min_float(data.data(), data.size()), -50.0f);
+    EXPECT_FLOAT_EQ(ops.max_float(data.data(), data.size()), 50.0f);
+}
+
+// ============================================================================
+// Platform-Specific Policy Tests (conditional)
+// ============================================================================
+
+#if defined(CONTAINER_HAS_SSE42) || defined(CONTAINER_HAS_SSE2)
+class SSEPolicyTest : public ::testing::Test {
+protected:
+    simd_ops<sse_simd_policy> ops;
+};
+
+TEST_F(SSEPolicyTest, PolicyName) {
+    EXPECT_EQ(simd_ops<sse_simd_policy>::policy_name(), "sse");
+}
+
+TEST_F(SSEPolicyTest, SimdWidth) {
+    EXPECT_EQ(simd_ops<sse_simd_policy>::simd_width(), 4u);
+}
+
+TEST_F(SSEPolicyTest, SumFloatsBasic) {
+    std::vector<float> data;
+    for (int i = 1; i <= 100; ++i) {
+        data.push_back(static_cast<float>(i));
+    }
+    float sum = ops.sum_floats(data.data(), data.size());
+    EXPECT_FLOAT_EQ(sum, 5050.0f);
+}
+#endif
+
+#if defined(CONTAINER_HAS_AVX2)
+class AVX2PolicyTest : public ::testing::Test {
+protected:
+    simd_ops<avx2_simd_policy> ops;
+};
+
+TEST_F(AVX2PolicyTest, PolicyName) {
+    EXPECT_EQ(simd_ops<avx2_simd_policy>::policy_name(), "avx2");
+}
+
+TEST_F(AVX2PolicyTest, SimdWidth) {
+    EXPECT_EQ(simd_ops<avx2_simd_policy>::simd_width(), 8u);
+}
+
+TEST_F(AVX2PolicyTest, SumFloatsBasic) {
+    std::vector<float> data;
+    for (int i = 1; i <= 100; ++i) {
+        data.push_back(static_cast<float>(i));
+    }
+    float sum = ops.sum_floats(data.data(), data.size());
+    EXPECT_FLOAT_EQ(sum, 5050.0f);
+}
+#endif
+
+#if defined(CONTAINER_HAS_AVX512)
+class AVX512PolicyTest : public ::testing::Test {
+protected:
+    simd_ops<avx512_simd_policy> ops;
+};
+
+TEST_F(AVX512PolicyTest, PolicyName) {
+    EXPECT_EQ(simd_ops<avx512_simd_policy>::policy_name(), "avx512");
+}
+
+TEST_F(AVX512PolicyTest, SimdWidth) {
+    EXPECT_EQ(simd_ops<avx512_simd_policy>::simd_width(), 16u);
+}
+
+TEST_F(AVX512PolicyTest, SumFloatsBasic) {
+    std::vector<float> data;
+    for (int i = 1; i <= 100; ++i) {
+        data.push_back(static_cast<float>(i));
+    }
+    float sum = ops.sum_floats(data.data(), data.size());
+    EXPECT_FLOAT_EQ(sum, 5050.0f);
+}
+#endif
+
+#if defined(CONTAINER_HAS_ARM_NEON)
+class NEONPolicyTest : public ::testing::Test {
+protected:
+    simd_ops<neon_simd_policy> ops;
+};
+
+TEST_F(NEONPolicyTest, PolicyName) {
+    EXPECT_EQ(simd_ops<neon_simd_policy>::policy_name(), "neon");
+}
+
+TEST_F(NEONPolicyTest, SimdWidth) {
+    EXPECT_EQ(simd_ops<neon_simd_policy>::simd_width(), 4u);
+}
+
+TEST_F(NEONPolicyTest, SumFloatsBasic) {
+    std::vector<float> data;
+    for (int i = 1; i <= 100; ++i) {
+        data.push_back(static_cast<float>(i));
+    }
+    float sum = ops.sum_floats(data.data(), data.size());
+    EXPECT_FLOAT_EQ(sum, 5050.0f);
+}
+#endif
+
+// ============================================================================
+// Concept Verification Tests
+// ============================================================================
+
+TEST(ConceptTest, ScalarPolicySatisfiesConcept) {
+    EXPECT_TRUE(SimdPolicy<scalar_simd_policy>);
+}
+
+#if defined(CONTAINER_HAS_SSE42) || defined(CONTAINER_HAS_SSE2)
+TEST(ConceptTest, SSEPolicySatisfiesConcept) {
+    EXPECT_TRUE(SimdPolicy<sse_simd_policy>);
+}
+#endif
+
+#if defined(CONTAINER_HAS_AVX2)
+TEST(ConceptTest, AVX2PolicySatisfiesConcept) {
+    EXPECT_TRUE(SimdPolicy<avx2_simd_policy>);
+}
+#endif
+
+#if defined(CONTAINER_HAS_AVX512)
+TEST(ConceptTest, AVX512PolicySatisfiesConcept) {
+    EXPECT_TRUE(SimdPolicy<avx512_simd_policy>);
+}
+#endif
+
+#if defined(CONTAINER_HAS_ARM_NEON)
+TEST(ConceptTest, NEONPolicySatisfiesConcept) {
+    EXPECT_TRUE(SimdPolicy<neon_simd_policy>);
+}
+#endif
+
+int main(int argc, char **argv) {
+    std::cout << "=== SIMD Policy Tests ===" << std::endl;
+    std::cout << "Default policy: " << simd_ops<>::policy_name() << std::endl;
+    std::cout << "SIMD width: " << simd_ops<>::simd_width() << std::endl;
+    std::cout << "=========================" << std::endl;
+
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

This PR introduces the foundation for compile-time SIMD policy selection (Phase 1 of #338):

- Add `SimdPolicy` C++20 concept for type-safe policy validation
- Implement policy classes for all supported platforms:
  - `scalar_simd_policy` - Baseline fallback (always available)
  - `sse_simd_policy` - x86 SSE4/SSE2 (128-bit)
  - `avx2_simd_policy` - x86 AVX2 (256-bit)
  - `avx512_simd_policy` - x86 AVX-512 (512-bit)
  - `neon_simd_policy` - ARM NEON (128-bit)
- Add `simd_ops<Policy>` wrapper template with automatic default policy selection
- Add comprehensive unit tests (34 tests covering all policies)

### Benefits of Policy-Based Design

| Aspect | Before (Runtime) | After (Compile-Time) |
|--------|------------------|----------------------|
| Branch prediction | Required per call | Eliminated |
| Inlining | Limited by branches | Full optimization |
| Code size | All paths included | Only needed path |
| Testing | Requires runtime switching | Each policy testable |

### Files Changed

- `internal/simd_policies.h` - New policy infrastructure
- `tests/simd_policies_tests.cpp` - Unit tests for policies
- `tests/CMakeLists.txt` - Register new test executable

### Next Steps (Future PRs)

- Phase 2: Migrate `simd_processor` to use `simd_ops<>` internally
- Phase 3: Add policy template parameter to container classes
- Phase 4: Benchmark and validate performance improvements

## Test Plan

- [x] All 34 new policy tests pass
- [x] All 31 existing SIMD tests pass (no regression)
- [x] Build succeeds on ARM (Apple Silicon with NEON)
- [ ] CI validation on x86 (SSE/AVX)

Closes #338 (Phase 1)