### PR TITLE
chore(deps): pin gRPC and Protobuf dependency versions in vcpkg.json

### DIFF
--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -14,10 +14,34 @@ with the project's BSD-3-Clause license.
 | Linking            | Header-only or shared                          |
 | BSD-3 Compatible   | Yes                                            |
 
+## gRPC (Version Override)
+
+| Item               | Value                                          |
+|--------------------|------------------------------------------------|
+| Component          | gRPC remote procedure call framework           |
+| License            | Apache-2.0                                     |
+| Pinned Version     | 1.51.1                                         |
+| Usage              | Version override for reproducible builds       |
+| Linking            | Shared                                         |
+| BSD-3 Compatible   | Yes                                            |
+
+## Protocol Buffers (Version Override)
+
+| Item               | Value                                          |
+|--------------------|------------------------------------------------|
+| Component          | Google Protocol Buffers                        |
+| License            | BSD-3-Clause                                   |
+| Pinned Version     | 3.21.12                                        |
+| Usage              | Version override for reproducible builds       |
+| Linking            | Shared                                         |
+| BSD-3 Compatible   | Yes                                            |
+
 ## All Dependencies (License Summary)
 
 | Dependency        | License        | Type     | BSD-3 Compatible |
 |-------------------|----------------|----------|------------------|
 | fmt               | MIT            | Optional | Yes              |
+| gRPC              | Apache-2.0     | Override | Yes              |
+| Protocol Buffers  | BSD-3-Clause   | Override | Yes              |
 | GTest/GMock       | BSD-3-Clause   | Testing  | Yes              |
 | Google Benchmark  | Apache-2.0     | Testing  | Yes              |

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -12,6 +12,8 @@
   ],
   "overrides": [
     { "name": "fmt", "version": "10.2.1" },
+    { "name": "grpc", "version": "1.51.1" },
+    { "name": "protobuf", "version": "3.21.12" },
     { "name": "gtest", "version": "1.14.0" },
     { "name": "benchmark", "version": "1.8.3" }
   ],


### PR DESCRIPTION
## Summary

- Pin gRPC to version 1.51.1 and Protobuf to version 3.21.12 via vcpkg.json overrides
- Update LICENSE-THIRD-PARTY with gRPC and Protobuf license entries
- Aligns container_system with the dependency versions used by monitoring_system and logger_system

## Why

Without pinned versions, vcpkg resolves the latest available gRPC and Protobuf,
which can differ across developer machines and CI runs. This causes:

- **Non-reproducible builds**: Different environments may pull different versions
- **ABI mismatches**: Transitive dependencies (e.g., abseil, re2) may conflict
  when sibling repositories pin different versions
- **Inaccurate CVE tracking**: Without a declared version, security scanning
  tools cannot reliably detect known vulnerabilities

Prior art: kcenon/monitoring_system#487 standardized on these same versions.

## Where

| File                  | Change                                          |
|-----------------------|-------------------------------------------------|
| `vcpkg.json`          | Added gRPC 1.51.1 and Protobuf 3.21.12 overrides |
| `LICENSE-THIRD-PARTY` | Added gRPC (Apache-2.0) and Protobuf (BSD-3-Clause) license entries |

## Test plan

- [x] Verify `vcpkg.json` is valid JSON (`python3 -m json.tool vcpkg.json`)
- [x] Confirm CI build passes with pinned versions
- [x] Verify no C++ source files were modified
- [ ] Cross-check pinned versions match monitoring_system and logger_system

Closes #389