### PR TITLE
chore(cleanup): remove stale .bak test backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,8 @@ Thumbs.db
 
 # Backup files
 *.bak
-*.origdocs/api/
+*.orig
+docs/api/
 
 # Documentation
 documents/


### PR DESCRIPTION
## Summary

- Remove 3 stale `.bak` backup files from `tests/` left over from API migration (`result_api_tests.cpp.bak`, `schema_tests.cpp.bak`, `unit_tests.cpp.bak`)
- Fix `.gitignore` formatting: split concatenated `*.origdocs/api/` into separate `*.orig` and `docs/api/` entries
- `*.bak` pattern was already present in `.gitignore` but the backup files existed as untracked local artifacts

Part of kcenon/common_system#393