### PR TITLE
chore(deps): pin fmt minimum version to 10.0.0

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -26,7 +26,10 @@
     "fmt-support": {
       "description": "Use fmt library for formatting (fallback for compilers without std::format)",
       "dependencies": [
-        "fmt"
+        {
+          "name": "fmt",
+          "version>=": "10.0.0"
+        }
       ]
     },
     "samples": {


### PR DESCRIPTION
## Summary

- Pin fmt dependency in `fmt-support` feature to `>= 10.0.0`
- Aligns with logger_system and network_system fmt version requirements
- Ensures SOUP traceability per IEC 62304

## Test Plan

- [x] `vcpkg.json` passes JSON validation
- [x] CI build succeeds with pinned version constraint

Closes #383