### PR TITLE
docs: add SOUP list for IEC 62304 compliance

### DIFF
--- a/docs/SOUP.md
+++ b/docs/SOUP.md
@@ -1,0 +1,101 @@
+# SOUP List &mdash; container_system
+
+> **Software of Unknown Provenance (SOUP) Register per IEC 62304:2006+AMD1:2015 &sect;8.1.2**
+>
+> This document is the authoritative reference for all external software dependencies.
+> Every entry must include: title, manufacturer, unique version identifier, license, and known anomalies.
+
+| Document | Version |
+|----------|---------|
+| IEC 62304 Reference | &sect;8.1.2 Software items from SOUP |
+| Last Reviewed | 2026-03-06 |
+| container_system Version | 2.0.0 |
+
+---
+
+## Internal Ecosystem Dependencies
+
+| ID | Name | Manufacturer | Version | License | Usage | Safety Class | Known Anomalies |
+|----|------|-------------|---------|---------|-------|-------------|-----------------|
+| INT-001 | [common_system](https://github.com/kcenon/common_system) | kcenon | Latest (vcpkg / source) | BSD-3-Clause | Result&lt;T&gt; pattern, error handling primitives, interfaces | B | None |
+
+---
+
+## Production SOUP
+
+### System Dependencies
+
+| ID | Name | Manufacturer | Version | License | Usage | Safety Class | Known Anomalies |
+|----|------|-------------|---------|---------|-------|-------------|-----------------|
+| SOUP-001 | POSIX Threads (pthreads) | POSIX / OS vendor | System-provided | N/A (OS) | Thread-safe container operations via `find_package(Threads)` | B | None |
+
+---
+
+## Optional SOUP
+
+| ID | Name | Manufacturer | Version | License | Usage | Safety Class | Known Anomalies |
+|----|------|-------------|---------|---------|-------|-------------|-----------------|
+| SOUP-002 | [fmt](https://github.com/fmtlib/fmt) | Victor Zverovich | 10.2.1 | MIT | String formatting fallback for compilers without `std::format` (`fmt-support` feature) | A | None |
+
+---
+
+## Development/Test SOUP (Not Deployed)
+
+| ID | Name | Manufacturer | Version | License | Usage | Qualification |
+|----|------|-------------|---------|---------|-------|--------------|
+| SOUP-T01 | [Google Test](https://github.com/google/googletest) | Google | 1.14.0 | BSD-3-Clause | Unit testing framework (includes GMock) | Required |
+| SOUP-T02 | [Google Benchmark](https://github.com/google/benchmark) | Google | 1.8.3 | Apache-2.0 | Performance benchmarking framework | Not required |
+| SOUP-T03 | [Doxygen](https://www.doxygen.nl/) | Dimitri van Heesch | Latest | GPL-2.0 | API documentation generation (build tool only) | Not required |
+
+---
+
+## Safety Classification Key
+
+| Class | Definition | Example |
+|-------|-----------|---------|
+| **A** | No contribution to hazardous situation | Logging, formatting, test frameworks |
+| **B** | Non-serious injury possible | Data processing, network communication |
+| **C** | Death or serious injury possible | Encryption, access control |
+
+---
+
+## Version Pinning (IEC 62304 Compliance)
+
+All SOUP versions are pinned in `vcpkg.json` via the `overrides` field:
+
+```json
+{
+  "overrides": [
+    { "name": "fmt", "version": "10.2.1" },
+    { "name": "gtest", "version": "1.14.0" },
+    { "name": "benchmark", "version": "1.8.3" }
+  ]
+}
+```
+
+The vcpkg baseline is locked in `vcpkg-configuration.json` to ensure reproducible builds.
+
+---
+
+## Version Update Process
+
+When updating any SOUP dependency:
+
+1. Update the version in `vcpkg.json` (overrides section)
+2. Update the corresponding row in this document
+3. Verify no new known anomalies (check CVE databases)
+4. Run full CI/CD pipeline to confirm compatibility
+5. Document the change in the PR description
+
+---
+
+## License Compliance Summary
+
+| License | Count | Copyleft | Obligation |
+|---------|-------|----------|------------|
+| MIT | 1 | No | Include copyright notice |
+| BSD-3-Clause | 1 | No | Include copyright + no-endorsement clause |
+| Apache-2.0 | 1 | No | Include license + NOTICE file |
+| GPL-2.0 | 1 | Yes | Build tool only; not linked or distributed |
+
+> **GPL contamination**: None. Doxygen is a build tool that does not link with or become part of the distributed software.


### PR DESCRIPTION
## Summary
- Add `docs/SOUP.md` — project-specific SOUP register per IEC 62304:2006+AMD1:2015 §8.1.2
- Documents system SOUP (pthreads), optional SOUP (fmt), and test/dev SOUP
- Includes safety classification, version pinning, and license compliance summary

## Test plan
- [x] Verify `docs/SOUP.md` renders correctly on GitHub
- [x] Validate version numbers match `vcpkg.json` overrides