### PR TITLE
refactor(namespace): migrate container_module to kcenon::container

### DIFF
--- a/benchmarks/container_operations_bench.cpp
+++ b/benchmarks/container_operations_bench.cpp
@@ -37,7 +37,7 @@
 #include "core/container.h"
 #include "tests/test_compat.h"
 
-using namespace container_module;
+using namespace kcenon::container;
 
 static void BM_Container_Create(benchmark::State& state) {
     for (auto _ : state) {

--- a/benchmarks/epoch_manager_bench.cpp
+++ b/benchmarks/epoch_manager_bench.cpp
@@ -42,7 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 #include <atomic>
 
-using namespace container_module;
+using namespace kcenon::container;
 
 static void BM_EpochEnterExit(benchmark::State& state)
 {

--- a/benchmarks/memory_efficiency_bench.cpp
+++ b/benchmarks/memory_efficiency_bench.cpp
@@ -34,7 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "core/container.h"
 #include "tests/test_compat.h"
 
-using namespace container_module;
+using namespace kcenon::container;
 
 /**
  * @brief Benchmark memory footprint of containers with different value counts

--- a/benchmarks/rcu_value_bench.cpp
+++ b/benchmarks/rcu_value_bench.cpp
@@ -43,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <atomic>
 #include <string>
 
-using namespace container_module;
+using namespace kcenon::container;
 
 static void BM_RcuValueReadSingleThread(benchmark::State& state)
 {

--- a/benchmarks/serialization_bench.cpp
+++ b/benchmarks/serialization_bench.cpp
@@ -37,7 +37,7 @@
 #include "core/container.h"
 #include "tests/test_compat.h"
 
-using namespace container_module;
+using namespace kcenon::container;
 
 static void BM_Serialize_Small(benchmark::State& state) {
     auto c = std::make_shared<value_container>();

--- a/benchmarks/thread_scalability_bench.cpp
+++ b/benchmarks/thread_scalability_bench.cpp
@@ -44,7 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <vector>
 
-using namespace container_module;
+using namespace kcenon::container;
 
 // =============================================================================
 // Container creation scaling

--- a/benchmarks/value_operations_bench.cpp
+++ b/benchmarks/value_operations_bench.cpp
@@ -36,7 +36,7 @@
 #include <benchmark/benchmark.h>
 #include "core/container.h"
 
-using namespace container_module;
+using namespace kcenon::container;
 
 static void BM_Value_CreateString(benchmark::State& state) {
     for (auto _ : state) {

--- a/container.h
+++ b/container.h
@@ -39,12 +39,12 @@
  * #include <container.h>
  *
  * // Create a message buffer (preferred name for serializable containers)
- * container_module::message_buffer msg;
+ * kcenon::container::message_buffer msg;
  * msg.set("name", "Alice");
  * msg.set("age", 30);
  *
  * // value_container is still supported (legacy name)
- * container_module::value_container container;  // Same as message_buffer
+ * kcenon::container::value_container container;  // Same as message_buffer
  * @endcode
  *
  * @note Since v2.0.0, `message_buffer` is the preferred name for `value_container`.

--- a/core/concepts.h
+++ b/core/concepts.h
@@ -35,7 +35,7 @@ All rights reserved.
 #include <variant>
 #include <cstdint>
 
-namespace container_module {
+namespace kcenon::container {
 
 // Forward declarations
 class thread_safe_container;
@@ -242,4 +242,4 @@ concept ContainerValue =
     std::same_as<std::decay_t<T>, std::shared_ptr<thread_safe_container>>;
 
 } // namespace concepts
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/container.cpp
+++ b/core/container.cpp
@@ -53,7 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fstream>
 #include <unordered_set>
 
-namespace container_module
+namespace kcenon::container
 {
 	// Use integer constants instead of string_view to ensure cross-platform compatibility
 	// with fmt library formatting. Linux fmt has issues with string_view arguments.
@@ -1588,7 +1588,7 @@ void value_container::clear_validation_errors() noexcept
 		}
 
 		// Convert internal format enum to serializer format enum
-		auto serializer_fmt = static_cast<container_module::serialization_format>(
+		auto serializer_fmt = static_cast<kcenon::container::serialization_format>(
 			static_cast<int>(fmt));
 
 		// Use serializer factory to create appropriate serializer
@@ -2264,4 +2264,4 @@ void value_container::clear_validation_errors() noexcept
 			target_variable = std::string(target_value.substr(start, end - start + 1));
 		}
 	}
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/container.h
+++ b/core/container.h
@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * #include <container.h>
  * @endcode
  *
- * @see container_module::value_container
+ * @see kcenon::container::value_container
  */
 
 #pragma once
@@ -75,7 +75,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <optional>
 #include <span>
 
-namespace container_module
+namespace kcenon::container
 {
 	// =======================================================================
 	// Unified Getter API Types (Issue #309)
@@ -1195,7 +1195,7 @@ namespace container_module
 	 *
 	 * @code
 	 * // Recommended usage:
-	 * container_module::message_buffer msg;
+	 * kcenon::container::message_buffer msg;
 	 * msg.set("name", "John");
 	 * auto bytes = msg.serialize(serialization_format::json);
 	 * @endcode
@@ -1205,4 +1205,4 @@ namespace container_module
 	 */
 	using message_buffer = value_container;
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/container/error_codes.h
+++ b/core/container/error_codes.h
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /**
  * @file core/container/error_codes.h
- * @brief Standardized error codes for container_module Result<T> pattern
+ * @brief Standardized error codes for kcenon::container Result<T> pattern
  *
  * This header defines comprehensive error codes organized by category:
  * - Value operations (1xx): key_not_found, type_mismatch, etc.
@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * - Resource (4xx): memory_allocation_failed, file errors, etc.
  * - Thread safety (5xx): lock_acquisition_failed, concurrent_modification
  *
- * @see container_module::value_container
+ * @see kcenon::container::value_container
  * @since 2.0.0
  */
 
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string_view>
 #include <string>
 
-namespace container_module
+namespace kcenon::container
 {
 	/**
 	 * @brief Standardized error codes for container operations
@@ -327,4 +327,4 @@ namespace container_module
 
 	} // namespace error_codes
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/container/fwd.h
+++ b/core/container/fwd.h
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 #include <cstdint>
 
-namespace container_module
+namespace kcenon::container
 {
 	// Forward declaration of main container class
 	class value_container;
@@ -90,4 +90,12 @@ namespace container_module
 	/// @brief Shared pointer to message_buffer (preferred name)
 	using message_buffer_ptr = std::shared_ptr<message_buffer>;
 
-} // namespace container_module
+} // namespace kcenon::container
+
+// =======================================================================
+// Backward-Compatibility Namespace Alias (Issue #380, Phase 1)
+// Temporary alias for one release cycle to ease migration.
+// Downstream code using `container_module::` will continue to compile.
+// Remove after all downstream systems have migrated to kcenon::container.
+// =======================================================================
+namespace container_module = kcenon::container;

--- a/core/container/metrics.h
+++ b/core/container/metrics.h
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /**
  * @file core/container/metrics.h
- * @brief Detailed observability metrics for container_module
+ * @brief Detailed observability metrics for kcenon::container
  *
  * This header defines comprehensive metrics structures for monitoring
  * container operations, including:
@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * - Latency histograms (P50, P95, P99, P999)
  * - SIMD and cache efficiency metrics
  *
- * @see container_module::value_container
+ * @see kcenon::container::value_container
  * @since 2.1.0
  */
 
@@ -55,7 +55,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <algorithm>
 #include <mutex>
 
-namespace container_module
+namespace kcenon::container
 {
 	/**
 	 * @brief Operation counter metrics for container operations
@@ -692,4 +692,4 @@ namespace container_module
 		static inline std::atomic<bool> enabled_{false};
 	};
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/container/msgpack.h
+++ b/core/container/msgpack.h
@@ -62,7 +62,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdexcept>
 #include <optional>
 
-namespace container_module
+namespace kcenon::container
 {
 	/**
 	 * @brief MessagePack format type codes
@@ -985,7 +985,7 @@ namespace container_module
 		size_t offset_;
 	};
 
-} // namespace container_module
+} // namespace kcenon::container
 
 // Restore Windows macros
 #ifdef _WIN32

--- a/core/container/schema.h
+++ b/core/container/schema.h
@@ -52,7 +52,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * }
  * @endcode
  *
- * @see container_module::value_container
+ * @see kcenon::container::value_container
  * @since 2.0.0
  */
 
@@ -79,7 +79,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define SCHEMA_HAS_COMMON_RESULT CONTAINER_HAS_RESULT
 #endif
 
-namespace container_module
+namespace kcenon::container
 {
 	// Forward declarations
 	class value_container;
@@ -621,4 +621,4 @@ namespace container_module
 		std::vector<field_def> fields_;  ///< Field definitions
 	};
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/container/types.h
+++ b/core/container/types.h
@@ -54,7 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdint>
 #include <memory>
 
-namespace container_module
+namespace kcenon::container
 {
 	// Forward declaration
 	class value_container;
@@ -154,4 +154,4 @@ namespace container_module
 		}
 	};
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/container/variant_helpers.h
+++ b/core/container/variant_helpers.h
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string_view>
 #include <cstdio>
 
-namespace container_module
+namespace kcenon::container
 {
 	/**
 	 * @brief Helper functions for variant value manipulation
@@ -240,4 +240,4 @@ namespace container_module
 		}
 	} // namespace variant_helpers
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/container_schema.cpp
+++ b/core/container_schema.cpp
@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <algorithm>
 #include <cmath>
 
-namespace container_module
+namespace kcenon::container
 {
 	// =========================================================================
 	// Field Definition API
@@ -599,4 +599,4 @@ namespace container_module
 		return true;
 	}
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/optimized_container.h
+++ b/core/optimized_container.h
@@ -11,7 +11,7 @@ All rights reserved.
 #include <string_view>
 #include <unordered_map>
 
-namespace container_module {
+namespace kcenon::container {
 
 /**
  * @class optimized_container
@@ -283,4 +283,4 @@ private:
     std::unordered_map<std::string, std::vector<std::shared_ptr<value>>> value_index_;
 };
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/policy_container.h
+++ b/core/policy_container.h
@@ -71,7 +71,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <span>
 #include <type_traits>
 
-namespace container_module {
+namespace kcenon::container {
 
 /**
  * @class basic_value_container
@@ -633,4 +633,4 @@ static_assert(policy::StoragePolicy<policy::dynamic_storage_policy>,
 static_assert(policy::StoragePolicy<policy::indexed_storage_policy>,
     "indexed_storage_policy must satisfy StoragePolicy concept");
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/serializers/binary_serializer.cpp
+++ b/core/serializers/binary_serializer.cpp
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "utilities/core/convert_string.h"
 #include "utilities/core/formatter.h"
 
-namespace container_module
+namespace kcenon::container
 {
 
 namespace
@@ -162,4 +162,4 @@ std::string binary_serializer::serialize_to_string(const value_container& contai
 }
 #endif
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/serializers/binary_serializer.h
+++ b/core/serializers/binary_serializer.h
@@ -42,7 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "serializer_strategy.h"
 
-namespace container_module
+namespace kcenon::container
 {
 
 	/**
@@ -99,4 +99,4 @@ namespace container_module
 		}
 	};
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/serializers/json_serializer.cpp
+++ b/core/serializers/json_serializer.cpp
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../container/variant_helpers.h"
 #include "utilities/core/formatter.h"
 
-namespace container_module
+namespace kcenon::container
 {
 
 #if CONTAINER_HAS_RESULT
@@ -136,4 +136,4 @@ std::string json_serializer::serialize_to_string(const value_container& containe
 }
 #endif
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/serializers/json_serializer.h
+++ b/core/serializers/json_serializer.h
@@ -42,7 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "serializer_strategy.h"
 
-namespace container_module
+namespace kcenon::container
 {
 
 	/**
@@ -99,4 +99,4 @@ namespace container_module
 		}
 	};
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/serializers/msgpack_serializer.cpp
+++ b/core/serializers/msgpack_serializer.cpp
@@ -34,7 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../container.h"
 #include "../container/msgpack.h"
 
-namespace container_module
+namespace kcenon::container
 {
 
 #if CONTAINER_HAS_RESULT
@@ -237,4 +237,4 @@ msgpack_serializer::serialize(const value_container& container) const noexcept
 }
 #endif
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/serializers/msgpack_serializer.h
+++ b/core/serializers/msgpack_serializer.h
@@ -42,7 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "serializer_strategy.h"
 
-namespace container_module
+namespace kcenon::container
 {
 
 	/**
@@ -89,4 +89,4 @@ namespace container_module
 		}
 	};
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/serializers/serializer_factory.cpp
+++ b/core/serializers/serializer_factory.cpp
@@ -36,7 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "xml_serializer.h"
 #include "msgpack_serializer.h"
 
-namespace container_module
+namespace kcenon::container
 {
 
 std::unique_ptr<serializer_strategy>
@@ -80,4 +80,4 @@ bool serializer_factory::is_supported(serialization_format fmt) noexcept
 	}
 }
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/serializers/serializer_factory.h
+++ b/core/serializers/serializer_factory.h
@@ -45,7 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <memory>
 
-namespace container_module
+namespace kcenon::container
 {
 
 	/**
@@ -88,4 +88,4 @@ namespace container_module
 		serializer_factory() = delete;
 	};
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/serializers/serializer_strategy.h
+++ b/core/serializers/serializer_strategy.h
@@ -48,7 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Unified Result<T> integration (Issue #335)
 #include "../container/result_integration.h"
 
-namespace container_module
+namespace kcenon::container
 {
 	// Forward declaration
 	class value_container;
@@ -119,4 +119,4 @@ namespace container_module
 		serializer_strategy& operator=(serializer_strategy&&) = default;
 	};
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/serializers/xml_serializer.cpp
+++ b/core/serializers/xml_serializer.cpp
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../container/variant_helpers.h"
 #include "utilities/core/formatter.h"
 
-namespace container_module
+namespace kcenon::container
 {
 
 #if CONTAINER_HAS_RESULT
@@ -120,4 +120,4 @@ std::string xml_serializer::serialize_to_string(const value_container& container
 }
 #endif
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/serializers/xml_serializer.h
+++ b/core/serializers/xml_serializer.h
@@ -42,7 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "serializer_strategy.h"
 
-namespace container_module
+namespace kcenon::container
 {
 
 	/**
@@ -99,4 +99,4 @@ namespace container_module
 		}
 	};
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/simd_batch.h
+++ b/core/simd_batch.h
@@ -12,7 +12,7 @@
 #include <utility>
 #include <concepts>
 
-namespace container_module::core {
+namespace kcenon::container::core {
 
 /**
  * @brief Lightweight container enforcing trivially copyable payloads.
@@ -32,7 +32,7 @@ namespace container_module::core {
  *
  * @see Issue #320, #328 for the rename rationale
  */
-template<container_module::concepts::TriviallyCopyable TValue>
+template<kcenon::container::concepts::TriviallyCopyable TValue>
 class simd_batch {
 
 public:
@@ -70,7 +70,7 @@ private:
  * @brief Deprecated alias for simd_batch
  * @deprecated Use simd_batch instead. This alias will be removed in the next major version.
  */
-template<container_module::concepts::TriviallyCopyable TValue>
+template<kcenon::container::concepts::TriviallyCopyable TValue>
 using typed_container [[deprecated("Use simd_batch instead. See Issue #328.")]] = simd_batch<TValue>;
 
-} // namespace container_module::core
+} // namespace kcenon::container::core

--- a/core/storage_policy.h
+++ b/core/storage_policy.h
@@ -59,7 +59,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <algorithm>
 #include <cstddef>
 
-namespace container_module::policy {
+namespace kcenon::container::policy {
 
 /**
  * @concept StoragePolicy
@@ -681,4 +681,4 @@ static_assert(StoragePolicy<indexed_storage_policy>,
 // Note: static_storage_policy concept check requires specific type instantiation
 // Example: static_assert(StoragePolicy<static_storage_policy<int, double, std::string>>);
 
-} // namespace container_module::policy
+} // namespace kcenon::container::policy

--- a/core/value_store.cpp
+++ b/core/value_store.cpp
@@ -34,7 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdexcept>
 #include <cstring>
 
-namespace container_module {
+namespace kcenon::container {
 
 void value_store::add(const std::string& key, value val) {
     // Always acquire lock to eliminate TOCTOU vulnerability (see #190)
@@ -255,4 +255,4 @@ void value_store::reset_statistics() {
     write_count_.store(0, std::memory_order_relaxed);
 }
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/value_store.h
+++ b/core/value_store.h
@@ -43,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <atomic>
 #include <unordered_map>
 
-namespace container_module {
+namespace kcenon::container {
 
 /**
  * @brief Domain-agnostic value storage
@@ -203,4 +203,4 @@ private:
     mutable std::atomic<size_t> write_count_{0};
 };
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/value_types.cpp
+++ b/core/value_types.cpp
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "value_types.h"
 
-namespace container_module
+namespace kcenon::container
 {
 	value_types convert_value_type(const std::string& target)
 	{
@@ -45,4 +45,4 @@ namespace container_module
 		// Use the constexpr function and convert to std::string
 		return std::string(get_string_from_type(target));
 	}
-} // namespace container_module
+} // namespace kcenon::container

--- a/core/value_types.h
+++ b/core/value_types.h
@@ -36,7 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <string_view>
 
-namespace container_module
+namespace kcenon::container
 {
 	/**
 	 * @brief Enumeration of available value types in the container system.
@@ -110,4 +110,4 @@ namespace container_module
 	value_types convert_value_type(const std::string& target);
 	std::string convert_value_type(const value_types& target);
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/examples/advanced_container_example.cpp
+++ b/examples/advanced_container_example.cpp
@@ -41,7 +41,7 @@
 
 #include "container.h"
 
-using namespace container_module;
+using namespace kcenon::container;
 
 /**
  * @brief Advanced Container System Example

--- a/examples/asio_integration_example.cpp
+++ b/examples/asio_integration_example.cpp
@@ -67,7 +67,7 @@
 #include "internal/async/async.h"
 #endif
 
-using namespace container_module;
+using namespace kcenon::container;
 
 /**
  * @brief Helper to print section headers
@@ -339,7 +339,7 @@ void demonstrate_message_queue() {
 
 #if CONTAINER_HAS_COROUTINES && (defined(HAS_STANDALONE_ASIO) || defined(HAS_BOOST_ASIO))
 
-using namespace container_module::async;
+using namespace kcenon::container::async;
 
 /**
  * @brief Demonstrate mixing container coroutines with Asio

--- a/examples/async_coroutine_example.cpp
+++ b/examples/async_coroutine_example.cpp
@@ -52,7 +52,7 @@
 #include "internal/async/async.h"
 #endif
 
-using namespace container_module;
+using namespace kcenon::container;
 
 /**
  * @brief Helper to print section headers
@@ -79,7 +79,7 @@ void print_error(const std::string& message) {
 
 #if CONTAINER_HAS_COROUTINES
 
-using namespace container_module::async;
+using namespace kcenon::container::async;
 
 /**
  * @brief Demonstrate basic async serialization

--- a/examples/basic_container_example.cpp
+++ b/examples/basic_container_example.cpp
@@ -35,7 +35,7 @@
 
 #include "container.h"
 
-using namespace container_module;
+using namespace kcenon::container;
 
 /**
  * @brief Basic Container System Example

--- a/examples/iterator_example.cpp
+++ b/examples/iterator_example.cpp
@@ -42,7 +42,7 @@
 #include <iostream>
 #include <numeric>
 
-using namespace container_module;
+using namespace kcenon::container;
 
 void demonstrate_range_based_for()
 {

--- a/examples/messaging_integration_example.cpp
+++ b/examples/messaging_integration_example.cpp
@@ -47,7 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Include the container system
 #include "container.h"
 
-using namespace container_module;
+using namespace kcenon::container;
 
 void demonstrate_basic_usage() {
     std::cout << "\n=== Basic Container Usage ===\n";

--- a/examples/real_world_scenarios.cpp
+++ b/examples/real_world_scenarios.cpp
@@ -44,7 +44,7 @@
 
 #include "container.h"
 
-using namespace container_module;
+using namespace kcenon::container;
 
 /**
  * @brief Real-world scenarios demonstrating practical usage of the container system

--- a/fuzz/fuzz_container_deserialize.cpp
+++ b/fuzz/fuzz_container_deserialize.cpp
@@ -12,7 +12,7 @@
 
 #include "internal/thread_safe_container.h"
 
-using namespace container_module;
+using namespace kcenon::container;
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     // Create input vector from fuzzer data

--- a/fuzz/fuzz_deserialize.cpp
+++ b/fuzz/fuzz_deserialize.cpp
@@ -12,7 +12,7 @@
 
 #include "internal/value.h"
 
-using namespace container_module;
+using namespace kcenon::container;
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     // Create input vector from fuzzer data

--- a/grpc/adapters/container_adapter.cpp
+++ b/grpc/adapters/container_adapter.cpp
@@ -37,18 +37,18 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdexcept>
 #include <algorithm>
 
-namespace container_grpc {
+namespace kcenon::container_grpc {
 
 // =============================================================================
 // Container Conversion (Main API)
 // =============================================================================
 
 GrpcContainer container_adapter::to_grpc(
-    const container_module::value_container& container) {
+    const kcenon::container::value_container& container) {
     return to_grpc_recursive(container, 0);
 }
 
-std::shared_ptr<container_module::value_container>
+std::shared_ptr<kcenon::container::value_container>
 container_adapter::from_grpc(const GrpcContainer& grpc_container) {
     return from_grpc_recursive(grpc_container, 0);
 }
@@ -58,7 +58,7 @@ container_adapter::from_grpc(const GrpcContainer& grpc_container) {
 // =============================================================================
 
 GrpcValue container_adapter::to_grpc_value(
-    const container_module::optimized_value& value) {
+    const kcenon::container::optimized_value& value) {
     GrpcValue grpc_value;
     grpc_value.set_name(value.name);
     grpc_value.set_type(to_grpc_type(value.type));
@@ -66,9 +66,9 @@ GrpcValue container_adapter::to_grpc_value(
     return grpc_value;
 }
 
-container_module::optimized_value
+kcenon::container::optimized_value
 container_adapter::from_grpc_value(const GrpcValue& grpc_value) {
-    container_module::optimized_value value;
+    kcenon::container::optimized_value value;
     value.name = grpc_value.name();
     value.type = from_grpc_type(grpc_value.type());
     value.data = get_variant_from_grpc(grpc_value, value.type);
@@ -79,13 +79,13 @@ container_adapter::from_grpc_value(const GrpcValue& grpc_value) {
 // Type Mapping
 // =============================================================================
 
-ValueType container_adapter::to_grpc_type(container_module::value_types type) {
+ValueType container_adapter::to_grpc_type(kcenon::container::value_types type) {
     return static_cast<ValueType>(static_cast<int>(type));
 }
 
-container_module::value_types
+kcenon::container::value_types
 container_adapter::from_grpc_type(ValueType type) {
-    return static_cast<container_module::value_types>(static_cast<int>(type));
+    return static_cast<kcenon::container::value_types>(static_cast<int>(type));
 }
 
 // =============================================================================
@@ -93,19 +93,19 @@ container_adapter::from_grpc_type(ValueType type) {
 // =============================================================================
 
 bool container_adapter::can_convert(
-    const container_module::value_container& container) noexcept {
+    const kcenon::container::value_container& container) noexcept {
     try {
         for (const auto& val : container) {
             if (!value_mapper::is_supported(val.type)) {
                 return false;
             }
             // Check for nested containers recursively
-            if (val.type == container_module::value_types::container_value) {
+            if (val.type == kcenon::container::value_types::container_value) {
                 if (std::holds_alternative<
-                        std::shared_ptr<container_module::value_container>>(
+                        std::shared_ptr<kcenon::container::value_container>>(
                         val.data)) {
                     auto nested = std::get<
-                        std::shared_ptr<container_module::value_container>>(
+                        std::shared_ptr<kcenon::container::value_container>>(
                         val.data);
                     if (nested && !can_convert(*nested)) {
                         return false;
@@ -146,141 +146,141 @@ bool container_adapter::can_convert(
 
 void container_adapter::set_grpc_value_data(
     GrpcValue& grpc_value,
-    const container_module::value_variant& data,
-    container_module::value_types type) {
+    const kcenon::container::value_variant& data,
+    kcenon::container::value_types type) {
 
     switch (type) {
-        case container_module::value_types::null_value:
+        case kcenon::container::value_types::null_value:
             grpc_value.set_null_flag(true);
             break;
 
-        case container_module::value_types::bool_value:
+        case kcenon::container::value_types::bool_value:
             grpc_value.set_bool_val(std::get<bool>(data));
             break;
 
-        case container_module::value_types::short_value:
+        case kcenon::container::value_types::short_value:
             grpc_value.set_short_val(std::get<short>(data));
             break;
 
-        case container_module::value_types::ushort_value:
+        case kcenon::container::value_types::ushort_value:
             grpc_value.set_ushort_val(std::get<unsigned short>(data));
             break;
 
-        case container_module::value_types::int_value:
+        case kcenon::container::value_types::int_value:
             grpc_value.set_int_val(std::get<int>(data));
             break;
 
-        case container_module::value_types::uint_value:
+        case kcenon::container::value_types::uint_value:
             grpc_value.set_uint_val(std::get<unsigned int>(data));
             break;
 
-        case container_module::value_types::long_value:
+        case kcenon::container::value_types::long_value:
             grpc_value.set_long_val(std::get<long>(data));
             break;
 
-        case container_module::value_types::ulong_value:
+        case kcenon::container::value_types::ulong_value:
             grpc_value.set_ulong_val(std::get<unsigned long>(data));
             break;
 
-        case container_module::value_types::llong_value:
+        case kcenon::container::value_types::llong_value:
             grpc_value.set_llong_val(std::get<long long>(data));
             break;
 
-        case container_module::value_types::ullong_value:
+        case kcenon::container::value_types::ullong_value:
             grpc_value.set_ullong_val(std::get<unsigned long long>(data));
             break;
 
-        case container_module::value_types::float_value:
+        case kcenon::container::value_types::float_value:
             grpc_value.set_float_val(std::get<float>(data));
             break;
 
-        case container_module::value_types::double_value:
+        case kcenon::container::value_types::double_value:
             grpc_value.set_double_val(std::get<double>(data));
             break;
 
-        case container_module::value_types::string_value:
+        case kcenon::container::value_types::string_value:
             grpc_value.set_string_val(std::get<std::string>(data));
             break;
 
-        case container_module::value_types::bytes_value: {
+        case kcenon::container::value_types::bytes_value: {
             const auto& bytes = std::get<std::vector<uint8_t>>(data);
             grpc_value.set_bytes_val(bytes.data(), bytes.size());
             break;
         }
 
-        case container_module::value_types::container_value: {
+        case kcenon::container::value_types::container_value: {
             auto nested = std::get<
-                std::shared_ptr<container_module::value_container>>(data);
+                std::shared_ptr<kcenon::container::value_container>>(data);
             if (nested) {
                 *grpc_value.mutable_container_val() = to_grpc(*nested);
             }
             break;
         }
 
-        case container_module::value_types::array_value:
+        case kcenon::container::value_types::array_value:
             // Array values would need special handling
             // For now, we handle arrays in future iterations
             break;
     }
 }
 
-container_module::value_variant container_adapter::get_variant_from_grpc(
+kcenon::container::value_variant container_adapter::get_variant_from_grpc(
     const GrpcValue& grpc_value,
-    container_module::value_types type) {
+    kcenon::container::value_types type) {
 
     switch (type) {
-        case container_module::value_types::null_value:
+        case kcenon::container::value_types::null_value:
             return std::monostate{};
 
-        case container_module::value_types::bool_value:
+        case kcenon::container::value_types::bool_value:
             return grpc_value.bool_val();
 
-        case container_module::value_types::short_value:
+        case kcenon::container::value_types::short_value:
             return static_cast<short>(grpc_value.short_val());
 
-        case container_module::value_types::ushort_value:
+        case kcenon::container::value_types::ushort_value:
             return static_cast<unsigned short>(grpc_value.ushort_val());
 
-        case container_module::value_types::int_value:
+        case kcenon::container::value_types::int_value:
             return grpc_value.int_val();
 
-        case container_module::value_types::uint_value:
+        case kcenon::container::value_types::uint_value:
             return grpc_value.uint_val();
 
-        case container_module::value_types::long_value:
+        case kcenon::container::value_types::long_value:
             return static_cast<long>(grpc_value.long_val());
 
-        case container_module::value_types::ulong_value:
+        case kcenon::container::value_types::ulong_value:
             return static_cast<unsigned long>(grpc_value.ulong_val());
 
-        case container_module::value_types::llong_value:
+        case kcenon::container::value_types::llong_value:
             return static_cast<long long>(grpc_value.llong_val());
 
-        case container_module::value_types::ullong_value:
+        case kcenon::container::value_types::ullong_value:
             return static_cast<unsigned long long>(grpc_value.ullong_val());
 
-        case container_module::value_types::float_value:
+        case kcenon::container::value_types::float_value:
             return grpc_value.float_val();
 
-        case container_module::value_types::double_value:
+        case kcenon::container::value_types::double_value:
             return grpc_value.double_val();
 
-        case container_module::value_types::string_value:
+        case kcenon::container::value_types::string_value:
             return grpc_value.string_val();
 
-        case container_module::value_types::bytes_value: {
+        case kcenon::container::value_types::bytes_value: {
             const auto& bytes_str = grpc_value.bytes_val();
             return std::vector<uint8_t>(bytes_str.begin(), bytes_str.end());
         }
 
-        case container_module::value_types::container_value: {
+        case kcenon::container::value_types::container_value: {
             if (grpc_value.has_container_val()) {
                 return from_grpc(grpc_value.container_val());
             }
-            return std::shared_ptr<container_module::value_container>{};
+            return std::shared_ptr<kcenon::container::value_container>{};
         }
 
-        case container_module::value_types::array_value:
+        case kcenon::container::value_types::array_value:
             // Array values would need special handling
             return std::monostate{};
 
@@ -290,7 +290,7 @@ container_module::value_variant container_adapter::get_variant_from_grpc(
 }
 
 GrpcContainer container_adapter::to_grpc_recursive(
-    const container_module::value_container& container,
+    const kcenon::container::value_container& container,
     int depth) {
     if (depth > MAX_NESTING_DEPTH) {
         throw std::runtime_error(
@@ -313,10 +313,10 @@ GrpcContainer container_adapter::to_grpc_recursive(
         grpc_val->set_name(val.name);
         grpc_val->set_type(to_grpc_type(val.type));
 
-        if (val.type == container_module::value_types::container_value) {
+        if (val.type == kcenon::container::value_types::container_value) {
             // Handle nested containers with depth tracking
             auto nested = std::get<
-                std::shared_ptr<container_module::value_container>>(val.data);
+                std::shared_ptr<kcenon::container::value_container>>(val.data);
             if (nested) {
                 *grpc_val->mutable_container_val() =
                     to_grpc_recursive(*nested, depth + 1);
@@ -329,7 +329,7 @@ GrpcContainer container_adapter::to_grpc_recursive(
     return grpc_container;
 }
 
-std::shared_ptr<container_module::value_container>
+std::shared_ptr<kcenon::container::value_container>
 container_adapter::from_grpc_recursive(
     const GrpcContainer& grpc_container,
     int depth) {
@@ -338,7 +338,7 @@ container_adapter::from_grpc_recursive(
             "Maximum nesting depth exceeded during conversion from gRPC");
     }
 
-    auto container = std::make_shared<container_module::value_container>();
+    auto container = std::make_shared<kcenon::container::value_container>();
 
     // Set header fields
     container->set_source(grpc_container.source_id(),
@@ -351,17 +351,17 @@ container_adapter::from_grpc_recursive(
     for (const auto& grpc_val : grpc_container.values()) {
         auto type = from_grpc_type(grpc_val.type());
 
-        if (type == container_module::value_types::container_value) {
+        if (type == kcenon::container::value_types::container_value) {
             // Handle nested containers with depth tracking
             if (grpc_val.has_container_val()) {
                 auto nested =
                     from_grpc_recursive(grpc_val.container_val(), depth + 1);
                 container->set(grpc_val.name(),
-                    std::shared_ptr<container_module::value_container>(nested));
+                    std::shared_ptr<kcenon::container::value_container>(nested));
             }
         } else {
             auto data = get_variant_from_grpc(grpc_val, type);
-            container_module::optimized_value val;
+            kcenon::container::optimized_value val;
             val.name = grpc_val.name();
             val.type = type;
             val.data = data;
@@ -377,39 +377,39 @@ container_adapter::from_grpc_recursive(
 // =============================================================================
 
 const char* value_mapper::type_name(
-    container_module::value_types type) noexcept {
+    kcenon::container::value_types type) noexcept {
     switch (type) {
-        case container_module::value_types::null_value:
+        case kcenon::container::value_types::null_value:
             return "null";
-        case container_module::value_types::bool_value:
+        case kcenon::container::value_types::bool_value:
             return "bool";
-        case container_module::value_types::short_value:
+        case kcenon::container::value_types::short_value:
             return "short";
-        case container_module::value_types::ushort_value:
+        case kcenon::container::value_types::ushort_value:
             return "ushort";
-        case container_module::value_types::int_value:
+        case kcenon::container::value_types::int_value:
             return "int";
-        case container_module::value_types::uint_value:
+        case kcenon::container::value_types::uint_value:
             return "uint";
-        case container_module::value_types::long_value:
+        case kcenon::container::value_types::long_value:
             return "long";
-        case container_module::value_types::ulong_value:
+        case kcenon::container::value_types::ulong_value:
             return "ulong";
-        case container_module::value_types::llong_value:
+        case kcenon::container::value_types::llong_value:
             return "llong";
-        case container_module::value_types::ullong_value:
+        case kcenon::container::value_types::ullong_value:
             return "ullong";
-        case container_module::value_types::float_value:
+        case kcenon::container::value_types::float_value:
             return "float";
-        case container_module::value_types::double_value:
+        case kcenon::container::value_types::double_value:
             return "double";
-        case container_module::value_types::string_value:
+        case kcenon::container::value_types::string_value:
             return "string";
-        case container_module::value_types::bytes_value:
+        case kcenon::container::value_types::bytes_value:
             return "bytes";
-        case container_module::value_types::container_value:
+        case kcenon::container::value_types::container_value:
             return "container";
-        case container_module::value_types::array_value:
+        case kcenon::container::value_types::array_value:
             return "array";
         default:
             return "unknown";
@@ -460,32 +460,32 @@ const char* value_mapper::proto_type_name(ValueType type) noexcept {
 // =============================================================================
 
 size_t size_calculator::estimate_proto_size(
-    container_module::value_types type,
+    kcenon::container::value_types type,
     size_t data_size) noexcept {
     // Base overhead for field tag and type
     constexpr size_t base_overhead = 3;
 
     switch (type) {
-        case container_module::value_types::null_value:
+        case kcenon::container::value_types::null_value:
             return base_overhead + 1;
-        case container_module::value_types::bool_value:
+        case kcenon::container::value_types::bool_value:
             return base_overhead + 1;
-        case container_module::value_types::short_value:
-        case container_module::value_types::ushort_value:
-        case container_module::value_types::int_value:
-        case container_module::value_types::uint_value:
+        case kcenon::container::value_types::short_value:
+        case kcenon::container::value_types::ushort_value:
+        case kcenon::container::value_types::int_value:
+        case kcenon::container::value_types::uint_value:
             return base_overhead + 5;  // varint
-        case container_module::value_types::long_value:
-        case container_module::value_types::ulong_value:
-        case container_module::value_types::llong_value:
-        case container_module::value_types::ullong_value:
+        case kcenon::container::value_types::long_value:
+        case kcenon::container::value_types::ulong_value:
+        case kcenon::container::value_types::llong_value:
+        case kcenon::container::value_types::ullong_value:
             return base_overhead + 10;  // varint
-        case container_module::value_types::float_value:
+        case kcenon::container::value_types::float_value:
             return base_overhead + 4;
-        case container_module::value_types::double_value:
+        case kcenon::container::value_types::double_value:
             return base_overhead + 8;
-        case container_module::value_types::string_value:
-        case container_module::value_types::bytes_value:
+        case kcenon::container::value_types::string_value:
+        case kcenon::container::value_types::bytes_value:
             return base_overhead + data_size + 2;  // length prefix
         default:
             return base_overhead + data_size;
@@ -505,4 +505,4 @@ size_t size_calculator::estimate_container_size(
     return header_overhead + (value_count * per_value);
 }
 
-} // namespace container_grpc
+} // namespace kcenon::container_grpc

--- a/grpc/adapters/container_adapter.h
+++ b/grpc/adapters/container_adapter.h
@@ -34,7 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /**
  * @file container_adapter.h
- * @brief Adapter layer for converting between container_module types and gRPC proto messages
+ * @brief Adapter layer for converting between kcenon::container types and gRPC proto messages
  *
  * This adapter provides a clean separation between the existing container system
  * and the gRPC protocol layer. It uses read-only access to existing container
@@ -42,7 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * Design Principles:
  * - Pure adapter pattern: No modifications to existing code
- * - Read-only access to container_module types
+ * - Read-only access to kcenon::container types
  * - Stateless conversion functions
  * - Zero runtime overhead when not using gRPC
  */
@@ -56,18 +56,18 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <optional>
 
 // Forward declare proto types to avoid including generated headers in public API
-namespace container_grpc {
+namespace kcenon::container_grpc {
 class GrpcValue;
 class GrpcArray;
 class GrpcContainer;
 enum ValueType : int;
 }
 
-namespace container_grpc {
+namespace kcenon::container_grpc {
 
 /**
  * @class container_adapter
- * @brief Bidirectional adapter between container_module and gRPC proto messages
+ * @brief Bidirectional adapter between kcenon::container and gRPC proto messages
  *
  * This class provides static methods for converting between native container
  * types and Protocol Buffer messages. All methods are stateless and thread-safe.
@@ -75,7 +75,7 @@ namespace container_grpc {
  * Usage:
  * @code
  *   // Convert native container to proto (for sending)
- *   auto native = std::make_shared<container_module::value_container>();
+ *   auto native = std::make_shared<kcenon::container::value_container>();
  *   native->set_message_type("request");
  *   native->set_value("count", 42);
  *
@@ -101,7 +101,7 @@ public:
      * This method reads all data from the container and creates an equivalent
      * proto message. The original container is not modified.
      */
-    static GrpcContainer to_grpc(const container_module::value_container& container);
+    static GrpcContainer to_grpc(const kcenon::container::value_container& container);
 
     /**
      * @brief Convert GrpcContainer proto message to native value_container
@@ -112,7 +112,7 @@ public:
      * This method creates a new value_container and populates it with data
      * from the proto message.
      */
-    static std::shared_ptr<container_module::value_container>
+    static std::shared_ptr<kcenon::container::value_container>
     from_grpc(const GrpcContainer& grpc_container);
 
     // =========================================================================
@@ -125,7 +125,7 @@ public:
      * @return GrpcValue proto message
      * @throws std::runtime_error if value type is not supported
      */
-    static GrpcValue to_grpc_value(const container_module::optimized_value& value);
+    static GrpcValue to_grpc_value(const kcenon::container::optimized_value& value);
 
     /**
      * @brief Convert GrpcValue proto message to optimized_value
@@ -133,7 +133,7 @@ public:
      * @return Native optimized_value
      * @throws std::runtime_error if proto type is not supported
      */
-    static container_module::optimized_value
+    static kcenon::container::optimized_value
     from_grpc_value(const GrpcValue& grpc_value);
 
     // =========================================================================
@@ -145,14 +145,14 @@ public:
      * @param type Native type enumeration
      * @return Corresponding proto ValueType enumeration
      */
-    static ValueType to_grpc_type(container_module::value_types type);
+    static ValueType to_grpc_type(kcenon::container::value_types type);
 
     /**
      * @brief Convert proto ValueType to native value_types
      * @param type Proto type enumeration
      * @return Corresponding native value_types enumeration
      */
-    static container_module::value_types from_grpc_type(ValueType type);
+    static kcenon::container::value_types from_grpc_type(ValueType type);
 
     // =========================================================================
     // Validation
@@ -165,7 +165,7 @@ public:
      *
      * Checks for unsupported types, circular references, etc.
      */
-    static bool can_convert(const container_module::value_container& container) noexcept;
+    static bool can_convert(const kcenon::container::value_container& container) noexcept;
 
     /**
      * @brief Validate that a proto message can be converted to native
@@ -184,27 +184,27 @@ private:
      */
     static void set_grpc_value_data(
         GrpcValue& grpc_value,
-        const container_module::value_variant& data,
-        container_module::value_types type);
+        const kcenon::container::value_variant& data,
+        kcenon::container::value_types type);
 
     /**
      * @brief Extract data from proto value to value_variant
      */
-    static container_module::value_variant get_variant_from_grpc(
+    static kcenon::container::value_variant get_variant_from_grpc(
         const GrpcValue& grpc_value,
-        container_module::value_types type);
+        kcenon::container::value_types type);
 
     /**
      * @brief Handle nested container conversion to avoid stack overflow
      */
     static GrpcContainer to_grpc_recursive(
-        const container_module::value_container& container,
+        const kcenon::container::value_container& container,
         int depth);
 
     /**
      * @brief Handle nested container conversion from proto
      */
-    static std::shared_ptr<container_module::value_container>
+    static std::shared_ptr<kcenon::container::value_container>
     from_grpc_recursive(const GrpcContainer& grpc_container, int depth);
 
     // Maximum nesting depth to prevent stack overflow
@@ -213,7 +213,7 @@ private:
 
 /**
  * @class value_mapper
- * @brief Type mapping utilities between container_module and proto types
+ * @brief Type mapping utilities between kcenon::container and proto types
  *
  * This class provides compile-time and runtime type mapping between
  * the native container value types and Protocol Buffer types.
@@ -225,24 +225,24 @@ public:
      * @param type The native value type
      * @return true if type can be converted to proto
      */
-    static constexpr bool is_supported(container_module::value_types type) noexcept {
+    static constexpr bool is_supported(kcenon::container::value_types type) noexcept {
         switch (type) {
-            case container_module::value_types::null_value:
-            case container_module::value_types::bool_value:
-            case container_module::value_types::short_value:
-            case container_module::value_types::ushort_value:
-            case container_module::value_types::int_value:
-            case container_module::value_types::uint_value:
-            case container_module::value_types::long_value:
-            case container_module::value_types::ulong_value:
-            case container_module::value_types::llong_value:
-            case container_module::value_types::ullong_value:
-            case container_module::value_types::float_value:
-            case container_module::value_types::double_value:
-            case container_module::value_types::string_value:
-            case container_module::value_types::bytes_value:
-            case container_module::value_types::container_value:
-            case container_module::value_types::array_value:
+            case kcenon::container::value_types::null_value:
+            case kcenon::container::value_types::bool_value:
+            case kcenon::container::value_types::short_value:
+            case kcenon::container::value_types::ushort_value:
+            case kcenon::container::value_types::int_value:
+            case kcenon::container::value_types::uint_value:
+            case kcenon::container::value_types::long_value:
+            case kcenon::container::value_types::ulong_value:
+            case kcenon::container::value_types::llong_value:
+            case kcenon::container::value_types::ullong_value:
+            case kcenon::container::value_types::float_value:
+            case kcenon::container::value_types::double_value:
+            case kcenon::container::value_types::string_value:
+            case kcenon::container::value_types::bytes_value:
+            case kcenon::container::value_types::container_value:
+            case kcenon::container::value_types::array_value:
                 return true;
             default:
                 return false;
@@ -254,7 +254,7 @@ public:
      * @param type The native value type
      * @return String representation of the type
      */
-    static const char* type_name(container_module::value_types type) noexcept;
+    static const char* type_name(kcenon::container::value_types type) noexcept;
 
     /**
      * @brief Get proto type name for debugging
@@ -264,4 +264,8 @@ public:
     static const char* proto_type_name(ValueType type) noexcept;
 };
 
-} // namespace container_grpc
+} // namespace kcenon::container_grpc
+
+// Backward-compatibility alias (Issue #380, Phase 1)
+// Remove after downstream migration to kcenon::container_grpc.
+namespace container_grpc = kcenon::container_grpc;

--- a/grpc/adapters/value_mapper.h
+++ b/grpc/adapters/value_mapper.h
@@ -34,7 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /**
  * @file value_mapper.h
- * @brief Type mapping utilities for container_module <-> gRPC proto conversion
+ * @brief Type mapping utilities for kcenon::container <-> gRPC proto conversion
  *
  * This header provides compile-time and runtime type mapping between native
  * container value types and Protocol Buffer types. It ensures type-safe
@@ -51,15 +51,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 
 // Forward declarations
-namespace container_grpc {
+namespace kcenon::container_grpc {
 enum ValueType : int;
 }
 
-namespace container_module {
+namespace kcenon::container {
 class value_container;
 }
 
-namespace container_grpc {
+namespace kcenon::container_grpc {
 
 /**
  * @brief Compile-time type traits for value mapping
@@ -81,106 +81,106 @@ struct native_to_proto_type {
 template<>
 struct native_to_proto_type<std::monostate> {
     static constexpr bool supported = true;
-    static constexpr container_module::value_types native_type =
-        container_module::value_types::null_value;
+    static constexpr kcenon::container::value_types native_type =
+        kcenon::container::value_types::null_value;
 };
 
 template<>
 struct native_to_proto_type<bool> {
     static constexpr bool supported = true;
-    static constexpr container_module::value_types native_type =
-        container_module::value_types::bool_value;
+    static constexpr kcenon::container::value_types native_type =
+        kcenon::container::value_types::bool_value;
 };
 
 template<>
 struct native_to_proto_type<short> {
     static constexpr bool supported = true;
-    static constexpr container_module::value_types native_type =
-        container_module::value_types::short_value;
+    static constexpr kcenon::container::value_types native_type =
+        kcenon::container::value_types::short_value;
 };
 
 template<>
 struct native_to_proto_type<unsigned short> {
     static constexpr bool supported = true;
-    static constexpr container_module::value_types native_type =
-        container_module::value_types::ushort_value;
+    static constexpr kcenon::container::value_types native_type =
+        kcenon::container::value_types::ushort_value;
 };
 
 template<>
 struct native_to_proto_type<int> {
     static constexpr bool supported = true;
-    static constexpr container_module::value_types native_type =
-        container_module::value_types::int_value;
+    static constexpr kcenon::container::value_types native_type =
+        kcenon::container::value_types::int_value;
 };
 
 template<>
 struct native_to_proto_type<unsigned int> {
     static constexpr bool supported = true;
-    static constexpr container_module::value_types native_type =
-        container_module::value_types::uint_value;
+    static constexpr kcenon::container::value_types native_type =
+        kcenon::container::value_types::uint_value;
 };
 
 template<>
 struct native_to_proto_type<long> {
     static constexpr bool supported = true;
-    static constexpr container_module::value_types native_type =
-        container_module::value_types::long_value;
+    static constexpr kcenon::container::value_types native_type =
+        kcenon::container::value_types::long_value;
 };
 
 template<>
 struct native_to_proto_type<unsigned long> {
     static constexpr bool supported = true;
-    static constexpr container_module::value_types native_type =
-        container_module::value_types::ulong_value;
+    static constexpr kcenon::container::value_types native_type =
+        kcenon::container::value_types::ulong_value;
 };
 
 template<>
 struct native_to_proto_type<long long> {
     static constexpr bool supported = true;
-    static constexpr container_module::value_types native_type =
-        container_module::value_types::llong_value;
+    static constexpr kcenon::container::value_types native_type =
+        kcenon::container::value_types::llong_value;
 };
 
 template<>
 struct native_to_proto_type<unsigned long long> {
     static constexpr bool supported = true;
-    static constexpr container_module::value_types native_type =
-        container_module::value_types::ullong_value;
+    static constexpr kcenon::container::value_types native_type =
+        kcenon::container::value_types::ullong_value;
 };
 
 template<>
 struct native_to_proto_type<float> {
     static constexpr bool supported = true;
-    static constexpr container_module::value_types native_type =
-        container_module::value_types::float_value;
+    static constexpr kcenon::container::value_types native_type =
+        kcenon::container::value_types::float_value;
 };
 
 template<>
 struct native_to_proto_type<double> {
     static constexpr bool supported = true;
-    static constexpr container_module::value_types native_type =
-        container_module::value_types::double_value;
+    static constexpr kcenon::container::value_types native_type =
+        kcenon::container::value_types::double_value;
 };
 
 template<>
 struct native_to_proto_type<std::string> {
     static constexpr bool supported = true;
-    static constexpr container_module::value_types native_type =
-        container_module::value_types::string_value;
+    static constexpr kcenon::container::value_types native_type =
+        kcenon::container::value_types::string_value;
 };
 
 template<>
 struct native_to_proto_type<std::vector<uint8_t>> {
     static constexpr bool supported = true;
-    static constexpr container_module::value_types native_type =
-        container_module::value_types::bytes_value;
+    static constexpr kcenon::container::value_types native_type =
+        kcenon::container::value_types::bytes_value;
 };
 
 template<>
-struct native_to_proto_type<std::shared_ptr<container_module::value_container>> {
+struct native_to_proto_type<std::shared_ptr<kcenon::container::value_container>> {
     static constexpr bool supported = true;
-    static constexpr container_module::value_types native_type =
-        container_module::value_types::container_value;
+    static constexpr kcenon::container::value_types native_type =
+        kcenon::container::value_types::container_value;
 };
 
 /**
@@ -193,7 +193,7 @@ inline constexpr bool is_supported_v = native_to_proto_type<T>::supported;
  * @brief Helper variable template for getting native type enum
  */
 template<typename T>
-inline constexpr container_module::value_types native_type_v =
+inline constexpr kcenon::container::value_types native_type_v =
     native_to_proto_type<T>::native_type;
 
 } // namespace type_traits
@@ -204,26 +204,26 @@ inline constexpr container_module::value_types native_type_v =
 class type_mapping {
 public:
     /**
-     * @brief Map container_module::value_types to proto ValueType enum value
+     * @brief Map kcenon::container::value_types to proto ValueType enum value
      * @param type Native type enumeration
      * @return Integer value of corresponding proto ValueType
      *
      * The mapping is 1:1 since proto ValueType mirrors value_types exactly.
      */
-    static int to_proto_enum(container_module::value_types type) noexcept {
+    static int to_proto_enum(kcenon::container::value_types type) noexcept {
         return static_cast<int>(type);
     }
 
     /**
-     * @brief Map proto ValueType to container_module::value_types
+     * @brief Map proto ValueType to kcenon::container::value_types
      * @param proto_type Proto type enumeration value
      * @return Native value_types enumeration
      */
-    static container_module::value_types from_proto_enum(int proto_type) noexcept {
+    static kcenon::container::value_types from_proto_enum(int proto_type) noexcept {
         if (proto_type < 0 || proto_type > 15) {
-            return container_module::value_types::null_value;
+            return kcenon::container::value_types::null_value;
         }
-        return static_cast<container_module::value_types>(proto_type);
+        return static_cast<kcenon::container::value_types>(proto_type);
     }
 
     /**
@@ -237,7 +237,7 @@ public:
      *   short_value (2) -> short_val (5)
      *   ... etc
      */
-    static int get_proto_field_number(container_module::value_types type) noexcept {
+    static int get_proto_field_number(kcenon::container::value_types type) noexcept {
         // Field numbers are offset by 3 from type enum values
         // (name=1, type=2, then value fields start at 3)
         return static_cast<int>(type) + 3;
@@ -258,7 +258,7 @@ public:
      * This is useful for pre-allocating buffers.
      */
     static size_t estimate_proto_size(
-        container_module::value_types type,
+        kcenon::container::value_types type,
         size_t data_size) noexcept;
 
     /**
@@ -274,4 +274,4 @@ public:
         size_t avg_data_size) noexcept;
 };
 
-} // namespace container_grpc
+} // namespace kcenon::container_grpc

--- a/grpc/client/grpc_client.cpp
+++ b/grpc/client/grpc_client.cpp
@@ -36,7 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <grpcpp/grpcpp.h>
 
-namespace container_grpc {
+namespace kcenon::container_grpc {
 
 // =============================================================================
 // Implementation Class
@@ -81,9 +81,9 @@ public:
         return timeout_;
     }
 
-    client_result<std::shared_ptr<container_module::value_container>>
-    send(std::shared_ptr<container_module::value_container> container) {
-        client_result<std::shared_ptr<container_module::value_container>> result;
+    client_result<std::shared_ptr<kcenon::container::value_container>>
+    send(std::shared_ptr<kcenon::container::value_container> container) {
+        client_result<std::shared_ptr<kcenon::container::value_container>> result;
 
         if (!container) {
             result.error_message = "Container is null";
@@ -120,9 +120,9 @@ public:
         }
     }
 
-    client_result<std::shared_ptr<container_module::value_container>>
-    process(std::shared_ptr<container_module::value_container> container) {
-        client_result<std::shared_ptr<container_module::value_container>> result;
+    client_result<std::shared_ptr<kcenon::container::value_container>>
+    process(std::shared_ptr<kcenon::container::value_container> container) {
+        client_result<std::shared_ptr<kcenon::container::value_container>> result;
 
         if (!container) {
             result.error_message = "Container is null";
@@ -153,7 +153,7 @@ public:
     }
 
     bool stream(
-        std::shared_ptr<container_module::value_container> request,
+        std::shared_ptr<kcenon::container::value_container> request,
         stream_callback callback) {
 
         if (!request || !callback) {
@@ -183,11 +183,11 @@ public:
         }
     }
 
-    client_result<std::vector<std::shared_ptr<container_module::value_container>>>
+    client_result<std::vector<std::shared_ptr<kcenon::container::value_container>>>
     send_batch(
-        const std::vector<std::shared_ptr<container_module::value_container>>& containers) {
+        const std::vector<std::shared_ptr<kcenon::container::value_container>>& containers) {
 
-        client_result<std::vector<std::shared_ptr<container_module::value_container>>> result;
+        client_result<std::vector<std::shared_ptr<kcenon::container::value_container>>> result;
 
         try {
             grpc::ClientContext context;
@@ -310,25 +310,25 @@ std::chrono::milliseconds grpc_client::timeout() const noexcept {
     return impl_->timeout();
 }
 
-client_result<std::shared_ptr<container_module::value_container>>
-grpc_client::send(std::shared_ptr<container_module::value_container> container) {
+client_result<std::shared_ptr<kcenon::container::value_container>>
+grpc_client::send(std::shared_ptr<kcenon::container::value_container> container) {
     return impl_->send(std::move(container));
 }
 
-client_result<std::shared_ptr<container_module::value_container>>
-grpc_client::process(std::shared_ptr<container_module::value_container> container) {
+client_result<std::shared_ptr<kcenon::container::value_container>>
+grpc_client::process(std::shared_ptr<kcenon::container::value_container> container) {
     return impl_->process(std::move(container));
 }
 
 bool grpc_client::stream(
-    std::shared_ptr<container_module::value_container> request,
+    std::shared_ptr<kcenon::container::value_container> request,
     stream_callback callback) {
     return impl_->stream(std::move(request), std::move(callback));
 }
 
-client_result<std::vector<std::shared_ptr<container_module::value_container>>>
+client_result<std::vector<std::shared_ptr<kcenon::container::value_container>>>
 grpc_client::send_batch(
-    const std::vector<std::shared_ptr<container_module::value_container>>& containers) {
+    const std::vector<std::shared_ptr<kcenon::container::value_container>>& containers) {
     return impl_->send_batch(containers);
 }
 
@@ -340,4 +340,4 @@ bool grpc_client::ping() {
     return impl_->ping();
 }
 
-} // namespace container_grpc
+} // namespace kcenon::container_grpc

--- a/grpc/client/grpc_client.h
+++ b/grpc/client/grpc_client.h
@@ -48,7 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <functional>
 #include <optional>
 
-namespace container_grpc {
+namespace kcenon::container_grpc {
 
 /**
  * @brief Configuration for gRPC client
@@ -77,7 +77,7 @@ struct client_result {
  * @brief Callback type for streaming responses
  */
 using stream_callback = std::function<void(
-    std::shared_ptr<container_module::value_container>)>;
+    std::shared_ptr<kcenon::container::value_container>)>;
 
 /**
  * @class grpc_client
@@ -88,9 +88,9 @@ using stream_callback = std::function<void(
  *
  * Example usage:
  * @code
- *   container_grpc::grpc_client client("localhost:50051");
+ *   kcenon::container_grpc::grpc_client client("localhost:50051");
  *
- *   auto container = std::make_shared<container_module::value_container>();
+ *   auto container = std::make_shared<kcenon::container::value_container>();
  *   container->set_message_type("request");
  *   container->add_value("count", 42);
  *
@@ -158,16 +158,16 @@ public:
      * @param container Container to send
      * @return Result containing response container or error
      */
-    client_result<std::shared_ptr<container_module::value_container>>
-    send(std::shared_ptr<container_module::value_container> container);
+    client_result<std::shared_ptr<kcenon::container::value_container>>
+    send(std::shared_ptr<kcenon::container::value_container> container);
 
     /**
      * @brief Process a container (simple unary call)
      * @param container Container to process
      * @return Result containing processed container or error
      */
-    client_result<std::shared_ptr<container_module::value_container>>
-    process(std::shared_ptr<container_module::value_container> container);
+    client_result<std::shared_ptr<kcenon::container::value_container>>
+    process(std::shared_ptr<kcenon::container::value_container> container);
 
     // =========================================================================
     // Streaming Operations
@@ -180,7 +180,7 @@ public:
      * @return true if streaming started successfully
      */
     bool stream(
-        std::shared_ptr<container_module::value_container> request,
+        std::shared_ptr<kcenon::container::value_container> request,
         stream_callback callback);
 
     /**
@@ -188,9 +188,9 @@ public:
      * @param containers Containers to send
      * @return Result containing batch response
      */
-    client_result<std::vector<std::shared_ptr<container_module::value_container>>>
+    client_result<std::vector<std::shared_ptr<kcenon::container::value_container>>>
     send_batch(
-        const std::vector<std::shared_ptr<container_module::value_container>>& containers);
+        const std::vector<std::shared_ptr<kcenon::container::value_container>>& containers);
 
     // =========================================================================
     // Status and Health
@@ -213,4 +213,4 @@ private:
     std::unique_ptr<impl> impl_;
 };
 
-} // namespace container_grpc
+} // namespace kcenon::container_grpc

--- a/grpc/examples/client_example.cpp
+++ b/grpc/examples/client_example.cpp
@@ -64,7 +64,7 @@ void print_usage(const char* program_name) {
               << "  " << program_name << " --target localhost:50051\n";
 }
 
-void print_container(const std::shared_ptr<container_module::value_container>& container,
+void print_container(const std::shared_ptr<kcenon::container::value_container>& container,
                      const std::string& label) {
     std::cout << "\n--- " << label << " ---" << std::endl;
     std::cout << "  Source: " << container->source_id();
@@ -85,16 +85,16 @@ void print_container(const std::shared_ptr<container_module::value_container>& c
     auto values = container->get_variant_values();
     for (const auto& val : values) {
         std::cout << "    - " << val.name << ": ";
-        std::cout << container_module::variant_helpers::to_string(val.data, val.type);
+        std::cout << kcenon::container::variant_helpers::to_string(val.data, val.type);
         std::cout << std::endl;
     }
 }
 
-bool demo_simple_request(container_grpc::grpc_client& client) {
+bool demo_simple_request(kcenon::container_grpc::grpc_client& client) {
     std::cout << "\n=== Demo 1: Simple Request ===" << std::endl;
 
     // Create a request container
-    auto request = std::make_shared<container_module::value_container>();
+    auto request = std::make_shared<kcenon::container::value_container>();
     request->set_source("client_example", "demo1");
     request->set_target("server", "processor");
     request->set_message_type("simple_request");
@@ -118,14 +118,14 @@ bool demo_simple_request(container_grpc::grpc_client& client) {
     return true;
 }
 
-bool demo_batch_request(container_grpc::grpc_client& client) {
+bool demo_batch_request(kcenon::container_grpc::grpc_client& client) {
     std::cout << "\n=== Demo 2: Batch Request ===" << std::endl;
 
     // Create multiple containers for batch processing
-    std::vector<std::shared_ptr<container_module::value_container>> batch;
+    std::vector<std::shared_ptr<kcenon::container::value_container>> batch;
 
     for (int i = 0; i < 3; ++i) {
-        auto container = std::make_shared<container_module::value_container>();
+        auto container = std::make_shared<kcenon::container::value_container>();
         container->set_source("client_example", "demo2");
         container->set_target("server", "batch_processor");
         container->set_message_type("batch_item");
@@ -150,7 +150,7 @@ bool demo_batch_request(container_grpc::grpc_client& client) {
     return true;
 }
 
-bool demo_health_check(container_grpc::grpc_client& client) {
+bool demo_health_check(kcenon::container_grpc::grpc_client& client) {
     std::cout << "\n=== Demo 3: Health Check ===" << std::endl;
 
     if (client.ping()) {
@@ -170,11 +170,11 @@ bool demo_health_check(container_grpc::grpc_client& client) {
     return true;
 }
 
-bool demo_streaming(container_grpc::grpc_client& client) {
+bool demo_streaming(kcenon::container_grpc::grpc_client& client) {
     std::cout << "\n=== Demo 4: Streaming ===" << std::endl;
 
     // Create subscription request
-    auto request = std::make_shared<container_module::value_container>();
+    auto request = std::make_shared<kcenon::container::value_container>();
     request->set_source("client_example", "demo4");
     request->set_target("server", "streamer");
     request->set_message_type("subscribe");
@@ -185,13 +185,13 @@ bool demo_streaming(container_grpc::grpc_client& client) {
 
     // Start streaming with callback
     bool started = client.stream(request,
-        [&received_count](std::shared_ptr<container_module::value_container> container) {
+        [&received_count](std::shared_ptr<kcenon::container::value_container> container) {
             ++received_count;
             std::cout << "  Received stream item #" << received_count << std::endl;
             auto values = container->get_variant_values();
             for (const auto& val : values) {
                 std::cout << "    " << val.name << ": "
-                          << container_module::variant_helpers::to_string(val.data, val.type)
+                          << kcenon::container::variant_helpers::to_string(val.data, val.type)
                           << std::endl;
             }
         });
@@ -226,13 +226,13 @@ int main(int argc, char* argv[]) {
     std::cout << "Connecting to " << target << "..." << std::endl;
 
     // Create client with configuration
-    container_grpc::client_config config;
+    kcenon::container_grpc::client_config config;
     config.target_address = target;
     config.timeout = std::chrono::milliseconds(30000);  // 30 second timeout
     config.max_retries = 3;
     config.client_id = "example_client";
 
-    container_grpc::grpc_client client(config);
+    kcenon::container_grpc::grpc_client client(config);
 
     // Check connection
     if (!client.is_connected()) {

--- a/grpc/examples/server_example.cpp
+++ b/grpc/examples/server_example.cpp
@@ -72,11 +72,11 @@ void signal_handler(int signal) {
  * - Create a response container
  * - Add processed values to response
  */
-std::shared_ptr<container_module::value_container> echo_processor(
-    std::shared_ptr<container_module::value_container> request) {
+std::shared_ptr<kcenon::container::value_container> echo_processor(
+    std::shared_ptr<kcenon::container::value_container> request) {
 
     // Create response container
-    auto response = std::make_shared<container_module::value_container>();
+    auto response = std::make_shared<kcenon::container::value_container>();
 
     // Swap source and target for response
     response->set_source(request->target_id(), request->target_sub_id());
@@ -86,7 +86,7 @@ std::shared_ptr<container_module::value_container> echo_processor(
     // Echo back all values with "echo_" prefix
     auto values = request->get_variant_values();
     for (const auto& val : values) {
-        container_module::optimized_value echo_val;
+        kcenon::container::optimized_value echo_val;
         echo_val.name = "echo_" + val.name;
         echo_val.type = val.type;
         echo_val.data = val.data;
@@ -133,12 +133,12 @@ int main(int argc, char* argv[]) {
     std::cout << "Starting server on " << address << "..." << std::endl;
 
     // Create server with configuration
-    container_grpc::server_config config;
+    kcenon::container_grpc::server_config config;
     config.address = address;
     config.max_receive_message_size = 64 * 1024 * 1024;  // 64MB
     config.max_send_message_size = 64 * 1024 * 1024;     // 64MB
 
-    container_grpc::grpc_server server(config);
+    kcenon::container_grpc::grpc_server server(config);
 
     // Set custom processor
     server.set_processor(echo_processor);

--- a/grpc/server/grpc_server.cpp
+++ b/grpc/server/grpc_server.cpp
@@ -38,7 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <chrono>
 
-namespace container_grpc {
+namespace kcenon::container_grpc {
 
 // =============================================================================
 // Implementation Class
@@ -179,4 +179,4 @@ size_t grpc_server::error_count() const noexcept {
     return impl_->error_count();
 }
 
-} // namespace container_grpc
+} // namespace kcenon::container_grpc

--- a/grpc/server/grpc_server.h
+++ b/grpc/server/grpc_server.h
@@ -54,7 +54,7 @@ class Server;
 class ServerBuilder;
 }
 
-namespace container_grpc {
+namespace kcenon::container_grpc {
 
 /**
  * @brief Configuration for gRPC server
@@ -71,8 +71,8 @@ struct server_config {
  * @brief Callback type for processing containers
  */
 using container_processor = std::function<
-    std::shared_ptr<container_module::value_container>(
-        std::shared_ptr<container_module::value_container>)>;
+    std::shared_ptr<kcenon::container::value_container>(
+        std::shared_ptr<kcenon::container::value_container>)>;
 
 /**
  * @class grpc_server
@@ -83,7 +83,7 @@ using container_processor = std::function<
  *
  * Example usage:
  * @code
- *   container_grpc::grpc_server server("0.0.0.0:50051");
+ *   kcenon::container_grpc::grpc_server server("0.0.0.0:50051");
  *
  *   // Set custom processor (optional)
  *   server.set_processor([](auto container) {
@@ -175,4 +175,4 @@ private:
     std::unique_ptr<impl> impl_;
 };
 
-} // namespace container_grpc
+} // namespace kcenon::container_grpc

--- a/grpc/server/service_impl.cpp
+++ b/grpc/server/service_impl.cpp
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdexcept>
 
-namespace container_grpc {
+namespace kcenon::container_grpc {
 
 container_service_impl::container_service_impl() = default;
 
@@ -288,4 +288,4 @@ grpc::Status container_service_impl::GetStreamStatus(
     return grpc::Status::OK;
 }
 
-} // namespace container_grpc
+} // namespace kcenon::container_grpc

--- a/grpc/server/service_impl.h
+++ b/grpc/server/service_impl.h
@@ -44,7 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <atomic>
 #include <mutex>
 
-namespace container_grpc {
+namespace kcenon::container_grpc {
 
 /**
  * @class container_service_impl
@@ -137,4 +137,4 @@ private:
     std::atomic<int64_t> messages_received_{0};
 };
 
-} // namespace container_grpc
+} // namespace kcenon::container_grpc

--- a/grpc/tests/adapter_test.cpp
+++ b/grpc/tests/adapter_test.cpp
@@ -34,7 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * @file adapter_test.cpp
  * @brief Unit tests for container_adapter conversion layer
  *
- * Tests verify bidirectional conversion between container_module types
+ * Tests verify bidirectional conversion between kcenon::container types
  * and gRPC proto messages with data integrity preservation.
  */
 
@@ -51,8 +51,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <vector>
 
-using namespace container_grpc;
-using namespace container_module;
+using namespace kcenon::container_grpc;
+using namespace kcenon::container;
 
 /**
  * Test fixture for container adapter tests

--- a/grpc/tests/service_test.cpp
+++ b/grpc/tests/service_test.cpp
@@ -50,8 +50,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 #include <thread>
 
-using namespace container_grpc;
-using namespace container_module;
+using namespace kcenon::container_grpc;
+using namespace kcenon::container;
 
 /**
  * Test fixture for gRPC service integration tests

--- a/include/container/optimizations/fast_parser.h
+++ b/include/container/optimizations/fast_parser.h
@@ -28,7 +28,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
-namespace container_module {
+namespace kcenon::container {
 template<typename Container>
 inline void reserve_if_possible(Container& c, size_t size) {
     if constexpr (requires { c.reserve(size); }) {

--- a/integration/messaging_integration.cpp
+++ b/integration/messaging_integration.cpp
@@ -34,7 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sstream>
 #include <iomanip>
 
-namespace container_module::integration {
+namespace kcenon::container::integration {
 
 #ifdef HAS_PERFORMANCE_METRICS
 messaging_integration::metrics messaging_integration::metrics_;
@@ -274,4 +274,4 @@ void container_performance_monitor::set_result_size(size_t size) {
 }
 #endif // HAS_PERFORMANCE_METRICS
 
-} // namespace container_module::integration
+} // namespace kcenon::container::integration

--- a/integration/messaging_integration.h
+++ b/integration/messaging_integration.h
@@ -48,7 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <unordered_map>
 #endif
 
-namespace container_module::integration {
+namespace kcenon::container::integration {
 
 /**
  * @brief Container integration manager for messaging systems
@@ -209,12 +209,12 @@ messaging_container_builder& messaging_container_builder::set(const std::string&
     return *this;
 }
 
-} // namespace container_module::integration
+} // namespace kcenon::container::integration
 
 // Convenience macros for performance monitoring
 #ifdef HAS_PERFORMANCE_METRICS
 #define CONTAINER_PERF_MONITOR(name) \
-    container_module::integration::container_performance_monitor _monitor(name)
+    kcenon::container::integration::container_performance_monitor _monitor(name)
 
 #define CONTAINER_PERF_SET_SIZE(size) \
     _monitor.set_container_size(size)

--- a/integration_tests/failures/error_handling_test.cpp
+++ b/integration_tests/failures/error_handling_test.cpp
@@ -51,8 +51,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <limits>
 #include <stdexcept>
 
-using namespace container_module;
-using namespace container_module::testing;
+using namespace kcenon::container;
+using namespace kcenon::container::testing;
 
 class ErrorHandlingTest : public ContainerSystemFixture
 {

--- a/integration_tests/framework/system_fixture.h
+++ b/integration_tests/framework/system_fixture.h
@@ -40,7 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 #include <chrono>
 
-namespace container_module
+namespace kcenon::container
 {
 namespace testing
 {
@@ -218,4 +218,4 @@ protected:
 };
 
 } // namespace testing
-} // namespace container_module
+} // namespace kcenon::container

--- a/integration_tests/framework/test_config.h
+++ b/integration_tests/framework/test_config.h
@@ -48,7 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <algorithm>
 #include <limits>
 
-namespace container_module
+namespace kcenon::container
 {
 namespace testing
 {
@@ -295,4 +295,4 @@ private:
 };
 
 } // namespace testing
-} // namespace container_module
+} // namespace kcenon::container

--- a/integration_tests/framework/test_environment_validation.cpp
+++ b/integration_tests/framework/test_environment_validation.cpp
@@ -45,7 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iostream>
 #include <cstdlib>
 
-using namespace container_module::testing;
+using namespace kcenon::container::testing;
 
 /**
  * @brief Test fixture for environment validation

--- a/integration_tests/framework/test_helpers.h
+++ b/integration_tests/framework/test_helpers.h
@@ -44,7 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdlib>
 #include <algorithm>
 
-namespace container_module
+namespace kcenon::container
 {
 namespace testing
 {
@@ -432,4 +432,4 @@ public:
 };
 
 } // namespace testing
-} // namespace container_module
+} // namespace kcenon::container

--- a/integration_tests/performance/serialization_performance_test.cpp
+++ b/integration_tests/performance/serialization_performance_test.cpp
@@ -50,8 +50,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iostream>
 #include <algorithm>
 
-using namespace container_module;
-using namespace container_module::testing;
+using namespace kcenon::container;
+using namespace kcenon::container::testing;
 
 class SerializationPerformanceTest : public ContainerSystemFixture
 {

--- a/integration_tests/scenarios/container_lifecycle_test.cpp
+++ b/integration_tests/scenarios/container_lifecycle_test.cpp
@@ -50,8 +50,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "framework/test_helpers.h"
 #include <core/container.h>
 
-using namespace container_module;
-using namespace container_module::testing;
+using namespace kcenon::container;
+using namespace kcenon::container::testing;
 
 class ContainerLifecycleTest : public ContainerSystemFixture
 {

--- a/integration_tests/scenarios/value_operations_test.cpp
+++ b/integration_tests/scenarios/value_operations_test.cpp
@@ -50,8 +50,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <core/container.h>
 #include <limits>
 
-using namespace container_module;
-using namespace container_module::testing;
+using namespace kcenon::container;
+using namespace kcenon::container::testing;
 
 class ValueOperationsTest : public ContainerSystemFixture
 {

--- a/internal/async/async.h
+++ b/internal/async/async.h
@@ -38,15 +38,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * @code
  * #include <internal/async/async.h>
  *
- * using namespace container_module::async;
+ * using namespace kcenon::container::async;
  *
  * task<int> compute() {
  *     co_return 42;
  * }
  * @endcode
  *
- * @see container_module::async::task
- * @see container_module::async::generator
+ * @see kcenon::container::async::task
+ * @see kcenon::container::async::generator
  */
 
 #pragma once
@@ -68,25 +68,25 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "thread_pool_executor.h"
 #include "async_container.h"
 
-namespace container_module::async
+namespace kcenon::container::async
 {
     /**
      * @brief Check if coroutines are available at compile time
      */
     inline constexpr bool has_coroutine_support = true;
 
-} // namespace container_module::async
+} // namespace kcenon::container::async
 
 #else
 
 // Fallback when coroutines are not available
-namespace container_module::async
+namespace kcenon::container::async
 {
     /**
      * @brief Check if coroutines are available at compile time
      */
     inline constexpr bool has_coroutine_support = false;
 
-} // namespace container_module::async
+} // namespace kcenon::container::async
 
 #endif // CONTAINER_HAS_COROUTINES

--- a/internal/async/async_container.h
+++ b/internal/async/async_container.h
@@ -51,7 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * }
  * @endcode
  *
- * @see container_module::async::async_container
+ * @see kcenon::container::async::async_container
  */
 
 #pragma once
@@ -72,7 +72,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <thread>
 #include <vector>
 
-namespace container_module::async
+namespace kcenon::container::async
 {
     /**
      * @brief Progress callback type for async file operations
@@ -622,7 +622,7 @@ namespace container_module::async
     inline task<kcenon::common::VoidResult>
         async_container::load_async(std::string_view path, progress_callback callback)
     {
-        using namespace container_module;
+        using namespace kcenon::container;
         auto container = container_;
         std::string path_str(path);
         auto result = co_await detail::make_async_awaitable(
@@ -631,9 +631,9 @@ namespace container_module::async
                 if (!file) {
                     return kcenon::common::VoidResult(
                         kcenon::common::error_info{
-                            container_module::error_codes::file_not_found,
-                            container_module::error_codes::make_message(
-                                container_module::error_codes::file_not_found, path_str),
+                            kcenon::container::error_codes::file_not_found,
+                            kcenon::container::error_codes::make_message(
+                                kcenon::container::error_codes::file_not_found, path_str),
                             "container_system"});
                 }
 
@@ -641,9 +641,9 @@ namespace container_module::async
                 if (size < 0) {
                     return kcenon::common::VoidResult(
                         kcenon::common::error_info{
-                            container_module::error_codes::file_read_error,
-                            container_module::error_codes::make_message(
-                                container_module::error_codes::file_read_error, path_str),
+                            kcenon::container::error_codes::file_read_error,
+                            kcenon::container::error_codes::make_message(
+                                kcenon::container::error_codes::file_read_error, path_str),
                             "container_system"});
                 }
                 file.seekg(0, std::ios::beg);
@@ -660,9 +660,9 @@ namespace container_module::async
                     if (!file) {
                         return kcenon::common::VoidResult(
                             kcenon::common::error_info{
-                                container_module::error_codes::file_read_error,
-                                container_module::error_codes::make_message(
-                                    container_module::error_codes::file_read_error, path_str),
+                                kcenon::container::error_codes::file_read_error,
+                                kcenon::container::error_codes::make_message(
+                                    kcenon::container::error_codes::file_read_error, path_str),
                                 "container_system"});
                     }
                     bytes_read += to_read;
@@ -697,9 +697,9 @@ namespace container_module::async
                 if (!file) {
                     return kcenon::common::VoidResult(
                         kcenon::common::error_info{
-                            container_module::error_codes::file_write_error,
-                            container_module::error_codes::make_message(
-                                container_module::error_codes::file_write_error, path_str),
+                            kcenon::container::error_codes::file_write_error,
+                            kcenon::container::error_codes::make_message(
+                                kcenon::container::error_codes::file_write_error, path_str),
                             "container_system"});
                 }
 
@@ -714,9 +714,9 @@ namespace container_module::async
                     if (!file) {
                         return kcenon::common::VoidResult(
                             kcenon::common::error_info{
-                                container_module::error_codes::file_write_error,
-                                container_module::error_codes::make_message(
-                                    container_module::error_codes::file_write_error, path_str),
+                                kcenon::container::error_codes::file_write_error,
+                                kcenon::container::error_codes::make_message(
+                                    kcenon::container::error_codes::file_write_error, path_str),
                                 "container_system"});
                     }
                     bytes_written += to_write;
@@ -740,9 +740,9 @@ namespace container_module::async
                 if (!file) {
                     return kcenon::common::Result<std::vector<uint8_t>>(
                         kcenon::common::error_info{
-                            container_module::error_codes::file_not_found,
-                            container_module::error_codes::make_message(
-                                container_module::error_codes::file_not_found, path_str),
+                            kcenon::container::error_codes::file_not_found,
+                            kcenon::container::error_codes::make_message(
+                                kcenon::container::error_codes::file_not_found, path_str),
                             "container_system"});
                 }
 
@@ -750,9 +750,9 @@ namespace container_module::async
                 if (size < 0) {
                     return kcenon::common::Result<std::vector<uint8_t>>(
                         kcenon::common::error_info{
-                            container_module::error_codes::file_read_error,
-                            container_module::error_codes::make_message(
-                                container_module::error_codes::file_read_error, path_str),
+                            kcenon::container::error_codes::file_read_error,
+                            kcenon::container::error_codes::make_message(
+                                kcenon::container::error_codes::file_read_error, path_str),
                             "container_system"});
                 }
                 file.seekg(0, std::ios::beg);
@@ -769,9 +769,9 @@ namespace container_module::async
                     if (!file) {
                         return kcenon::common::Result<std::vector<uint8_t>>(
                             kcenon::common::error_info{
-                                container_module::error_codes::file_read_error,
-                                container_module::error_codes::make_message(
-                                    container_module::error_codes::file_read_error, path_str),
+                                kcenon::container::error_codes::file_read_error,
+                                kcenon::container::error_codes::make_message(
+                                    kcenon::container::error_codes::file_read_error, path_str),
                                 "container_system"});
                     }
                     bytes_read += to_read;
@@ -798,9 +798,9 @@ namespace container_module::async
                 if (!file) {
                     return kcenon::common::VoidResult(
                         kcenon::common::error_info{
-                            container_module::error_codes::file_write_error,
-                            container_module::error_codes::make_message(
-                                container_module::error_codes::file_write_error, path_str),
+                            kcenon::container::error_codes::file_write_error,
+                            kcenon::container::error_codes::make_message(
+                                kcenon::container::error_codes::file_write_error, path_str),
                             "container_system"});
                 }
 
@@ -815,9 +815,9 @@ namespace container_module::async
                     if (!file) {
                         return kcenon::common::VoidResult(
                             kcenon::common::error_info{
-                                container_module::error_codes::file_write_error,
-                                container_module::error_codes::make_message(
-                                    container_module::error_codes::file_write_error, path_str),
+                                kcenon::container::error_codes::file_write_error,
+                                kcenon::container::error_codes::make_message(
+                                    kcenon::container::error_codes::file_write_error, path_str),
                                 "container_system"});
                     }
                     bytes_written += to_write;
@@ -870,9 +870,9 @@ namespace container_module::async
             // Return an error indicating more data is needed
             co_return kcenon::common::Result<std::shared_ptr<value_container>>(
                 kcenon::common::error_info{
-                    container_module::error_codes::deserialization_failed,
-                    container_module::error_codes::make_message(
-                        container_module::error_codes::deserialization_failed,
+                    kcenon::container::error_codes::deserialization_failed,
+                    kcenon::container::error_codes::make_message(
+                        kcenon::container::error_codes::deserialization_failed,
                         "streaming requires complete data (is_final=true)"),
                     "container_system"});
         }
@@ -1151,4 +1151,4 @@ namespace container_module::async
 
 #endif
 
-} // namespace container_module::async
+} // namespace kcenon::container::async

--- a/internal/async/generator.h
+++ b/internal/async/generator.h
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * }
  * @endcode
  *
- * @see container_module::async::generator
+ * @see kcenon::container::async::generator
  */
 
 #pragma once
@@ -62,7 +62,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <type_traits>
 #include <memory>
 
-namespace container_module::async
+namespace kcenon::container::async
 {
     /**
      * @brief Forward declaration of generator
@@ -402,4 +402,4 @@ namespace container_module::async
         }
     }
 
-} // namespace container_module::async
+} // namespace kcenon::container::async

--- a/internal/async/task.h
+++ b/internal/async/task.h
@@ -48,7 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * }
  * @endcode
  *
- * @see container_module::async::task
+ * @see kcenon::container::async::task
  */
 
 #pragma once
@@ -61,7 +61,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <variant>
 #include <atomic>
 
-namespace container_module::async
+namespace kcenon::container::async
 {
     /**
      * @brief Forward declaration of task
@@ -449,4 +449,4 @@ namespace container_module::async
         co_return;
     }
 
-} // namespace container_module::async
+} // namespace kcenon::container::async

--- a/internal/async/thread_pool_executor.h
+++ b/internal/async/thread_pool_executor.h
@@ -46,7 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * auto result = co_await cont.serialize_async();
  * @endcode
  *
- * @see container_module::async::executor_awaitable
+ * @see kcenon::container::async::executor_awaitable
  * @see kcenon::common::interfaces::IExecutor
  */
 
@@ -69,7 +69,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <kcenon/common/interfaces/thread_pool_interface.h>
 #endif
 
-namespace container_module::async
+namespace kcenon::container::async
 {
     /**
      * @brief Executor type for async operations
@@ -330,4 +330,4 @@ namespace container_module::async
         executor_ptr previous_;
     };
 
-} // namespace container_module::async
+} // namespace kcenon::container::async

--- a/internal/epoch_manager.h
+++ b/internal/epoch_manager.h
@@ -38,7 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <functional>
 #include <mutex>
 
-namespace container_module
+namespace kcenon::container
 {
     /**
      * @brief Epoch-based memory reclamation for lock-free data structures
@@ -347,4 +347,4 @@ namespace container_module
         epoch_guard& operator=(epoch_guard&&) = delete;
     };
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/internal/memory_pool.h
+++ b/internal/memory_pool.h
@@ -41,7 +41,7 @@
 #include <memory>
 #include <stdexcept>
 
-namespace container_module::internal {
+namespace kcenon::container::internal {
 
 class fixed_block_pool {
 public:
@@ -174,5 +174,5 @@ private:
     std::size_t allocated_count_{0};  // Track number of currently allocated blocks
 };
 
-} // namespace container_module::internal
+} // namespace kcenon::container::internal
 

--- a/internal/pool_allocator.h
+++ b/internal/pool_allocator.h
@@ -50,7 +50,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace container_module::internal {
+namespace kcenon::container::internal {
 
 /**
  * @brief Size class thresholds for pool allocation
@@ -263,4 +263,4 @@ inline constexpr int get_size_class(std::size_t size) noexcept {
     return 2;
 }
 
-} // namespace container_module::internal
+} // namespace kcenon::container::internal

--- a/internal/rcu_value.h
+++ b/internal/rcu_value.h
@@ -36,7 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 #include <type_traits>
 
-namespace container_module
+namespace kcenon::container
 {
     /**
      * @brief Lock-free value wrapper using Read-Copy-Update (RCU) pattern
@@ -210,4 +210,4 @@ namespace container_module
         std::atomic<size_t> update_count_{0};
     };
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/internal/simd_policies.h
+++ b/internal/simd_policies.h
@@ -103,7 +103,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     #include <arm_neon.h>
 #endif
 
-namespace container_module::simd {
+namespace kcenon::container::simd {
 
 /**
  * @brief Concept for SIMD policy classes.
@@ -712,4 +712,4 @@ static_assert(SimdPolicy<avx512_simd_policy>, "avx512_simd_policy must satisfy S
 static_assert(SimdPolicy<neon_simd_policy>, "neon_simd_policy must satisfy SimdPolicy");
 #endif
 
-} // namespace container_module::simd
+} // namespace kcenon::container::simd

--- a/internal/simd_processor.cpp
+++ b/internal/simd_processor.cpp
@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     #endif
 #endif
 
-namespace container_module
+namespace kcenon::container
 {
 namespace simd
 {
@@ -709,4 +709,4 @@ namespace simd
     }
 
 } // namespace simd
-} // namespace container_module
+} // namespace kcenon::container

--- a/internal/simd_processor.h
+++ b/internal/simd_processor.h
@@ -80,7 +80,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     #include <arm_neon.h>
 #endif
 
-namespace container_module
+namespace kcenon::container
 {
 namespace simd
 {
@@ -340,4 +340,4 @@ namespace simd
     #endif
 
 } // namespace simd
-} // namespace container_module
+} // namespace kcenon::container

--- a/internal/thread_safe_container.cpp
+++ b/internal/thread_safe_container.cpp
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <algorithm>
 #include <cstring>
 
-namespace container_module
+namespace kcenon::container
 {
     using namespace utility_module;
 
@@ -387,4 +387,4 @@ namespace container_module
         snapshot_ = new_snapshot;
     }
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/internal/thread_safe_container.h
+++ b/internal/thread_safe_container.h
@@ -44,7 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "value.h"
 #include "core/concepts.h"
 
-namespace container_module
+namespace kcenon::container
 {
     // Forward declarations
     class lockfree_container_reader;
@@ -832,4 +832,4 @@ namespace container_module
         return std::make_shared<auto_refresh_reader>(shared_from_this(), refresh_interval);
     }
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/internal/value.cpp
+++ b/internal/value.cpp
@@ -13,7 +13,7 @@ All rights reserved.
 #include <stdexcept>
 #include <set>
 
-namespace container_module
+namespace kcenon::container
 {
     namespace detail {
         // Thread-local set for detecting circular references during serialization
@@ -335,7 +335,7 @@ namespace container_module
                         result.insert(result.end(), elem_data.begin(), elem_data.end());
                     } else {
                         // Null element: serialize as null_value with empty name
-                        container_module::value null_elem("");
+                        kcenon::container::value null_elem("");
                         auto null_data = null_elem.serialize();
                         result.insert(result.end(), null_data.begin(), null_data.end());
                     }
@@ -590,7 +590,7 @@ namespace container_module
         }
 
         // Create result with name
-        container_module::value result(name);
+        kcenon::container::value result(name);
 
         // Deserialize data based on type
         if (!deserialize_data(result, type, data, offset)) {
@@ -613,4 +613,4 @@ namespace container_module
         return data_ < other.data_;
     }
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/internal/value.h
+++ b/internal/value.h
@@ -21,7 +21,7 @@ All rights reserved.
 #include <type_traits>
 #include <concepts>
 
-namespace container_module
+namespace kcenon::container
 {
     // Forward declarations
     class thread_safe_container;
@@ -355,4 +355,4 @@ namespace container_module
     template<typename T>
     inline constexpr bool is_variant_type_v2_v = is_variant_type_v2<T>::value;
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/internal/value_view.h
+++ b/internal/value_view.h
@@ -64,7 +64,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <optional>
 #include <type_traits>
 
-namespace container_module
+namespace kcenon::container
 {
 
 /**
@@ -321,4 +321,4 @@ struct value_index_entry
     {}
 };
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/internal/variant_value_factory.h
+++ b/internal/variant_value_factory.h
@@ -17,7 +17,7 @@ All rights reserved.
 #include <type_traits>
 #include <concepts>
 
-namespace container_module
+namespace kcenon::container
 {
     // ============================================================================
     // Modern Factory API (Recommended)
@@ -422,4 +422,4 @@ namespace container_module
         }
     }
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/messaging/message_container.cpp
+++ b/messaging/message_container.cpp
@@ -48,7 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 #endif
 
-namespace container_module {
+namespace kcenon::container {
 
 // ============================================================================
 // Constructors
@@ -262,4 +262,4 @@ std::unique_ptr<message_container> message_container::deserialize_binary(const s
     return container;
 }
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/messaging/message_container.h
+++ b/messaging/message_container.h
@@ -40,7 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string_view>
 #include <vector>
 
-namespace container_module {
+namespace kcenon::container {
 
 /**
  * @brief Messaging-specific container
@@ -242,4 +242,4 @@ private:
     value_store payload_;
 };
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/samples/basic_usage.cpp
+++ b/samples/basic_usage.cpp
@@ -8,7 +8,7 @@
 #include <vector>
 #include "container.h"
 
-using namespace container_module;
+using namespace kcenon::container;
 
 int main() {
     std::cout << "=== Container System - Basic Usage Example ===" << std::endl;

--- a/samples/performance_benchmark.cpp
+++ b/samples/performance_benchmark.cpp
@@ -11,7 +11,7 @@
 #include <thread>
 #include "container.h"
 
-using namespace container_module;
+using namespace kcenon::container;
 
 class performance_benchmark {
 public:

--- a/samples/thread_safe_example.cpp
+++ b/samples/thread_safe_example.cpp
@@ -12,7 +12,7 @@
 #include <mutex>
 #include "container.h"
 
-using namespace container_module;
+using namespace kcenon::container;
 
 int main() {
     std::cout << "=== Container System - Thread Safety Example ===" << std::endl;

--- a/src/modules/container.cppm
+++ b/src/modules/container.cppm
@@ -14,7 +14,7 @@
  * @code
  * import kcenon.container;
  *
- * using namespace container_module;
+ * using namespace kcenon::container;
  *
  * value_container container;
  * container.set("name", std::string("value"));
@@ -64,7 +64,7 @@ export import kcenon.common;
 // Exported Container Module Types
 // =============================================================================
 
-export namespace container_module {
+export namespace kcenon::container {
 
 // =============================================================================
 // Value Types Enumeration
@@ -599,4 +599,4 @@ struct module_version {
     static constexpr const char* module_name = "kcenon.container";
 };
 
-} // namespace container_module
+} // namespace kcenon::container

--- a/tests/async_tests.cpp
+++ b/tests/async_tests.cpp
@@ -21,7 +21,7 @@ All rights reserved.
 #include <filesystem>
 #include <fstream>
 
-using namespace container_module::async;
+using namespace kcenon::container::async;
 using namespace std::chrono_literals;
 
 class AsyncTaskTest : public ::testing::Test {
@@ -309,7 +309,7 @@ TEST_F(AsyncGeneratorTest, TakeGenerator) {
 class AsyncContainerTest : public ::testing::Test {
 protected:
     void SetUp() override {
-        container_ = std::make_shared<container_module::value_container>();
+        container_ = std::make_shared<kcenon::container::value_container>();
         container_->set("string_key", std::string("hello"));
         container_->set("int_key", static_cast<int64_t>(42));
         container_->set("double_key", 3.14);
@@ -319,7 +319,7 @@ protected:
         container_.reset();
     }
 
-    std::shared_ptr<container_module::value_container> container_;
+    std::shared_ptr<kcenon::container::value_container> container_;
 };
 
 TEST_F(AsyncContainerTest, SerializeAsyncReturnsValidData) {
@@ -363,7 +363,7 @@ TEST_F(AsyncContainerTest, SerializeStringAsyncReturnsValidData) {
 
 TEST_F(AsyncContainerTest, DeserializeAsyncRestoresData) {
     // First serialize using unified API
-    auto serialize_result = container_->serialize(container_module::value_container::serialization_format::binary);
+    auto serialize_result = container_->serialize(kcenon::container::value_container::serialization_format::binary);
     ASSERT_TRUE(serialize_result.is_ok());
     auto serialized = serialize_result.value();
     EXPECT_FALSE(serialized.empty());
@@ -401,7 +401,7 @@ TEST_F(AsyncContainerTest, DeserializeAsyncRestoresData) {
 
 TEST_F(AsyncContainerTest, DeserializeStringAsyncRestoresData) {
     // First serialize using unified API
-    auto serialize_result = container_->serialize_string(container_module::value_container::serialization_format::binary);
+    auto serialize_result = container_->serialize_string(kcenon::container::value_container::serialization_format::binary);
     ASSERT_TRUE(serialize_result.is_ok());
     auto serialized = serialize_result.value();
     EXPECT_FALSE(serialized.empty());
@@ -511,7 +511,7 @@ protected:
 };
 
 TEST_F(AsyncFileIOTest, SaveAndLoadAsync) {
-    auto container = std::make_shared<container_module::value_container>();
+    auto container = std::make_shared<kcenon::container::value_container>();
     container->set("test_key", std::string("test_value"));
     container->set("int_key", static_cast<int64_t>(12345));
 
@@ -576,7 +576,7 @@ TEST_F(AsyncFileIOTest, LoadAsyncFileNotFound) {
     auto result = load_task.get();
 #if CONTAINER_HAS_COMMON_RESULT
     EXPECT_FALSE(result.is_ok());
-    EXPECT_EQ(result.error().code, container_module::error_codes::file_not_found);
+    EXPECT_EQ(result.error().code, kcenon::container::error_codes::file_not_found);
 #else
     EXPECT_FALSE(result);
 #endif
@@ -637,7 +637,7 @@ TEST_F(AsyncFileIOTest, WriteFileAsync) {
 }
 
 TEST_F(AsyncFileIOTest, ProgressCallbackCalled) {
-    auto container = std::make_shared<container_module::value_container>();
+    auto container = std::make_shared<kcenon::container::value_container>();
     // Create container with some data
     for (int i = 0; i < 100; ++i) {
         container->set("key_" + std::to_string(i),
@@ -676,7 +676,7 @@ TEST_F(AsyncFileIOTest, ProgressCallbackCalled) {
 }
 
 TEST_F(AsyncFileIOTest, RoundTripLargeFile) {
-    auto container = std::make_shared<container_module::value_container>();
+    auto container = std::make_shared<kcenon::container::value_container>();
     // Create container with substantial data
     // Note: Using smaller data size (10KB total) to avoid stack overflow in
     // std::regex under AddressSanitizer (regex uses backtracking which is
@@ -732,7 +732,7 @@ TEST_F(AsyncFileIOTest, RoundTripLargeFile) {
 class AsyncStreamingTest : public ::testing::Test {
 protected:
     void SetUp() override {
-        container_ = std::make_shared<container_module::value_container>();
+        container_ = std::make_shared<kcenon::container::value_container>();
         // Add some test data
         for (int i = 0; i < 100; ++i) {
             container_->set("key_" + std::to_string(i),
@@ -744,7 +744,7 @@ protected:
         container_.reset();
     }
 
-    std::shared_ptr<container_module::value_container> container_;
+    std::shared_ptr<kcenon::container::value_container> container_;
 };
 
 TEST_F(AsyncStreamingTest, SerializeChunkedBasic) {
@@ -768,7 +768,7 @@ TEST_F(AsyncStreamingTest, SerializeChunkedBasic) {
     EXPECT_FALSE(full_data.empty());
 
     // Verify the full data can be deserialized
-    auto restored = std::make_shared<container_module::value_container>(full_data, false);
+    auto restored = std::make_shared<kcenon::container::value_container>(full_data, false);
     EXPECT_TRUE(restored->contains("key_0"));
     EXPECT_TRUE(restored->contains("key_99"));
 }
@@ -794,7 +794,7 @@ TEST_F(AsyncStreamingTest, SerializeChunkedSmallChunks) {
     EXPECT_GT(chunk_count, 1u);
 
     // Verify data integrity
-    auto restored = std::make_shared<container_module::value_container>(full_data, false);
+    auto restored = std::make_shared<kcenon::container::value_container>(full_data, false);
     auto val = restored->get_value("key_50");
     ASSERT_TRUE(val.has_value());
     auto* str_ptr = std::get_if<std::string>(&val->data);
@@ -821,12 +821,12 @@ TEST_F(AsyncStreamingTest, SerializeChunkedLargeChunks) {
     EXPECT_EQ(chunk_count, 1u);
 
     // Verify data integrity
-    auto restored = std::make_shared<container_module::value_container>(full_data, false);
+    auto restored = std::make_shared<kcenon::container::value_container>(full_data, false);
     EXPECT_TRUE(restored->contains("key_0"));
 }
 
 TEST_F(AsyncStreamingTest, SerializeChunkedEmptyContainer) {
-    auto empty_container = std::make_shared<container_module::value_container>();
+    auto empty_container = std::make_shared<kcenon::container::value_container>();
     async_container async_cont(empty_container);
 
     auto gen = async_cont.serialize_chunked();
@@ -843,7 +843,7 @@ TEST_F(AsyncStreamingTest, SerializeChunkedEmptyContainer) {
 
 TEST_F(AsyncStreamingTest, DeserializeStreamingComplete) {
     // First serialize the container using unified API
-    auto serialize_result = container_->serialize(container_module::value_container::serialization_format::binary);
+    auto serialize_result = container_->serialize(kcenon::container::value_container::serialization_format::binary);
     ASSERT_TRUE(serialize_result.is_ok());
     auto serialized = serialize_result.value();
     EXPECT_FALSE(serialized.empty());
@@ -876,7 +876,7 @@ TEST_F(AsyncStreamingTest, DeserializeStreamingComplete) {
 
 TEST_F(AsyncStreamingTest, DeserializeStreamingIncomplete) {
     // First serialize the container using unified API
-    auto serialize_result = container_->serialize(container_module::value_container::serialization_format::binary);
+    auto serialize_result = container_->serialize(kcenon::container::value_container::serialization_format::binary);
     ASSERT_TRUE(serialize_result.is_ok());
     auto serialized = serialize_result.value();
     EXPECT_FALSE(serialized.empty());
@@ -893,7 +893,7 @@ TEST_F(AsyncStreamingTest, DeserializeStreamingIncomplete) {
 #if CONTAINER_HAS_COMMON_RESULT
     // Should return error because is_final=false
     EXPECT_FALSE(result.is_ok());
-    EXPECT_EQ(result.error().code, container_module::error_codes::deserialization_failed);
+    EXPECT_EQ(result.error().code, kcenon::container::error_codes::deserialization_failed);
 #else
     // Should return nullptr
     EXPECT_EQ(result, nullptr);
@@ -1093,7 +1093,7 @@ TEST(AsyncFeatureTest, CoroutinesSupportDetected) {
 
 // Placeholder test when coroutines are not available
 TEST(AsyncFeatureTest, CoroutinesNotAvailable) {
-    EXPECT_FALSE(container_module::async::has_coroutine_support);
+    EXPECT_FALSE(kcenon::container::async::has_coroutine_support);
 }
 
 #endif // CONTAINER_HAS_COROUTINES

--- a/tests/benchmark_tests.cpp
+++ b/tests/benchmark_tests.cpp
@@ -47,7 +47,7 @@
 #include <sstream>
 #include <cstring>
 
-using namespace container_module;
+using namespace kcenon::container;
 
 // Helper function to generate random string
 std::string generate_random_string(size_t length) {

--- a/tests/error_codes_tests.cpp
+++ b/tests/error_codes_tests.cpp
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /**
  * @file error_codes_tests.cpp
- * @brief Unit tests for container_module error codes and message mapping
+ * @brief Unit tests for kcenon::container error codes and message mapping
  *
  * Tests cover:
  * - Error code value verification
@@ -45,8 +45,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <gtest/gtest.h>
 #include <core/container/error_codes.h>
 
-using namespace container_module;
-using namespace container_module::error_codes;
+using namespace kcenon::container;
+using namespace kcenon::container::error_codes;
 
 // ============================================================================
 // Error Code Value Tests

--- a/tests/fast_parser_integration_tests.cpp
+++ b/tests/fast_parser_integration_tests.cpp
@@ -51,7 +51,7 @@
 
 namespace {
 
-using namespace container_module;
+using namespace kcenon::container;
 
 /**
  * @brief Verifies that fast_parser.h includes resolve correctly

--- a/tests/fuzz/container_fuzzer.cpp
+++ b/tests/fuzz/container_fuzzer.cpp
@@ -19,7 +19,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         // bit 0: parse_header_only
         bool parse_header_only = (Data[0] & 1) == 0;
         
-        container_module::value_container container(input_data, parse_header_only);
+        kcenon::container::value_container container(input_data, parse_header_only);
 
         // Exercise read methods to ensure internal state is consistent
         [[maybe_unused]] auto src = container.source_id();

--- a/tests/generate_test_data.cpp
+++ b/tests/generate_test_data.cpp
@@ -32,7 +32,7 @@
 #include <memory>
 #include "container.h"
 
-using namespace container_module;
+using namespace kcenon::container;
 
 int main() {
     // Create a container with all basic types

--- a/tests/generate_test_values.cpp
+++ b/tests/generate_test_values.cpp
@@ -32,7 +32,7 @@
 #include <memory>
 #include <vector>
 
-using namespace container_module;
+using namespace kcenon::container;
 
 int main() {
     std::cout << "Generating individual value test files..." << std::endl;

--- a/tests/memory_pool_benchmark.cpp
+++ b/tests/memory_pool_benchmark.cpp
@@ -48,7 +48,7 @@
 #include <algorithm>
 #include <cstring>
 
-using namespace container_module::internal;
+using namespace kcenon::container::internal;
 
 // ============================================================================
 // Basic Allocation Benchmarks

--- a/tests/memory_pool_tests.cpp
+++ b/tests/memory_pool_tests.cpp
@@ -49,7 +49,7 @@
 #include <random>
 #include <chrono>
 
-using namespace container_module::internal;
+using namespace kcenon::container::internal;
 
 // Test fixture for memory pool tests
 class MemoryPoolTest : public ::testing::Test {
@@ -537,7 +537,7 @@ TEST_F(MemoryPoolTest, ManyBlocksPerChunk) {
 #include <internal/pool_allocator.h>
 #include <core/container.h>
 
-using namespace container_module::internal;
+using namespace kcenon::container::internal;
 
 class PoolAllocatorTest : public ::testing::Test {
 protected:
@@ -637,7 +637,7 @@ TEST_F(PoolAllocatorTest, HitRateCalculation) {
 }
 
 TEST_F(PoolAllocatorTest, ContainerPoolStats) {
-    using namespace container_module;
+    using namespace kcenon::container;
 
     // Clear any previous stats
     value_container::clear_pool();

--- a/tests/msgpack_tests.cpp
+++ b/tests/msgpack_tests.cpp
@@ -45,7 +45,7 @@
 #include <cstdint>
 #include <string>
 
-using namespace container_module;
+using namespace kcenon::container;
 
 // ============================================================================
 // MessagePack Encoder Tests

--- a/tests/performance_tests.cpp
+++ b/tests/performance_tests.cpp
@@ -47,7 +47,7 @@
 #include "integration/messaging_integration.h"
 #endif
 
-using namespace container_module;
+using namespace kcenon::container;
 
 class PerformanceTest : public ::testing::Test {
 protected:

--- a/tests/policy_container_tests.cpp
+++ b/tests/policy_container_tests.cpp
@@ -48,8 +48,8 @@
 #include <chrono>
 #include <random>
 
-using namespace container_module;
-using namespace container_module::policy;
+using namespace kcenon::container;
+using namespace kcenon::container::policy;
 
 // ============================================================================
 // Basic Container Tests (Dynamic Storage)

--- a/tests/result_api_tests.cpp
+++ b/tests/result_api_tests.cpp
@@ -51,7 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <span>
 #include <vector>
 
-using namespace container_module;
+using namespace kcenon::container;
 
 // ============================================================================
 // Test Fixture

--- a/tests/schema_tests.cpp
+++ b/tests/schema_tests.cpp
@@ -47,7 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "test_compat.h"
 #include <core/container/schema.h>
 
-using namespace container_module;
+using namespace kcenon::container;
 
 // ============================================================================
 // Test Fixture

--- a/tests/serializer_factory_tests.cpp
+++ b/tests/serializer_factory_tests.cpp
@@ -42,7 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <core/serializers/serializer_strategy.h>
 #include <container.h>
 
-using namespace container_module;
+using namespace kcenon::container;
 
 // =============================================================================
 // serialization_format enum tests

--- a/tests/simd_policies_tests.cpp
+++ b/tests/simd_policies_tests.cpp
@@ -50,7 +50,7 @@
 #include <cmath>
 #include <limits>
 
-using namespace container_module::simd;
+using namespace kcenon::container::simd;
 
 // ============================================================================
 // Scalar Policy Tests (Baseline)

--- a/tests/simd_tests.cpp
+++ b/tests/simd_tests.cpp
@@ -46,7 +46,7 @@
 #include <cmath>
 #include <limits>
 
-using namespace container_module::simd;
+using namespace kcenon::container::simd;
 
 class SIMDSupportTest : public ::testing::Test {
 protected:
@@ -56,8 +56,8 @@ protected:
 
 class SIMDOperationsTest : public ::testing::Test {
 protected:
-    std::vector<container_module::ValueVariant> float_values;
-    std::vector<container_module::ValueVariant> double_values;
+    std::vector<kcenon::container::ValueVariant> float_values;
+    std::vector<kcenon::container::ValueVariant> double_values;
     std::mt19937 rng{42};
 
     void SetUp() override {
@@ -157,13 +157,13 @@ TEST_F(SIMDOperationsTest, SumFloatsBasic) {
 }
 
 TEST_F(SIMDOperationsTest, SumFloatsEmpty) {
-    std::vector<container_module::ValueVariant> empty;
+    std::vector<kcenon::container::ValueVariant> empty;
     float sum = simd_processor::sum_floats(empty);
     EXPECT_FLOAT_EQ(sum, 0.0F);
 }
 
 TEST_F(SIMDOperationsTest, SumFloatsLargeDataset) {
-    std::vector<container_module::ValueVariant> large_data;
+    std::vector<kcenon::container::ValueVariant> large_data;
     large_data.reserve(10000);
 
     for (int i = 0; i < 10000; ++i) {
@@ -176,7 +176,7 @@ TEST_F(SIMDOperationsTest, SumFloatsLargeDataset) {
 
 TEST_F(SIMDOperationsTest, SumFloatsMixedTypes) {
     // Test with mixed types (only floats should be summed)
-    std::vector<container_module::ValueVariant> mixed;
+    std::vector<kcenon::container::ValueVariant> mixed;
     mixed.push_back(1.0F);
     mixed.push_back(std::string("ignore"));
     mixed.push_back(2.0F);
@@ -204,19 +204,19 @@ TEST_F(SIMDOperationsTest, MaxFloatBasic) {
 }
 
 TEST_F(SIMDOperationsTest, MinFloatEmpty) {
-    std::vector<container_module::ValueVariant> empty;
+    std::vector<kcenon::container::ValueVariant> empty;
     auto min_val = simd_processor::min_float(empty);
     EXPECT_FALSE(min_val.has_value());
 }
 
 TEST_F(SIMDOperationsTest, MaxFloatEmpty) {
-    std::vector<container_module::ValueVariant> empty;
+    std::vector<kcenon::container::ValueVariant> empty;
     auto max_val = simd_processor::max_float(empty);
     EXPECT_FALSE(max_val.has_value());
 }
 
 TEST_F(SIMDOperationsTest, MinFloatWithNegatives) {
-    std::vector<container_module::ValueVariant> data;
+    std::vector<kcenon::container::ValueVariant> data;
     data.push_back(-100.0F);
     data.push_back(50.0F);
     data.push_back(-200.0F);
@@ -228,7 +228,7 @@ TEST_F(SIMDOperationsTest, MinFloatWithNegatives) {
 }
 
 TEST_F(SIMDOperationsTest, MaxFloatWithNegatives) {
-    std::vector<container_module::ValueVariant> data;
+    std::vector<kcenon::container::ValueVariant> data;
     data.push_back(-100.0F);
     data.push_back(50.0F);
     data.push_back(-200.0F);
@@ -240,7 +240,7 @@ TEST_F(SIMDOperationsTest, MaxFloatWithNegatives) {
 }
 
 TEST_F(SIMDOperationsTest, MinMaxFloatLargeDataset) {
-    std::vector<container_module::ValueVariant> large_data;
+    std::vector<kcenon::container::ValueVariant> large_data;
     large_data.reserve(10000);
 
     std::uniform_real_distribution<float> dist(-1000.0F, 1000.0F);
@@ -276,7 +276,7 @@ TEST_F(SIMDOperationsTest, SumDoublesBasic) {
 }
 
 TEST_F(SIMDOperationsTest, SumDoublesEmpty) {
-    std::vector<container_module::ValueVariant> empty;
+    std::vector<kcenon::container::ValueVariant> empty;
     double sum = simd_processor::sum_doubles(empty);
     EXPECT_DOUBLE_EQ(sum, 0.0);
 }
@@ -297,7 +297,7 @@ TEST_F(SIMDOperationsTest, FindEqualFloatsNotFound) {
 }
 
 TEST_F(SIMDOperationsTest, FindEqualFloatsMultipleMatches) {
-    std::vector<container_module::ValueVariant> data;
+    std::vector<kcenon::container::ValueVariant> data;
     data.push_back(1.0F);
     data.push_back(2.0F);
     data.push_back(1.0F);
@@ -343,7 +343,7 @@ TEST_F(SIMDOperationsTest, FastCompareNotEqual) {
 // ============================================================================
 
 TEST_F(SIMDOperationsTest, SingleElementSum) {
-    std::vector<container_module::ValueVariant> single;
+    std::vector<kcenon::container::ValueVariant> single;
     single.push_back(42.0F);
 
     float sum = simd_processor::sum_floats(single);
@@ -351,7 +351,7 @@ TEST_F(SIMDOperationsTest, SingleElementSum) {
 }
 
 TEST_F(SIMDOperationsTest, SingleElementMinMax) {
-    std::vector<container_module::ValueVariant> single;
+    std::vector<kcenon::container::ValueVariant> single;
     single.push_back(42.0F);
 
     auto min_val = simd_processor::min_float(single);
@@ -365,7 +365,7 @@ TEST_F(SIMDOperationsTest, SingleElementMinMax) {
 
 TEST_F(SIMDOperationsTest, NonAlignedSizeSum) {
     // Test with size that doesn't align to SIMD width
-    std::vector<container_module::ValueVariant> data;
+    std::vector<kcenon::container::ValueVariant> data;
     for (int i = 1; i <= 17; ++i) {  // 17 elements (not aligned to 4, 8, or 16)
         data.push_back(static_cast<float>(i));
     }

--- a/tests/storage_policy_tests.cpp
+++ b/tests/storage_policy_tests.cpp
@@ -45,8 +45,8 @@
 #include <string>
 #include <algorithm>
 
-using namespace container_module;
-using namespace container_module::policy;
+using namespace kcenon::container;
+using namespace kcenon::container::policy;
 
 // ============================================================================
 // Concept Verification Tests

--- a/tests/test_compat.h
+++ b/tests/test_compat.h
@@ -22,7 +22,7 @@
 #include <limits>
 #include <cstdint>
 
-namespace container_module {
+namespace kcenon::container {
 namespace test_compat {
 
 // Factory functions that return shared_ptr for legacy API compatibility
@@ -312,47 +312,47 @@ inline std::string ov_name(const std::optional<optimized_value>& ov) {
 }
 
 } // namespace test_compat
-} // namespace container_module
+} // namespace kcenon::container
 
 // Pull test_compat functions into global scope for test convenience
-using container_module::test_compat::make_int_value;
-using container_module::test_compat::make_bool_value;
-using container_module::test_compat::make_string_value;
-using container_module::test_compat::make_llong_value;
-using container_module::test_compat::make_long_value;
-using container_module::test_compat::make_ulong_value;
-using container_module::test_compat::make_bytes_value;
-using container_module::test_compat::make_double_value;
-using container_module::test_compat::make_float_value;
-using container_module::test_compat::make_short_value;
-using container_module::test_compat::make_ushort_value;
-using container_module::test_compat::make_uint_value;
-using container_module::test_compat::make_ullong_value;
+using kcenon::container::test_compat::make_int_value;
+using kcenon::container::test_compat::make_bool_value;
+using kcenon::container::test_compat::make_string_value;
+using kcenon::container::test_compat::make_llong_value;
+using kcenon::container::test_compat::make_long_value;
+using kcenon::container::test_compat::make_ulong_value;
+using kcenon::container::test_compat::make_bytes_value;
+using kcenon::container::test_compat::make_double_value;
+using kcenon::container::test_compat::make_float_value;
+using kcenon::container::test_compat::make_short_value;
+using kcenon::container::test_compat::make_ushort_value;
+using kcenon::container::test_compat::make_uint_value;
+using kcenon::container::test_compat::make_ullong_value;
 
 // Pull helper functions into global scope
-using container_module::test_compat::is_boolean;
-using container_module::test_compat::is_numeric;
-using container_module::test_compat::is_string;
-using container_module::test_compat::is_container;
-using container_module::test_compat::is_bytes;
-using container_module::test_compat::to_boolean;
-using container_module::test_compat::to_int;
-using container_module::test_compat::to_long;
-using container_module::test_compat::to_llong;
-using container_module::test_compat::to_ulong;
-using container_module::test_compat::to_ullong;
-using container_module::test_compat::to_double;
-using container_module::test_compat::to_bytes;
-using container_module::test_compat::value_size;
-using container_module::test_compat::ov_to_string;
-using container_module::test_compat::ov_to_int;
-using container_module::test_compat::ov_to_boolean;
-using container_module::test_compat::ov_to_llong;
-using container_module::test_compat::ov_to_double;
-using container_module::test_compat::ov_is_null;
-using container_module::test_compat::ov_is_bytes;
-using container_module::test_compat::ov_is_container;
-using container_module::test_compat::ov_data;
-using container_module::test_compat::ov_name;
-using container_module::test_compat::is_int32_range;
-using container_module::test_compat::is_uint32_range;
+using kcenon::container::test_compat::is_boolean;
+using kcenon::container::test_compat::is_numeric;
+using kcenon::container::test_compat::is_string;
+using kcenon::container::test_compat::is_container;
+using kcenon::container::test_compat::is_bytes;
+using kcenon::container::test_compat::to_boolean;
+using kcenon::container::test_compat::to_int;
+using kcenon::container::test_compat::to_long;
+using kcenon::container::test_compat::to_llong;
+using kcenon::container::test_compat::to_ulong;
+using kcenon::container::test_compat::to_ullong;
+using kcenon::container::test_compat::to_double;
+using kcenon::container::test_compat::to_bytes;
+using kcenon::container::test_compat::value_size;
+using kcenon::container::test_compat::ov_to_string;
+using kcenon::container::test_compat::ov_to_int;
+using kcenon::container::test_compat::ov_to_boolean;
+using kcenon::container::test_compat::ov_to_llong;
+using kcenon::container::test_compat::ov_to_double;
+using kcenon::container::test_compat::ov_is_null;
+using kcenon::container::test_compat::ov_is_bytes;
+using kcenon::container::test_compat::ov_is_container;
+using kcenon::container::test_compat::ov_data;
+using kcenon::container::test_compat::ov_name;
+using kcenon::container::test_compat::is_int32_range;
+using kcenon::container::test_compat::is_uint32_range;

--- a/tests/test_long_range_checking.cpp
+++ b/tests/test_long_range_checking.cpp
@@ -20,7 +20,7 @@ All rights reserved.
 #include <limits>
 #include <cstdint>
 
-using namespace container_module;
+using namespace kcenon::container;
 
 // ============================================================================
 // Test Fixture

--- a/tests/test_messaging_integration.cpp
+++ b/tests/test_messaging_integration.cpp
@@ -41,7 +41,7 @@
 
 #include "core/container.h"
 
-using namespace container_module;
+using namespace kcenon::container;
 
 class MessagingIntegrationTest : public ::testing::Test {
 protected:

--- a/tests/thread_pool_executor_tests.cpp
+++ b/tests/thread_pool_executor_tests.cpp
@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <chrono>
 #include <stdexcept>
 
-using namespace container_module::async;
+using namespace kcenon::container::async;
 using namespace std::chrono_literals;
 
 class ThreadPoolExecutorTest : public ::testing::Test {

--- a/tests/thread_safety_tests.cpp
+++ b/tests/thread_safety_tests.cpp
@@ -20,7 +20,7 @@ All rights reserved.
 #include <algorithm>
 #include <random>
 
-using namespace container_module;
+using namespace kcenon::container;
 using namespace std::chrono_literals;
 
 class ContainerThreadSafetyTest : public ::testing::Test {

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -48,7 +48,7 @@
 #include <chrono>
 #include <barrier>
 
-using namespace container_module;
+using namespace kcenon::container;
 
 // Test fixture for value tests
 class ValueTest : public ::testing::Test {

--- a/tests/variant_value_factory_tests.cpp
+++ b/tests/variant_value_factory_tests.cpp
@@ -19,7 +19,7 @@ All rights reserved.
 #pragma warning(disable: 4996)
 #endif
 
-using namespace container_module;
+using namespace kcenon::container;
 
 // ============================================================================
 // Modern factory API tests (factory::make, factory::make_null)


### PR DESCRIPTION
Closes #380 (Phase 1: Namespace migration)

## Summary

- Rename root namespace from `container_module` to `kcenon::container` across all 120 source files for ecosystem consistency
- Rename `container_grpc` to `kcenon::container_grpc` across all gRPC modules (13 files)
- Add backward-compatibility namespace aliases (`container_module = kcenon::container`, `container_grpc = kcenon::container_grpc`) for one release cycle
- All sub-namespaces preserved: `::async`, `::internal`, `::integration`, `::simd`, `::core`, `::policy`

### Migration Statistics

| Metric | Count |
|--------|-------|
| Files modified | 120 |
| `container_module` references replaced | 517 |
| `container_grpc` references replaced | 32 |
| Backward-compat aliases added | 2 |

### Ecosystem Alignment

| System | Namespace | Status |
|--------|-----------|--------|
| common_system | `kcenon::common` | Already consistent |
| thread_system | `kcenon::thread` | Already consistent |
| logger_system | `kcenon::logger` | Already consistent |
| **container_system** | **`kcenon::container`** | **This PR** |

### Remaining Phases (tracked in #380)

- [ ] Phase 2: Include path migration (`include/container/` → `include/kcenon/container/`)
- [ ] Phase 3: Downstream updates (network_system, database_system, pacs_system)
- [ ] Phase 4: Remove backward-compat aliases

## Test Plan

- [x] Full CMake build passes (Release config, zero new errors)
- [x] All 27 unit and integration tests pass (100%)
- [x] Backward-compatibility aliases verified (downstream code using `container_module::` compiles)
- [x] CI pipeline verification (Linux, macOS, Windows)
- [x] ASAN/TSAN builds pass