### PR TITLE
fix(build): use relative include paths in core/ and internal/

### DIFF
--- a/core/container.cpp
+++ b/core/container.cpp
@@ -30,19 +30,19 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
-#include "core/container.h"
+#include "container.h"
 
 #include "utilities/core/formatter.h"
 #include "utilities/core/convert_string.h"
 
-#include "core/value_types.h"
+#include "value_types.h"
 #include "internal/value.h"
 #include "internal/pool_allocator.h"
-#include "core/serializers/serializer_factory.h"
-#include "core/serializers/binary_serializer.h"
-#include "core/serializers/json_serializer.h"
-#include "core/serializers/xml_serializer.h"
-#include "core/serializers/msgpack_serializer.h"
+#include "serializers/serializer_factory.h"
+#include "serializers/binary_serializer.h"
+#include "serializers/json_serializer.h"
+#include "serializers/xml_serializer.h"
+#include "serializers/msgpack_serializer.h"
 // Legacy value includes removed - using variant-based storage only
 
 #include <fcntl.h>

--- a/core/container.h
+++ b/core/container.h
@@ -49,21 +49,21 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // =============================================================================
 // Sub-headers (modular include structure)
 // =============================================================================
-#include "core/container/fwd.h"
-#include "core/container/types.h"
-#include "core/container/variant_helpers.h"
-#include "core/container/error_codes.h"
-#include "core/container/schema.h"
-#include "core/container/metrics.h"
-#include "core/container/msgpack.h"
+#include "container/fwd.h"
+#include "container/types.h"
+#include "container/variant_helpers.h"
+#include "container/error_codes.h"
+#include "container/schema.h"
+#include "container/metrics.h"
+#include "container/msgpack.h"
 
-#include "core/value_types.h"
-#include "core/simd_batch.h"  // Renamed from typed_container.h (Issue #328)
+#include "value_types.h"
+#include "simd_batch.h"  // Renamed from typed_container.h (Issue #328)
 #include "internal/value.h"
 #include "internal/value_view.h"
 
 // Unified Result<T> integration (Issue #335)
-#include "core/container/result_integration.h"
+#include "container/result_integration.h"
 
 #include <memory>
 #include <vector>

--- a/core/container/schema.h
+++ b/core/container/schema.h
@@ -58,9 +58,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include "core/container/types.h"
-#include "core/container/error_codes.h"
-#include "core/value_types.h"
+#include "types.h"
+#include "error_codes.h"
+#include "../value_types.h"
 
 #include <string>
 #include <string_view>
@@ -72,7 +72,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <concepts>
 
 // Unified Result<T> integration (Issue #335)
-#include "core/container/result_integration.h"
+#include "result_integration.h"
 
 // Backward compatibility alias
 #ifndef SCHEMA_HAS_COMMON_RESULT

--- a/core/container/types.h
+++ b/core/container/types.h
@@ -43,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include "core/value_types.h"
+#include "../value_types.h"
 
 // Note: When included from container.h, these paths resolve correctly
 // via the container -> . symlink in project root

--- a/core/container/variant_helpers.h
+++ b/core/container/variant_helpers.h
@@ -43,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include "core/container/types.h"
+#include "types.h"
 
 #include <string>
 #include <string_view>

--- a/core/container_schema.cpp
+++ b/core/container_schema.cpp
@@ -35,8 +35,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * @brief Implementation of container_schema class
  */
 
-#include "core/container/schema.h"
-#include "core/container.h"
+#include "container/schema.h"
+#include "container.h"
 
 #include <algorithm>
 #include <cmath>

--- a/core/policy_container.h
+++ b/core/policy_container.h
@@ -55,13 +55,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include "core/storage_policy.h"
-#include "core/container/types.h"
-#include "core/container/error_codes.h"
-#include "core/value_types.h"
+#include "storage_policy.h"
+#include "container/types.h"
+#include "container/error_codes.h"
+#include "value_types.h"
 
 // Unified Result<T> integration (Issue #335)
-#include "core/container/result_integration.h"
+#include "container/result_integration.h"
 
 #include <memory>
 #include <mutex>

--- a/core/serializers/binary_serializer.cpp
+++ b/core/serializers/binary_serializer.cpp
@@ -31,7 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
 #include "binary_serializer.h"
-#include "core/container.h"
+#include "../container.h"
 #include "utilities/core/convert_string.h"
 #include "utilities/core/formatter.h"
 

--- a/core/serializers/json_serializer.cpp
+++ b/core/serializers/json_serializer.cpp
@@ -31,8 +31,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
 #include "json_serializer.h"
-#include "core/container.h"
-#include "core/container/variant_helpers.h"
+#include "../container.h"
+#include "../container/variant_helpers.h"
 #include "utilities/core/formatter.h"
 
 namespace container_module

--- a/core/serializers/msgpack_serializer.cpp
+++ b/core/serializers/msgpack_serializer.cpp
@@ -31,8 +31,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
 #include "msgpack_serializer.h"
-#include "core/container.h"
-#include "core/container/msgpack.h"
+#include "../container.h"
+#include "../container/msgpack.h"
 
 namespace container_module
 {

--- a/core/serializers/serializer_strategy.h
+++ b/core/serializers/serializer_strategy.h
@@ -46,7 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 
 // Unified Result<T> integration (Issue #335)
-#include "core/container/result_integration.h"
+#include "../container/result_integration.h"
 
 namespace container_module
 {

--- a/core/serializers/xml_serializer.cpp
+++ b/core/serializers/xml_serializer.cpp
@@ -31,8 +31,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
 #include "xml_serializer.h"
-#include "core/container.h"
-#include "core/container/variant_helpers.h"
+#include "../container.h"
+#include "../container/variant_helpers.h"
 #include "utilities/core/formatter.h"
 
 namespace container_module

--- a/core/simd_batch.h
+++ b/core/simd_batch.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "core/concepts.h"
+#include "concepts.h"
 #include <type_traits>
 #include <vector>
 #include <cstddef>

--- a/core/storage_policy.h
+++ b/core/storage_policy.h
@@ -47,8 +47,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include "core/container/types.h"
-#include "core/value_types.h"
+#include "container/types.h"
+#include "value_types.h"
 
 #include <concepts>
 #include <optional>

--- a/core/typed_container.h
+++ b/core/typed_container.h
@@ -13,7 +13,7 @@
 #endif
 
 // Include the new header which provides the deprecated alias
-#include "core/simd_batch.h"
+#include "simd_batch.h"
 
 // Note: typed_container is now a deprecated alias for simd_batch
 // defined in simd_batch.h

--- a/core/value_store.cpp
+++ b/core/value_store.cpp
@@ -30,7 +30,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
-#include "core/value_store.h"
+#include "value_store.h"
 #include <stdexcept>
 #include <cstring>
 

--- a/core/value_types.cpp
+++ b/core/value_types.cpp
@@ -30,7 +30,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
-#include "core/value_types.h"
+#include "value_types.h"
 
 namespace container_module
 {

--- a/internal/pool_allocator.h
+++ b/internal/pool_allocator.h
@@ -42,7 +42,7 @@
  * - Large: Direct heap allocation (bypasses pool)
  */
 
-#include "internal/memory_pool.h"
+#include "memory_pool.h"
 
 #include <cstddef>
 #include <atomic>

--- a/internal/simd_processor.cpp
+++ b/internal/simd_processor.cpp
@@ -30,7 +30,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
-#include "internal/simd_processor.h"
+#include "simd_processor.h"
 #include <algorithm>
 #include <cmath>
 #include <limits>

--- a/internal/simd_processor.h
+++ b/internal/simd_processor.h
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include "internal/value.h"
+#include "value.h"
 #include <vector>
 #include <string>
 #include <numeric>

--- a/internal/thread_safe_container.cpp
+++ b/internal/thread_safe_container.cpp
@@ -30,7 +30,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
-#include "internal/thread_safe_container.h"
+#include "thread_safe_container.h"
 #include "utilities/core/formatter.h"
 #include <algorithm>
 #include <cstring>

--- a/internal/thread_safe_container.h
+++ b/internal/thread_safe_container.h
@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <thread>
 #include <chrono>
 #include <condition_variable>
-#include "internal/value.h"
+#include "value.h"
 #include "core/concepts.h"
 
 namespace container_module

--- a/internal/value.cpp
+++ b/internal/value.cpp
@@ -5,8 +5,8 @@ Copyright (c) 2024, 🍀☀🌕🌥 🌊
 All rights reserved.
 *****************************************************************************/
 
-#include "internal/value.h"
-#include "internal/thread_safe_container.h"
+#include "value.h"
+#include "thread_safe_container.h"
 #include <sstream>
 #include <iomanip>
 #include <cstring>

--- a/internal/variant_value_factory.h
+++ b/internal/variant_value_factory.h
@@ -7,7 +7,7 @@ All rights reserved.
 
 #pragma once
 
-#include "internal/value.h"
+#include "value.h"
 #include "core/value_types.h"
 #include "core/concepts.h"
 #include <string>


### PR DESCRIPTION
## Summary
- Resolves include path resolution failures in CI environments
- Files within `core/` and `internal/` directories now use relative include paths instead of absolute prefixes
- Maintains cross-directory includes (e.g., `internal/` referencing `core/`) with proper prefixes

## What

### Problem
Files in `core/` directory used `#include "core/..."` patterns, which caused include path resolution failures when building dependent projects in CI:

```
container_system/core/simd_batch.h:35:28: error: 'container_module::concepts' has not been declared
container_system/internal/value.h:226:18: error: 'concepts' has not been declared
```

When the compiler processes `core/simd_batch.h` with `#include "core/concepts.h"`:
1. First looks for `core/concepts.h` relative to current file → `core/core/concepts.h` (doesn't exist)
2. Some compilers/environments fail without proceeding to check include directories

### Solution
- **Same-directory includes**: Use relative paths (`"concepts.h"` instead of `"core/concepts.h"`)
- **Subdirectory includes**: Use relative paths (`"container/types.h"` instead of `"core/container/types.h"`)
- **Parent directory includes**: Use `../` prefix (`"../container.h"` instead of `"core/container.h"`)
- **Cross-directory includes**: Keep prefixes (`internal/` files referencing `core/` keep `"core/..."`)

## Files Changed

### core/ directory (17 files)
- `simd_batch.h`, `storage_policy.h`, `typed_container.h`, `policy_container.h`, `container.h`
- `value_store.cpp`, `container_schema.cpp`, `value_types.cpp`, `container.cpp`
- `serializers/*.cpp`, `serializers/serializer_strategy.h`
- `container/variant_helpers.h`, `container/types.h`, `container/schema.h`

### internal/ directory (7 files)
- `pool_allocator.h`, `simd_processor.cpp`, `simd_processor.h`
- `thread_safe_container.cpp`, `thread_safe_container.h`
- `value.cpp`, `variant_value_factory.h`

## Test Plan
- [x] CMake configuration succeeds
- [x] Build completes without errors
- [x] Unit tests pass (22/25 - 3 pre-existing failures unrelated to this change)
- [x] Integration tests pass

## Related Issues
- Closes #359
- Related to commit 315c07cf (similar fix for `container/X` → `X` symlink issue)