### PR TITLE
docs(legal): document grpc module dependency scope

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -59,60 +59,8 @@ jobs:
       with:
         sarif_file: ${{ steps.grype-scan.outputs.sarif }}
 
-    - name: Parse vcpkg dependencies
-      run: |
-        if [ -f "vcpkg.json" ]; then
-          python3 << 'PYEOF' > vcpkg-dependencies.md
-        import json
-
-        with open('vcpkg.json', 'r') as f:
-            manifest = json.load(f)
-
-        print("# vcpkg Dependencies")
-        print()
-        print(f"**Project**: {manifest.get('name', 'N/A')}")
-        print(f"**Version**: {manifest.get('version', 'N/A')}")
-        print()
-        print("## Direct Dependencies")
-        print()
-        print("| Package | Version Constraint | Features |")
-        print("|---------|-------------------|----------|")
-
-        deps = manifest.get('dependencies', [])
-        for dep in deps:
-            if isinstance(dep, str):
-                print(f"| {dep} | - | - |")
-            elif isinstance(dep, dict):
-                name = dep.get('name', 'unknown')
-                version = dep.get('version>=', '-')
-                features = ', '.join(dep.get('features', [])) or '-'
-                print(f"| {name} | {version} | {features} |")
-
-        features = manifest.get('features', {})
-        if features:
-            print()
-            print("## Feature Dependencies")
-            print()
-            for feat_name, feat_data in features.items():
-                feat_deps = feat_data.get('dependencies', [])
-                if feat_deps:
-                    print(f"### {feat_name}")
-                    print()
-                    print("| Package | Version Constraint | Features |")
-                    print("|---------|-------------------|----------|")
-                    for dep in feat_deps:
-                        if isinstance(dep, str):
-                            print(f"| {dep} | - | - |")
-                        elif isinstance(dep, dict):
-                            name = dep.get('name', 'unknown')
-                            version = dep.get('version>=', '-')
-                            dep_features = ', '.join(dep.get('features', [])) or '-'
-                            print(f"| {name} | {version} | {dep_features} |")
-                    print()
-        PYEOF
-        else
-          echo "No vcpkg.json found" > vcpkg-dependencies.md
-        fi
+    - name: Generate dependency inventory report
+      run: python3 scripts/ci/generate_dependency_report.py > vcpkg-dependencies.md
 
     - name: Create combined SBOM report
       run: |

--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -3,7 +3,16 @@
 This file documents third-party dependencies and their license compatibility
 with the project's BSD-3-Clause license.
 
-## fmt (Optional — fmt-support feature)
+## Default Build
+
+The default root package has no required third-party library dependencies.
+`container_system` links internal ecosystem code (`common_system`) and
+system-provided threading support, but third-party libraries are introduced
+only by optional features, isolated module builds, or test tooling.
+
+## Optional Feature Dependencies
+
+## fmt (`fmt-support` feature)
 
 | Item               | Value                                          |
 |--------------------|--------------------------------------------- --|
@@ -14,34 +23,60 @@ with the project's BSD-3-Clause license.
 | Linking            | Header-only or shared                          |
 | BSD-3 Compatible   | Yes                                            |
 
-## gRPC (Version Override)
+## Optional Module Deliverables
+
+## gRPC (`grpc/` isolated subproject)
 
 | Item               | Value                                          |
 |--------------------|------------------------------------------------|
 | Component          | gRPC remote procedure call framework           |
 | License            | Apache-2.0                                     |
 | Pinned Version     | 1.51.1                                         |
-| Usage              | Version override for reproducible builds       |
+| Usage              | Transport/runtime dependency for the isolated `grpc/` deliverable |
 | Linking            | Shared                                         |
 | BSD-3 Compatible   | Yes                                            |
 
-## Protocol Buffers (Version Override)
+## Protocol Buffers (`grpc/` isolated subproject)
 
 | Item               | Value                                          |
 |--------------------|------------------------------------------------|
 | Component          | Google Protocol Buffers                        |
 | License            | BSD-3-Clause                                   |
 | Pinned Version     | 3.21.12                                        |
-| Usage              | Version override for reproducible builds       |
+| Usage              | Serialization and code generation for the isolated `grpc/` deliverable |
 | Linking            | Shared                                         |
 | BSD-3 Compatible   | Yes                                            |
 
-## All Dependencies (License Summary)
+## Development and Test Dependencies
+
+## Google Test / GMock (`testing` feature)
+
+| Item               | Value                                          |
+|--------------------|------------------------------------------------|
+| Component          | Google Test / GMock                            |
+| License            | BSD-3-Clause                                   |
+| Pinned Version     | 1.14.0                                         |
+| Usage              | Unit and integration tests                     |
+| Linking            | Static or shared                               |
+| BSD-3 Compatible   | Yes                                            |
+
+## Google Benchmark (`testing` feature)
+
+| Item               | Value                                          |
+|--------------------|------------------------------------------------|
+| Component          | Google Benchmark                               |
+| License            | Apache-2.0                                     |
+| Pinned Version     | 1.8.3                                          |
+| Usage              | Performance benchmarking                       |
+| Linking            | Static or shared                               |
+| BSD-3 Compatible   | Yes                                            |
+
+## Dependency Summary
 
 | Dependency        | License        | Type     | BSD-3 Compatible |
 |-------------------|----------------|----------|------------------|
 | fmt               | MIT            | Optional | Yes              |
-| gRPC              | Apache-2.0     | Override | Yes              |
-| Protocol Buffers  | BSD-3-Clause   | Override | Yes              |
+| gRPC              | Apache-2.0     | Optional module | Yes              |
+| Protocol Buffers  | BSD-3-Clause   | Optional module | Yes              |
 | GTest/GMock       | BSD-3-Clause   | Testing  | Yes              |
 | Google Benchmark  | Apache-2.0     | Testing  | Yes              |

--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ common_system (ONLY required ecosystem dependency)
 | Circular dependency risk | None | Only depends downward |
 | Isolated build | ✅ | Can build with only common_system |
 
+> **Optional module boundary**: The repository also contains an isolated `grpc/`
+> subproject that is not built by the root `CMakeLists.txt`. It is a separately
+> scoped deliverable with its own gRPC/protobuf dependency path.
+
 **Why this matters:**
 - Faster compilation times
 - Easier testing and debugging
@@ -142,6 +146,21 @@ common_system (ONLY required ecosystem dependency)
 | CMake | 3.20+ | Yes | Build system |
 | common_system | latest | Yes | C++20 Concepts and common interfaces |
 | vcpkg | latest | Optional | Package management (recommended) |
+
+#### Optional Module Deliverables
+
+| Module | Built by Root Project | Dependencies | Scope |
+|--------|-----------------------|--------------|-------|
+| `grpc/` | No | `protobuf` 3.21.12, `gRPC` 1.51.1, system threads | Isolated integration module built with `cmake -S grpc -B build-grpc` |
+
+SBOM artifacts treat `grpc/` as a module-scoped optional deliverable. The root
+package dependency inventory covers `vcpkg.json`, and the SBOM report adds a
+separate section for the isolated gRPC build path when that module is relevant.
+
+```bash
+cmake -S grpc -B build-grpc
+cmake --build build-grpc
+```
 
 ### Installation
 

--- a/docs/SOUP.md
+++ b/docs/SOUP.md
@@ -8,7 +8,7 @@
 | Document | Version |
 |----------|---------|
 | IEC 62304 Reference | &sect;8.1.2 Software items from SOUP |
-| Last Reviewed | 2026-03-06 |
+| Last Reviewed | 2026-03-10 |
 | container_system Version | 2.0.0 |
 
 ---
@@ -33,9 +33,14 @@
 
 ## Optional SOUP
 
+Optional SOUP entries cover both root-package features and separately scoped
+module deliverables that are not built by the root `CMakeLists.txt`.
+
 | ID | Name | Manufacturer | Version | License | Usage | Safety Class | Known Anomalies |
 |----|------|-------------|---------|---------|-------|-------------|-----------------|
-| SOUP-002 | [fmt](https://github.com/fmtlib/fmt) | Victor Zverovich | 10.2.1 | MIT | String formatting fallback for compilers without `std::format` (`fmt-support` feature) | A | None |
+| SOUP-002 | [fmt](https://github.com/fmtlib/fmt) | Victor Zverovich | 10.0.0+ | MIT | String formatting fallback for compilers without `std::format` (`fmt-support` feature) | A | None |
+| SOUP-003 | [gRPC](https://grpc.io/) | Google / CNCF | 1.51.1 | Apache-2.0 | RPC transport and generated service bindings for the isolated `grpc/` integration module | B | None |
+| SOUP-004 | [Protocol Buffers](https://protobuf.dev/) | Google | 3.21.12 | BSD-3-Clause | Message serialization and code generation for the isolated `grpc/` integration module | B | None |
 
 ---
 
@@ -59,21 +64,43 @@
 
 ---
 
-## Version Pinning (IEC 62304 Compliance)
+## Version Pinning and Feature Constraints (IEC 62304 Compliance)
 
-All SOUP versions are pinned in `vcpkg.json` via the `overrides` field:
+Pinned versions in `vcpkg.json` are controlled via the `overrides` field for
+module and test dependencies, while feature-scoped dependencies can use
+version constraints:
 
 ```json
 {
   "overrides": [
-    { "name": "fmt", "version": "10.2.1" },
+    { "name": "grpc", "version": "1.51.1" },
+    { "name": "protobuf", "version": "3.21.12" },
     { "name": "gtest", "version": "1.14.0" },
     { "name": "benchmark", "version": "1.8.3" }
-  ]
+  ],
+  "features": {
+    "fmt-support": {
+      "dependencies": [
+        {
+          "name": "fmt",
+          "version>=": "10.0.0"
+        }
+      ]
+    }
+  }
 }
 ```
 
 The vcpkg baseline is locked in `vcpkg-configuration.json` to ensure reproducible builds.
+
+## Module Scope Boundary
+
+The root `container_system` package does not link gRPC or protobuf in its
+default build. Those dependencies apply only when the isolated `grpc/`
+subproject is configured directly, for example with `cmake -S grpc -B build-grpc`.
+Treat the `grpc/` artifacts (`container_grpc_proto`, `container_grpc_adapter`,
+and `container_grpc`) as a separately scoped deliverable for SOUP, license,
+and SBOM review.
 
 ---
 
@@ -81,7 +108,7 @@ The vcpkg baseline is locked in `vcpkg-configuration.json` to ensure reproducibl
 
 When updating any SOUP dependency:
 
-1. Update the version in `vcpkg.json` (overrides section)
+1. Update the version in `vcpkg.json` (`overrides` or feature constraints)
 2. Update the corresponding row in this document
 3. Verify no new known anomalies (check CVE databases)
 4. Run full CI/CD pipeline to confirm compatibility
@@ -94,8 +121,8 @@ When updating any SOUP dependency:
 | License | Count | Copyleft | Obligation |
 |---------|-------|----------|------------|
 | MIT | 1 | No | Include copyright notice |
-| BSD-3-Clause | 1 | No | Include copyright + no-endorsement clause |
-| Apache-2.0 | 1 | No | Include license + NOTICE file |
+| BSD-3-Clause | 2 | No | Include copyright + no-endorsement clause |
+| Apache-2.0 | 2 | No | Include license + NOTICE file |
 | GPL-2.0 | 1 | Yes | Build tool only; not linked or distributed |
 
 > **GPL contamination**: None. Doxygen is a build tool that does not link with or become part of the distributed software.

--- a/scripts/ci/generate_dependency_report.py
+++ b/scripts/ci/generate_dependency_report.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Generate a human-readable dependency report for SBOM artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO_ROOT / "vcpkg.json"
+GRPC_CMAKE_PATH = REPO_ROOT / "grpc" / "CMakeLists.txt"
+
+
+def format_dependency(dep: str | dict) -> tuple[str, str, str]:
+    if isinstance(dep, str):
+        return dep, "-", "-"
+
+    name = dep.get("name", "unknown")
+    version = dep.get("version>=", "-")
+    features = ", ".join(dep.get("features", [])) or "-"
+    return name, version, features
+
+
+def print_table(rows: list[tuple[str, str, str]]) -> None:
+    print("| Package | Version Constraint | Features |")
+    print("|---------|-------------------|----------|")
+    for name, version, features in rows:
+        print(f"| {name} | {version} | {features} |")
+
+
+def main() -> int:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    overrides = {item["name"]: item["version"] for item in manifest.get("overrides", [])}
+
+    print("# Dependency Inventory")
+    print()
+    print(f"**Project**: {manifest.get('name', 'N/A')}")
+    print(f"**Version**: {manifest.get('version', 'N/A')}")
+    print()
+    print("## Root Package Dependencies")
+    print()
+
+    direct_rows = [format_dependency(dep) for dep in manifest.get("dependencies", [])]
+    if direct_rows:
+        print_table(direct_rows)
+    else:
+        print("The root package has no direct third-party dependencies.")
+
+    features = manifest.get("features", {})
+    if features:
+        print()
+        print("## Feature Dependencies")
+        print()
+        for feature_name, feature_data in features.items():
+            print(f"### {feature_name}")
+            print()
+            rows = [format_dependency(dep) for dep in feature_data.get("dependencies", [])]
+            if rows:
+                print_table(rows)
+            else:
+                print("No additional package dependencies.")
+            print()
+
+    print("## Module-Scoped Optional Deliverables")
+    print()
+    if GRPC_CMAKE_PATH.exists():
+        print("| Module | Built by Root Project | Dependencies | Activation |")
+        print("|--------|-----------------------|--------------|------------|")
+        grpc_version = overrides.get("grpc", "unversioned")
+        protobuf_version = overrides.get("protobuf", "unversioned")
+        print(
+            "| `grpc/` | No | "
+            f"`protobuf` {protobuf_version}, `gRPC` {grpc_version}, system threads | "
+            "Configure `cmake -S grpc -B build-grpc` |"
+        )
+        print()
+        print(
+            "When the isolated `grpc/` subproject is built, review these module-scoped "
+            "dependencies alongside the root manifest because they are outside the "
+            "default package dependency set."
+        )
+    else:
+        print("No module-scoped optional deliverables detected.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Background

`container_system` already contains an isolated gRPC/protobuf integration under `grpc/`, and the repository pins `grpc` and `protobuf` versions in `vcpkg.json`. The legal and SOUP documentation, however, only described `fmt` as optional and did not explain how the isolated gRPC deliverable should be scoped.

## Problem

The dependency inventory under-reported optional functionality that can materially affect distributed artifacts, license review, and SBOM interpretation. In particular, the repository did not document whether the gRPC integration belongs to the root package or a separate build path.

## Approach

Document the `grpc/` integration as an isolated, module-scoped optional deliverable, align SOUP and license inventory entries with that boundary, and update the SBOM dependency report generation so the gRPC/protobuf path is explicitly represented when relevant.

## Main Changes

- Added gRPC and Protocol Buffers to `docs/SOUP.md` as optional SOUP entries and documented the module-scope boundary for the isolated `grpc/` subproject.
- Reworked `LICENSE-THIRD-PARTY` so the default build, optional feature dependencies, optional module deliverables, and test dependencies are clearly separated.
- Updated `README.md` to explain that `grpc/` is not built by the root `CMakeLists.txt`, how to build it directly, and how SBOM artifacts should interpret that path.
- Replaced the inline SBOM dependency-report generator with `scripts/ci/generate_dependency_report.py`, which now emits both root-manifest and module-scoped dependency information.

## Verification

- `python3 scripts/ci/generate_dependency_report.py`
- `python3 -m py_compile scripts/ci/generate_dependency_report.py`

## Remaining Risks / Follow-up

- `grpc` and `protobuf` remain version overrides rather than root-package dependencies, so automated package-level SBOM tools still need the new module-scoped annotation to avoid misclassification.
- `README.kr.md` and Korean gRPC proposal materials were left untouched because this issue targeted the primary English legal and compliance documentation.

Closes #406