### PR TITLE
chore(ci): Graduate sanitizer jobs from Phase 0 to Phase 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,11 +149,9 @@ jobs:
           build/CMakeFiles/*.log
           build/Testing/Temporary/
 
-  # Phase 0: Allow failures, just collect data
   sanitizers:
     name: Sanitizers (${{ matrix.sanitizer.name }})
     runs-on: ubuntu-24.04
-    continue-on-error: true
     timeout-minutes: 30
 
     strategy:
@@ -217,7 +215,7 @@ jobs:
         for test in bin/unit_tests bin/test_messaging_integration; do
           if [ -f "$test" ]; then
             echo "Running $(basename $test) with ${{ matrix.sanitizer.name }}..."
-            ./$test || echo "${{ matrix.sanitizer.name }} detected issues (expected in Phase 0)"
+            ./$test
           fi
         done
 

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -119,7 +119,7 @@ jobs:
       run: |
         echo "# Sanitizer Test Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "## Phase 0: Baseline Establishment" >> $GITHUB_STEP_SUMMARY
+        echo "## Phase 1: Blocking Sanitizer Tests" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "Sanitizer tests configured and running." >> $GITHUB_STEP_SUMMARY
-        echo "Warnings allowed in Phase 0 for baseline establishment." >> $GITHUB_STEP_SUMMARY
+        echo "Sanitizer failures block merges in Phase 1." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` from sanitizer job in ci.yml
- Remove `|| echo` fallbacks from sanitizer test execution
- Update sanitizers.yml summary text to Phase 1

## Test plan
- [x] ASan CI job passes
- [x] TSan CI job passes
- [x] UBSan CI job passes

Refs: kcenon/common_system#394