### PR TITLE
fix(build): remove stale fmt dependency from installed CMake config

### DIFF
--- a/cmake/ContainerSystemConfig.cmake.in
+++ b/cmake/ContainerSystemConfig.cmake.in
@@ -8,7 +8,6 @@ include(CMakeFindDependencyMacro)
 
 # Find required dependencies
 find_dependency(Threads REQUIRED)
-find_dependency(fmt CONFIG REQUIRED)
 
 # Include targets
 include("${CMAKE_CURRENT_LIST_DIR}/ContainerSystemTargets.cmake")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,7 +11,6 @@
     "kcenon-common-system"
   ],
   "overrides": [
-    { "name": "fmt", "version": "10.2.1" },
     { "name": "grpc", "version": "1.51.1" },
     { "name": "protobuf", "version": "3.21.12" },
     { "name": "gtest", "version": "1.14.0" },


### PR DESCRIPTION
## Summary
- Remove `find_dependency(fmt CONFIG REQUIRED)` from `ContainerSystemConfig.cmake.in` — the project migrated to C++20 `std::format` but the config template still required `fmt`
- Remove `fmt` version override from `vcpkg.json` — `fmt` remains available as an optional `fmt-support` feature for compilers without `std::format`
- `CMakeLists.txt:310` confirms: "C++20 std::format is required (no fmt library fallback)"

## Test plan
- [x] CI builds pass on all platforms (Ubuntu, macOS, Windows)
- [x] No `fmt` references remain in mandatory dependency paths
- [x] `fmt-support` feature in vcpkg.json remains intact for optional use

Closes #391