### PR TITLE
chore(deps): replace GIT_TAG main default with v0.1.0 and add deprecation warning

### DIFF
--- a/cmake/UnifiedDependencies.cmake
+++ b/cmake/UnifiedDependencies.cmake
@@ -30,8 +30,20 @@ include(FetchContent)
 option(UNIFIED_ALLOW_FETCHCONTENT "Allow FetchContent fallback for dependencies" ON)
 
 # GitHub repository URLs for FetchContent
+# IMPORTANT: Set UNIFIED_COMMON_SYSTEM_GIT_TAG to a specific release tag (e.g., "v0.1.0")
+# for reproducible builds. Using "main" is a moving target and breaks SOUP traceability.
+# See: https://github.com/kcenon/common_system/issues/402
 set(UNIFIED_COMMON_SYSTEM_GIT_URL "https://github.com/kcenon/common_system.git" CACHE STRING "Git URL for common_system")
-set(UNIFIED_COMMON_SYSTEM_GIT_TAG "main" CACHE STRING "Git tag/branch for common_system")
+set(UNIFIED_COMMON_SYSTEM_GIT_TAG "v0.1.0" CACHE STRING "Git tag/branch for common_system (use a release tag, not 'main')")
+
+if("${UNIFIED_COMMON_SYSTEM_GIT_TAG}" STREQUAL "main")
+    message(WARNING
+        "UNIFIED_COMMON_SYSTEM_GIT_TAG is set to 'main', which is a moving target.\n"
+        "This breaks build reproducibility and SOUP version traceability (IEC 62304 §8.1.2).\n"
+        "Set UNIFIED_COMMON_SYSTEM_GIT_TAG to a specific release tag, e.g.:\n"
+        "  cmake -DUNIFIED_COMMON_SYSTEM_GIT_TAG=v0.1.0 ..."
+    )
+endif()
 
 #[[
 unified_find_dependency(<name> [REQUIRED])


### PR DESCRIPTION
Part of kcenon/common_system#402

## Summary

- Change `UNIFIED_COMMON_SYSTEM_GIT_TAG` default from `"main"` to `"v0.1.0"`
- Add CMake `WARNING` when the tag is set to `"main"` to catch accidental usage
- Add reference to tracking issue in the comment block

## Why

Using `main` as a `GIT_TAG` breaks:
1. **Build reproducibility** — a push to `main` can silently change what gets compiled
2. **SOUP version traceability** — IEC 62304 §8.1.2 requires exact version identification for SOUP components

## Files Modified

- `cmake/UnifiedDependencies.cmake`

## Test Plan

- [ ] CMake configure with default settings uses `v0.1.0` tag
- [ ] Setting `-DUNIFIED_COMMON_SYSTEM_GIT_TAG=main` emits a CMake WARNING
- [ ] FetchContent fallback still works when tag exists in remote