### PR TITLE
fix(core): add missing value_types enum definition

### DIFF
--- a/core/value_types.h
+++ b/core/value_types.h
@@ -32,6 +32,82 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-// Forwarding header for backward compatibility
-// The actual implementation is in container/core/value_types.h
-#include "container/core/value_types.h"
+#include <array>
+#include <string>
+#include <string_view>
+
+namespace container_module
+{
+	/**
+	 * @brief Enumeration of available value types in the container system.
+	 */
+	enum class value_types
+	{
+		null_value,
+		bool_value,
+		short_value,
+		ushort_value,
+		int_value,
+		uint_value,
+		long_value,
+		ulong_value,
+		llong_value,
+		ullong_value,
+		float_value,
+		double_value,
+		string_value,
+		bytes_value,
+		container_value,
+		array_value
+	};
+
+	// Compile-time type mapping
+	constexpr std::array<std::pair<std::string_view, value_types>, 16> type_map{
+		{{"0", value_types::null_value},
+		 {"1", value_types::bool_value},
+		 {"2", value_types::short_value},
+		 {"3", value_types::ushort_value},
+		 {"4", value_types::int_value},
+		 {"5", value_types::uint_value},
+		 {"6", value_types::long_value},
+		 {"7", value_types::ulong_value},
+		 {"8", value_types::llong_value},
+		 {"9", value_types::ullong_value},
+		 {"10", value_types::float_value},
+		 {"11", value_types::double_value},
+		 {"12", value_types::string_value},
+		 {"13", value_types::bytes_value},
+		 {"14", value_types::container_value},
+		 {"15", value_types::array_value}}};
+
+	/**
+	 * @brief Compile-time conversion from string to value_types
+	 */
+	constexpr value_types get_type_from_string(std::string_view str) noexcept
+	{
+		for (const auto& [key, type] : type_map)
+		{
+			if (key == str)
+				return type;
+		}
+		return value_types::null_value;
+	}
+
+	/**
+	 * @brief Compile-time conversion from value_types to string
+	 */
+	constexpr std::string_view get_string_from_type(value_types type) noexcept
+	{
+		for (const auto& [key, val] : type_map)
+		{
+			if (val == type)
+				return key;
+		}
+		return "0";
+	}
+
+	// Non-constexpr conversion functions (implemented in value_types.cpp)
+	value_types convert_value_type(const std::string& target);
+	std::string convert_value_type(const value_types& target);
+
+} // namespace container_module


### PR DESCRIPTION
## What

### Summary
Fixes the missing `value_types` enum definition that was causing build failures. The `container/core/value_types.h` file was a forwarding header that included itself, creating infinite include recursion.

### Change Type
- [x] Bugfix (fixes an issue)

## Why

### Related Issues
Closes #343

### Problem Solved
The `value_types.h` file was causing compilation errors because:
1. It was a forwarding header that included itself (infinite recursion)
2. The actual enum definition was missing from the header
3. All dependent code that used `value_types` enum failed to compile

This was blocking CI for network_system and other dependent projects.

## Where

### Files Changed
- `core/value_types.h` - Added actual enum definition and helper functions

### Breaking Changes
None - This is a bug fix that restores previously working functionality.

## How

### Implementation Details
1. Replaced circular include with actual enum definition
2. Added `value_types` enum with all 16 type variants (from `src/modules/container.cppm`)
3. Added `type_map` constexpr array for type conversions
4. Added helper functions: `get_type_from_string()`, `get_string_from_type()`
5. Added forward declarations for `convert_value_type()` functions

### Testing Done
- [x] Build succeeds (Release mode)
- [x] Integration tests pass (5/5 tests)
- [x] No new compilation errors

### Test Plan
1. Run `cmake --build build/ --config Release`
2. Verify all dependent files compile successfully
3. Run `ctest --test-dir build/` to verify tests

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Build verified
- [x] No breaking changes introduced