### PR TITLE
docs: fix architecture diagram to match actual ecosystem structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,33 +275,36 @@ cmake --build build
 
 ## Architecture Overview
 
+### Ecosystem Position
+
 ```
                     ┌─────────────────┐
-                    │ utilities_module│
-                    │   (Foundation)  │
+                    │  common_system  │
+                    │  (Foundation)   │
                     └────────┬────────┘
                              │
-         ┌───────────────────┼───────────────────┐
-         │                   │                   │
-         ▼                   ▼                   ▼
-┌────────────────┐  ┌────────────────┐  ┌────────────────┐
-│ container_system│  │messaging_system│  │ network_system │
-│  (This Project) │◄─│   (Consumer)   │◄─│  (Transport)   │
-└────────────────┘  └────────────────┘  └────────────────┘
-         │
-         └──────────────────────┐
-                                ▼
-                    ┌────────────────────┐
-                    │  database_system   │
-                    │     (Storage)      │
-                    └────────────────────┘
+                             ▼
+                    ┌─────────────────┐
+                    │container_system │
+                    │(Data Containers)│
+                    └────────┬────────┘
+                             │ used by
+       ┌─────────────────────┼─────────────────────┐
+       │                     │                     │
+       ▼                     ▼                     ▼
+┌──────────────┐    ┌────────────────┐    ┌──────────────┐
+│network_system│    │database_system │    │Other systems │
+└──────────────┘    └────────────────┘    └──────────────┘
 ```
 
+container_system has **minimal dependencies** - only common_system is required.
+This makes it ideal as a foundational data layer for the ecosystem.
+
 **Integration Benefits**:
-- **Type-safe messaging**: Prevents runtime errors
-- **Performance-optimized**: SIMD acceleration for high-throughput
-- **Universal serialization**: Binary, JSON, XML for diverse needs
-- **Unified data model**: Consistent structure across ecosystem
+- **Type-safe data containers**: Prevents runtime errors with compile-time checks
+- **Performance-optimized**: SIMD acceleration for high-throughput operations
+- **Universal serialization**: Binary, JSON, XML for diverse integration needs
+- **Unified data model**: Consistent structure across the entire ecosystem
 
 🏗️ **[Architecture Guide →](docs/ARCHITECTURE.md)**
 


### PR DESCRIPTION
Closes #361

## Summary

- Replaced incorrect `utilities_module` with `common_system` as the actual foundation layer
- Removed `messaging_system` reference which is not part of the analyzed ecosystem
- Added "Ecosystem Position" section title for better organization
- Highlighted the minimal dependencies advantage of container_system
- Updated integration benefits descriptions for accuracy

## Changes

The architecture diagram now correctly shows:
```
common_system (Foundation)
       │
       └── container_system (depends only on common_system)
              │
              └── Used by: network_system, database_system, other systems
```

## Test Plan

- [x] Architecture diagram accurately shows common_system as foundation
- [x] References to utilities_module removed
- [x] Downstream consumers accurately listed
- [x] Minimal dependency advantage highlighted