### PR TITLE
docs: add LICENSE-THIRD-PARTY for SOUP compliance

### DIFF
--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -1,0 +1,23 @@
+# Third-Party License Compliance
+
+This file documents third-party dependencies and their license compatibility
+with the project's BSD-3-Clause license.
+
+## fmt (Optional — fmt-support feature)
+
+| Item               | Value                                          |
+|--------------------|--------------------------------------------- --|
+| Component          | {fmt} formatting library                       |
+| License            | MIT                                            |
+| Minimum Version    | 10.0.0                                         |
+| Usage              | String formatting (fallback for std::format)   |
+| Linking            | Header-only or shared                          |
+| BSD-3 Compatible   | Yes                                            |
+
+## All Dependencies (License Summary)
+
+| Dependency        | License        | Type     | BSD-3 Compatible |
+|-------------------|----------------|----------|------------------|
+| fmt               | MIT            | Optional | Yes              |
+| GTest/GMock       | BSD-3-Clause   | Testing  | Yes              |
+| Google Benchmark  | Apache-2.0     | Testing  | Yes              |


### PR DESCRIPTION
## Summary

- Add LICENSE-THIRD-PARTY documenting third-party dependency licenses
- Covers fmt (MIT), GTest (BSD-3-Clause), Google Benchmark (Apache-2.0)
- Follows ecosystem convention from network_system and database_system

## Test Plan

- [x] Format consistent with existing LICENSE-THIRD-PARTY files
- [x] All vcpkg.json dependencies covered

Part of kcenon/common_system#382