### PR TITLE
test: add unit tests for thread_pool_executor, value_view, rcu_value, and epoch_manager

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,7 +71,7 @@ set(TEST_SOURCES
 
 # Add async tests if coroutines are enabled
 if(CONTAINER_ENABLE_COROUTINES)
-    list(APPEND TEST_SOURCES async_tests.cpp)
+    list(APPEND TEST_SOURCES async_tests.cpp thread_pool_executor_tests.cpp)
     message(STATUS "Container: Async coroutine tests enabled")
 endif()
 

--- a/tests/thread_pool_executor_tests.cpp
+++ b/tests/thread_pool_executor_tests.cpp
@@ -1,0 +1,227 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "internal/async/async.h"
+
+#if CONTAINER_HAS_COROUTINES
+
+#include <thread>
+#include <atomic>
+#include <chrono>
+#include <stdexcept>
+
+using namespace container_module::async;
+using namespace std::chrono_literals;
+
+class ThreadPoolExecutorTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Ensure clean state before each test
+        async_executor_context::instance().clear_executor();
+    }
+
+    void TearDown() override {
+        async_executor_context::instance().clear_executor();
+    }
+};
+
+// =============================================================================
+// async_executor_context singleton tests
+// =============================================================================
+
+TEST_F(ThreadPoolExecutorTest, SingletonReturnsSameInstance) {
+    auto& inst1 = async_executor_context::instance();
+    auto& inst2 = async_executor_context::instance();
+    EXPECT_EQ(&inst1, &inst2);
+}
+
+TEST_F(ThreadPoolExecutorTest, InitialStateHasNoExecutor) {
+    EXPECT_FALSE(async_executor_context::instance().has_executor());
+}
+
+TEST_F(ThreadPoolExecutorTest, GetExecutorReturnsNullWhenNotSet) {
+    auto executor = async_executor_context::instance().get_executor();
+#ifdef KCENON_HAS_COMMON_SYSTEM
+    EXPECT_EQ(executor, nullptr);
+#else
+    // Without common_system, executor_ptr is std::nullptr_t
+    (void)executor;
+    SUCCEED();
+#endif
+}
+
+TEST_F(ThreadPoolExecutorTest, ClearExecutorIsIdempotent) {
+    async_executor_context::instance().clear_executor();
+    EXPECT_FALSE(async_executor_context::instance().has_executor());
+
+    async_executor_context::instance().clear_executor();
+    EXPECT_FALSE(async_executor_context::instance().has_executor());
+}
+
+// =============================================================================
+// executor_context_guard RAII tests
+// =============================================================================
+
+TEST_F(ThreadPoolExecutorTest, GuardRestoresPreviousExecutor) {
+    EXPECT_FALSE(async_executor_context::instance().has_executor());
+
+    {
+        executor_context_guard guard(executor_ptr{});
+        // Within guard scope, executor is set (even if to nullptr_t)
+        // On destruction, previous state should be restored
+    }
+
+    EXPECT_FALSE(async_executor_context::instance().has_executor());
+}
+
+TEST_F(ThreadPoolExecutorTest, NestedGuardsRestoreCorrectly) {
+    EXPECT_FALSE(async_executor_context::instance().has_executor());
+
+    {
+        executor_context_guard outer(executor_ptr{});
+        {
+            executor_context_guard inner(executor_ptr{});
+        }
+        // After inner guard destruction, state from outer guard remains
+        EXPECT_FALSE(async_executor_context::instance().has_executor());
+    }
+
+    // After outer guard destruction, original state restored
+    EXPECT_FALSE(async_executor_context::instance().has_executor());
+}
+
+// =============================================================================
+// executor_awaitable tests (fallback thread path)
+// =============================================================================
+
+TEST_F(ThreadPoolExecutorTest, AwaitableAlwaysNotReady) {
+    auto work = []() -> int { return 42; };
+    detail::executor_awaitable<int> awaitable(work, executor_ptr{});
+    EXPECT_FALSE(awaitable.await_ready());
+}
+
+TEST_F(ThreadPoolExecutorTest, FallbackThreadExecutesWork) {
+    auto coroutine_task = []() -> task<int> {
+        auto result = co_await detail::make_executor_awaitable(
+            []() -> int { return 42; }, executor_ptr{});
+        co_return result;
+    };
+
+    auto t = coroutine_task();
+    // Wait for async completion with timeout
+    auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (!t.done() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(10ms);
+    }
+
+    ASSERT_TRUE(t.done());
+    EXPECT_EQ(t.get(), 42);
+}
+
+TEST_F(ThreadPoolExecutorTest, FallbackThreadHandlesStringResult) {
+    auto coroutine_task = []() -> task<std::string> {
+        auto result = co_await detail::make_executor_awaitable(
+            []() -> std::string { return "hello from thread"; },
+            executor_ptr{});
+        co_return result;
+    };
+
+    auto t = coroutine_task();
+    auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (!t.done() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(10ms);
+    }
+
+    ASSERT_TRUE(t.done());
+    EXPECT_EQ(t.get(), "hello from thread");
+}
+
+TEST_F(ThreadPoolExecutorTest, FallbackThreadPropagatesException) {
+    auto coroutine_task = []() -> task<int> {
+        auto result = co_await detail::make_executor_awaitable(
+            []() -> int { throw std::runtime_error("test error"); },
+            executor_ptr{});
+        co_return result;
+    };
+
+    auto t = coroutine_task();
+    auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (!t.done() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(10ms);
+    }
+
+    ASSERT_TRUE(t.done());
+    EXPECT_THROW(t.get(), std::runtime_error);
+}
+
+TEST_F(ThreadPoolExecutorTest, FallbackThreadRunsOnDifferentThread) {
+    auto main_thread_id = std::this_thread::get_id();
+
+    auto coroutine_task = [&main_thread_id]() -> task<bool> {
+        auto runs_on_different = co_await detail::make_executor_awaitable(
+            [&main_thread_id]() -> bool {
+                return std::this_thread::get_id() != main_thread_id;
+            },
+            executor_ptr{});
+        co_return runs_on_different;
+    };
+
+    auto t = coroutine_task();
+    auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (!t.done() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(10ms);
+    }
+
+    ASSERT_TRUE(t.done());
+    EXPECT_TRUE(t.get());
+}
+
+TEST_F(ThreadPoolExecutorTest, MakeExecutorAwaitableDeducesType) {
+    // Verify that make_executor_awaitable correctly deduces the return type
+    auto awaitable_int = detail::make_executor_awaitable(
+        []() -> int { return 0; }, executor_ptr{});
+    auto awaitable_str = detail::make_executor_awaitable(
+        []() -> std::string { return ""; }, executor_ptr{});
+
+    EXPECT_FALSE(awaitable_int.await_ready());
+    EXPECT_FALSE(awaitable_str.await_ready());
+}
+
+#else // !CONTAINER_HAS_COROUTINES
+
+TEST(ThreadPoolExecutorTest, CoroutinesNotAvailable) {
+    GTEST_SKIP() << "C++20 coroutines not available";
+}
+
+#endif // CONTAINER_HAS_COROUTINES

--- a/tests/thread_safety_tests.cpp
+++ b/tests/thread_safety_tests.cpp
@@ -1192,6 +1192,287 @@ TEST_F(ContainerThreadSafetyTest, EpochManagerDeferredDeletion) {
 }
 
 // =============================================================================
+// Epoch Manager Extended Tests (Issue #375)
+// =============================================================================
+
+TEST_F(ContainerThreadSafetyTest, EpochManagerCurrentEpochIncrementsOnGC) {
+    epoch_manager& em = epoch_manager::instance();
+    uint64_t epoch_before = em.current_epoch();
+
+    em.try_gc();
+    EXPECT_EQ(em.current_epoch(), epoch_before + 1);
+
+    em.try_gc();
+    EXPECT_EQ(em.current_epoch(), epoch_before + 2);
+}
+
+TEST_F(ContainerThreadSafetyTest, EpochManagerGCCountIncrementsOnReclamation) {
+    epoch_manager& em = epoch_manager::instance();
+    size_t gc_before = em.gc_count();
+
+    // Defer some deletions
+    for (int i = 0; i < 5; ++i) {
+        em.defer_delete(new int(i), [](void* p) { delete static_cast<int*>(p); });
+    }
+
+    // Advance epochs enough to trigger reclamation
+    for (int i = 0; i < 3; ++i) {
+        em.try_gc();
+    }
+
+    // Force remaining cleanup
+    em.force_gc();
+
+    EXPECT_GT(em.gc_count(), gc_before);
+}
+
+TEST_F(ContainerThreadSafetyTest, EpochManagerReclaimedCountTracksObjects) {
+    epoch_manager& em = epoch_manager::instance();
+    size_t reclaimed_before = em.reclaimed_count();
+
+    constexpr int num_objects = 10;
+    for (int i = 0; i < num_objects; ++i) {
+        em.defer_delete(new int(i), [](void* p) { delete static_cast<int*>(p); });
+    }
+
+    // Advance past safety window
+    for (int i = 0; i < 3; ++i) {
+        em.try_gc();
+    }
+    em.force_gc();
+
+    EXPECT_GE(em.reclaimed_count() - reclaimed_before,
+              static_cast<size_t>(num_objects));
+}
+
+TEST_F(ContainerThreadSafetyTest, EpochManagerTypedDeferDelete) {
+    epoch_manager& em = epoch_manager::instance();
+
+    struct TestObject {
+        static std::atomic<int>& destroy_count() {
+            static std::atomic<int> count{0};
+            return count;
+        }
+        ~TestObject() { destroy_count().fetch_add(1); }
+    };
+
+    int initial_count = TestObject::destroy_count().load();
+
+    constexpr int num_objects = 5;
+    for (int i = 0; i < num_objects; ++i) {
+        em.defer_delete(new TestObject());
+    }
+
+    for (int i = 0; i < 3; ++i) {
+        em.try_gc();
+    }
+    em.force_gc();
+
+    EXPECT_GE(TestObject::destroy_count().load() - initial_count, num_objects);
+}
+
+TEST_F(ContainerThreadSafetyTest, EpochManagerDeferDeleteNullptrIgnored) {
+    epoch_manager& em = epoch_manager::instance();
+    size_t pending_before = em.pending_count();
+
+    em.defer_delete(nullptr, [](void*) {});
+
+    EXPECT_EQ(em.pending_count(), pending_before);
+}
+
+TEST_F(ContainerThreadSafetyTest, EpochManagerMultiThreadedReaderPlusGC) {
+    epoch_manager& em = epoch_manager::instance();
+
+    constexpr int num_readers = 4;
+    constexpr int reader_iterations = 5000;
+    std::atomic<int> errors{0};
+    std::atomic<bool> gc_done{false};
+    std::barrier sync_point(num_readers + 1);
+
+    std::vector<std::thread> threads;
+
+    // Reader threads: repeatedly enter/exit critical sections
+    for (int i = 0; i < num_readers; ++i) {
+        threads.emplace_back([&]() {
+            sync_point.arrive_and_wait();
+
+            for (int j = 0; j < reader_iterations; ++j) {
+                try {
+                    epoch_guard guard;
+                    // Simulate reading from a lock-free structure
+                    if (!em.in_critical_section()) {
+                        ++errors;
+                    }
+                } catch (...) {
+                    ++errors;
+                }
+
+                if (j % 100 == 0) {
+                    std::this_thread::yield();
+                }
+            }
+        });
+    }
+
+    // GC thread: defer deletions and run GC concurrently
+    threads.emplace_back([&]() {
+        sync_point.arrive_and_wait();
+
+        for (int j = 0; j < 100; ++j) {
+            int* ptr = new int(j);
+            em.defer_delete(ptr, [](void* p) { delete static_cast<int*>(p); });
+
+            if (j % 10 == 0) {
+                em.try_gc();
+            }
+
+            std::this_thread::yield();
+        }
+
+        gc_done.store(true);
+    });
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_EQ(errors.load(), 0);
+    EXPECT_TRUE(gc_done.load());
+
+    // Clean up remaining deferred objects
+    em.force_gc();
+}
+
+// =============================================================================
+// RCU Value Extended Tests (Issue #375)
+// =============================================================================
+
+TEST_F(ContainerThreadSafetyTest, RcuValueDefaultConstructor) {
+    rcu_value<int> val;
+    auto snapshot = val.read();
+    ASSERT_NE(snapshot, nullptr);
+    EXPECT_EQ(*snapshot, 0);
+    EXPECT_EQ(val.update_count(), 0u);
+}
+
+TEST_F(ContainerThreadSafetyTest, RcuValueCopyConstructor) {
+    rcu_value<std::string> original{"hello"};
+    rcu_value<std::string> copy(original);
+
+    auto original_snap = original.read();
+    auto copy_snap = copy.read();
+
+    ASSERT_NE(original_snap, nullptr);
+    ASSERT_NE(copy_snap, nullptr);
+    EXPECT_EQ(*original_snap, *copy_snap);
+    EXPECT_EQ(*copy_snap, "hello");
+}
+
+TEST_F(ContainerThreadSafetyTest, RcuValueMoveConstructor) {
+    rcu_value<std::string> source{"world"};
+    rcu_value<std::string> moved(std::move(source));
+
+    auto moved_snap = moved.read();
+    ASSERT_NE(moved_snap, nullptr);
+    EXPECT_EQ(*moved_snap, "world");
+}
+
+TEST_F(ContainerThreadSafetyTest, RcuValueCopyAssignment) {
+    rcu_value<int> a{10};
+    rcu_value<int> b{20};
+
+    b = a;
+
+    auto snap_a = a.read();
+    auto snap_b = b.read();
+    ASSERT_NE(snap_a, nullptr);
+    ASSERT_NE(snap_b, nullptr);
+    EXPECT_EQ(*snap_a, 10);
+    EXPECT_EQ(*snap_b, 10);
+}
+
+TEST_F(ContainerThreadSafetyTest, RcuValueMoveAssignment) {
+    rcu_value<int> a{30};
+    rcu_value<int> b{40};
+
+    b = std::move(a);
+
+    auto snap_b = b.read();
+    ASSERT_NE(snap_b, nullptr);
+    EXPECT_EQ(*snap_b, 30);
+}
+
+TEST_F(ContainerThreadSafetyTest, RcuValueSelfAssignment) {
+    rcu_value<int> val{42};
+
+    val = val;
+
+    auto snap = val.read();
+    ASSERT_NE(snap, nullptr);
+    EXPECT_EQ(*snap, 42);
+}
+
+TEST_F(ContainerThreadSafetyTest, RcuValueHasValue) {
+    rcu_value<int> val{0};
+    EXPECT_TRUE(val.has_value());
+
+    rcu_value<std::string> str{"test"};
+    EXPECT_TRUE(str.has_value());
+}
+
+TEST_F(ContainerThreadSafetyTest, RcuValueHasValueAfterUpdate) {
+    rcu_value<int> val{0};
+    EXPECT_TRUE(val.has_value());
+
+    val.update(100);
+    EXPECT_TRUE(val.has_value());
+}
+
+TEST_F(ContainerThreadSafetyTest, RcuValueConcurrentCASContention) {
+    rcu_value<int> counter{0};
+
+    constexpr int num_threads = 8;
+    constexpr int increments_per_thread = 1000;
+    std::atomic<int> success_count{0};
+    std::atomic<int> retry_count{0};
+    std::barrier sync_point(num_threads);
+
+    std::vector<std::thread> threads;
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back([&]() {
+            sync_point.arrive_and_wait();
+
+            for (int j = 0; j < increments_per_thread; ++j) {
+                bool done = false;
+                while (!done) {
+                    auto expected = counter.read();
+                    int new_val = *expected + 1;
+                    done = counter.compare_and_update(expected, new_val);
+                    if (!done) {
+                        retry_count.fetch_add(1);
+                    }
+                }
+                success_count.fetch_add(1);
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    // All increments should have succeeded
+    EXPECT_EQ(success_count.load(), num_threads * increments_per_thread);
+    // Final value should equal total increments
+    EXPECT_EQ(*counter.read(), num_threads * increments_per_thread);
+    // Under contention, there should be some retries
+    EXPECT_GT(retry_count.load(), 0);
+    // Update count should match successful CAS operations
+    EXPECT_EQ(counter.update_count(),
+              static_cast<size_t>(num_threads * increments_per_thread));
+}
+
+// =============================================================================
 // Auto-Refresh Reader Tests (Issue #262)
 // =============================================================================
 

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -1536,6 +1536,233 @@ TEST_F(ZeroCopyTest, MultipleValuesIndexing) {
 }
 
 // ============================================================================
+// Direct value_view API Tests (Issue #375)
+// ============================================================================
+
+class ValueViewDirectTest : public ::testing::Test {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+TEST_F(ValueViewDirectTest, NameReturnsKeyName) {
+    const char* name = "my_key";
+    const char* val = "hello";
+    value_view view(name, 6, val, 5, value_types::string_value);
+    EXPECT_EQ(view.name(), "my_key");
+}
+
+TEST_F(ValueViewDirectTest, IsNullForNullType) {
+    const char* name = "null_key";
+    value_view view(name, 8, nullptr, 0, value_types::null_value);
+    EXPECT_TRUE(view.is_null());
+}
+
+TEST_F(ValueViewDirectTest, IsNullFalseForNonNullType) {
+    const char* name = "key";
+    const char* val = "42";
+    value_view view(name, 3, val, 2, value_types::int_value);
+    EXPECT_FALSE(view.is_null());
+}
+
+TEST_F(ValueViewDirectTest, DataAndSizeAccessors) {
+    const char* name = "key";
+    const char* val = "test_data";
+    value_view view(name, 3, val, 9, value_types::string_value);
+
+    EXPECT_EQ(view.data(), val);
+    EXPECT_EQ(view.size(), 9u);
+}
+
+TEST_F(ValueViewDirectTest, AsBoolTruePatterns) {
+    const char* name = "flag";
+
+    const char* val_t = "t";
+    value_view view_t(name, 4, val_t, 1, value_types::bool_value);
+    auto result_t = view_t.as<bool>();
+    ASSERT_TRUE(result_t.has_value());
+    EXPECT_TRUE(*result_t);
+
+    const char* val_T = "T";
+    value_view view_T(name, 4, val_T, 1, value_types::bool_value);
+    auto result_T = view_T.as<bool>();
+    ASSERT_TRUE(result_T.has_value());
+    EXPECT_TRUE(*result_T);
+
+    const char* val_1 = "1";
+    value_view view_1(name, 4, val_1, 1, value_types::bool_value);
+    auto result_1 = view_1.as<bool>();
+    ASSERT_TRUE(result_1.has_value());
+    EXPECT_TRUE(*result_1);
+}
+
+TEST_F(ValueViewDirectTest, AsBoolFalsePatterns) {
+    const char* name = "flag";
+
+    const char* val_f = "f";
+    value_view view_f(name, 4, val_f, 1, value_types::bool_value);
+    auto result_f = view_f.as<bool>();
+    ASSERT_TRUE(result_f.has_value());
+    EXPECT_FALSE(*result_f);
+
+    const char* val_0 = "0";
+    value_view view_0(name, 4, val_0, 1, value_types::bool_value);
+    auto result_0 = view_0.as<bool>();
+    ASSERT_TRUE(result_0.has_value());
+    EXPECT_FALSE(*result_0);
+}
+
+TEST_F(ValueViewDirectTest, AsBoolNulloptForNonBoolType) {
+    const char* name = "val";
+    const char* val = "t";
+    value_view view(name, 3, val, 1, value_types::string_value);
+    EXPECT_FALSE(view.as<bool>().has_value());
+}
+
+TEST_F(ValueViewDirectTest, AsBoolNulloptForEmptyData) {
+    const char* name = "val";
+    value_view view(name, 3, nullptr, 0, value_types::bool_value);
+    EXPECT_FALSE(view.as<bool>().has_value());
+}
+
+TEST_F(ValueViewDirectTest, AsDoubleFromDoubleType) {
+    const char* name = "pi";
+    const char* val = "3.14159";
+    value_view view(name, 2, val, 7, value_types::double_value);
+
+    auto result = view.as<double>();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_NEAR(*result, 3.14159, 0.00001);
+}
+
+TEST_F(ValueViewDirectTest, AsDoubleFromFloatType) {
+    const char* name = "f";
+    const char* val = "2.5";
+    value_view view(name, 1, val, 3, value_types::float_value);
+
+    auto result = view.as<double>();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_NEAR(*result, 2.5, 0.001);
+}
+
+TEST_F(ValueViewDirectTest, AsFloatFromFloatType) {
+    const char* name = "f";
+    const char* val = "1.5";
+    value_view view(name, 1, val, 3, value_types::float_value);
+
+    auto result = view.as<float>();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_NEAR(*result, 1.5f, 0.001f);
+}
+
+TEST_F(ValueViewDirectTest, AsInt64FromIntType) {
+    const char* name = "big";
+    const char* val = "9876543210";
+    value_view view(name, 3, val, 10, value_types::llong_value);
+
+    auto result = view.as<int64_t>();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, 9876543210LL);
+}
+
+TEST_F(ValueViewDirectTest, AsUint32FromUintType) {
+    const char* name = "u";
+    const char* val = "42";
+    value_view view(name, 1, val, 2, value_types::uint_value);
+
+    auto result = view.as<uint32_t>();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, 42u);
+}
+
+TEST_F(ValueViewDirectTest, AsInt64FromShortType) {
+    const char* name = "s";
+    const char* val = "-100";
+    value_view view(name, 1, val, 4, value_types::short_value);
+
+    auto result = view.as<int64_t>();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, -100);
+}
+
+TEST_F(ValueViewDirectTest, TypeMismatchIntReturnsNullopt) {
+    const char* name = "s";
+    const char* val = "hello";
+    value_view view(name, 1, val, 5, value_types::string_value);
+
+    EXPECT_FALSE(view.as<int>().has_value());
+    EXPECT_FALSE(view.as<int64_t>().has_value());
+    EXPECT_FALSE(view.as<uint32_t>().has_value());
+}
+
+TEST_F(ValueViewDirectTest, TypeMismatchDoubleReturnsNullopt) {
+    const char* name = "s";
+    const char* val = "42";
+    value_view view(name, 1, val, 2, value_types::int_value);
+
+    EXPECT_FALSE(view.as<double>().has_value());
+    EXPECT_FALSE(view.as<float>().has_value());
+}
+
+TEST_F(ValueViewDirectTest, TypeMismatchStringReturnsNullopt) {
+    const char* name = "n";
+    const char* val = "42";
+    value_view view(name, 1, val, 2, value_types::int_value);
+
+    EXPECT_FALSE(view.as<std::string>().has_value());
+    EXPECT_FALSE(view.as<std::string_view>().has_value());
+}
+
+TEST_F(ValueViewDirectTest, AsStringViewFromStringType) {
+    const char* name = "k";
+    const char* val = "hello world";
+    value_view view(name, 1, val, 11, value_types::string_value);
+
+    auto result = view.as<std::string_view>();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "hello world");
+}
+
+TEST_F(ValueViewDirectTest, AsStringViewFromBytesType) {
+    const char* name = "b";
+    const char* val = "raw bytes";
+    value_view view(name, 1, val, 9, value_types::bytes_value);
+
+    auto result = view.as<std::string_view>();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, "raw bytes");
+}
+
+TEST_F(ValueViewDirectTest, EmptyIntegralDataReturnsNullopt) {
+    const char* name = "e";
+    value_view view(name, 1, "", 0, value_types::int_value);
+
+    EXPECT_FALSE(view.as<int>().has_value());
+}
+
+TEST_F(ValueViewDirectTest, EmptyFloatingDataReturnsNullopt) {
+    const char* name = "e";
+    value_view view(name, 1, "", 0, value_types::double_value);
+
+    EXPECT_FALSE(view.as<double>().has_value());
+}
+
+TEST_F(ValueViewDirectTest, ValueIndexEntryDefaultConstruction) {
+    value_index_entry entry;
+    EXPECT_EQ(entry.value_offset, 0u);
+    EXPECT_EQ(entry.value_length, 0u);
+    EXPECT_EQ(entry.type, value_types::null_value);
+}
+
+TEST_F(ValueViewDirectTest, ValueIndexEntryParameterizedConstruction) {
+    value_index_entry entry("mykey", 100, 50, value_types::string_value);
+    EXPECT_EQ(entry.name, "mykey");
+    EXPECT_EQ(entry.value_offset, 100u);
+    EXPECT_EQ(entry.value_length, 50u);
+    EXPECT_EQ(entry.type, value_types::string_value);
+}
+
+// ============================================================================
 // Batch Operation Tests (Issue #229)
 // ============================================================================
 


### PR DESCRIPTION
Closes #375

## Summary
- Add 12 new tests for `thread_pool_executor.h`: singleton API, RAII executor guard, awaitable protocol, and fallback thread execution path
- Add 23 new tests for `value_view.h`: direct API testing for `name()`, `is_null()`, `data()`, `size()`, all `as<T>()` specializations (bool, double, float, int64_t, uint32_t), type mismatch returning `nullopt`, and `value_index_entry` construction
- Add 6 new tests for `epoch_manager.h`: `current_epoch()` increment verification, `gc_count()`/`reclaimed_count()` tracking, typed `defer_delete<T>()`, nullptr handling, and multi-threaded test with 4 reader threads + 1 GC thread
- Add 9 new tests for `rcu_value.h`: default/copy/move constructors, copy/move assignment, self-assignment, `has_value()`, and concurrent CAS contention with 8 threads verifying atomicity

## Test Plan
- [x] All 12 thread_pool_executor tests pass
- [x] All 23 value_view direct tests pass
- [x] All 20 epoch_manager + rcu_value tests pass (6 existing + 6 new epoch + 9 new rcu - 1 existing overlap)
- [x] All 153 existing unit tests pass (LargeDataHandling crash is pre-existing on main)
- [x] All 52 thread_safety tests pass
- [x] Build succeeds with no new warnings