### PR TITLE
docs: improve Doxyfile configuration and add missing Doxygen comments

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -85,7 +85,7 @@ QUIET                  = NO
 WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = YES
 WARN_IF_DOC_ERROR      = YES
-WARN_NO_PARAMDOC       = NO
+WARN_NO_PARAMDOC       = YES
 WARN_AS_ERROR          = NO
 WARN_FORMAT            = "$file:$line: $text"
 WARN_LOGFILE           =
@@ -105,7 +105,8 @@ FILE_PATTERNS          = *.c \
                          *.h \
                          *.hh \
                          *.hpp \
-                         *.tpp
+                         *.tpp \
+                         *.cppm
 
 RECURSIVE              = YES
 EXCLUDE                = build \
@@ -129,19 +130,18 @@ INPUT_FILTER           =
 FILTER_PATTERNS        =
 FILTER_SOURCE_FILES    = NO
 FILTER_SOURCE_PATTERNS =
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = README.md
 
 SOURCE_BROWSER         = YES
 INLINE_SOURCES         = YES
 STRIP_CODE_COMMENTS    = YES
-REFERENCED_BY_RELATION = NO
-REFERENCES_RELATION    = NO
+REFERENCED_BY_RELATION = YES
+REFERENCES_RELATION    = YES
 REFERENCES_LINK_SOURCE = YES
 SOURCE_TOOLTIPS        = YES
 USE_HTAGS              = NO
 VERBATIM_HEADERS       = YES
 CLANG_ASSISTED_PARSING = NO
-CLANG_OPTIONS          = -std=c++20
 
 ALPHABETICAL_INDEX     = YES
 COLS_IN_ALPHA_INDEX    = 5
@@ -185,7 +185,7 @@ QHG_LOCATION           =
 GENERATE_ECLIPSEHELP   = NO
 ECLIPSE_DOC_ID         = org.container.system
 DISABLE_INDEX          = NO
-GENERATE_TREEVIEW      = NO
+GENERATE_TREEVIEW      = YES
 ENUM_VALUES_PER_LINE   = 4
 TREEVIEW_WIDTH         = 250
 EXT_LINKS_IN_WINDOW    = NO
@@ -294,7 +294,7 @@ COLLABORATION_GRAPH    = YES
 GROUP_GRAPHS           = YES
 UML_LOOK               = YES
 UML_LIMIT_NUM_FIELDS   = 10
-TEMPLATE_RELATIONS     = NO
+TEMPLATE_RELATIONS     = YES
 INCLUDE_GRAPH          = YES
 INCLUDED_BY_GRAPH      = YES
 CALL_GRAPH             = YES

--- a/include/container/optimizations/fast_parser.h
+++ b/include/container/optimizations/fast_parser.h
@@ -28,15 +28,34 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
+
+/**
+ * @file fast_parser.h
+ * @brief Fast-path parsing utilities and configuration for the container system.
+ */
+
 namespace kcenon::container {
+
+/**
+ * @brief Reserve capacity on a container if the reserve() method is available.
+ * @tparam Container A container type that may or may not support reserve().
+ * @param c The container to reserve capacity on.
+ * @param size The number of elements to reserve space for.
+ */
 template<typename Container>
 inline void reserve_if_possible(Container& c, size_t size) {
     if constexpr (requires { c.reserve(size); }) {
         c.reserve(size);
     }
 }
+
+/**
+ * @struct parser_config
+ * @brief Configuration parameters for the fast parser.
+ */
 struct parser_config {
-    bool use_fast_path{true};
-    size_t initial_capacity{256};
+    bool use_fast_path{true};       ///< Whether to use the optimized fast parsing path.
+    size_t initial_capacity{256};   ///< Initial buffer capacity in bytes.
 };
-} // namespace
+
+} // namespace kcenon::container

--- a/src/modules/container.cppm
+++ b/src/modules/container.cppm
@@ -71,25 +71,26 @@ export namespace kcenon::container {
 // =============================================================================
 
 /**
+ * @enum value_types
  * @brief Enumeration of available value types in the container system.
  */
 enum class value_types {
-    null_value,
-    bool_value,
-    short_value,
-    ushort_value,
-    int_value,
-    uint_value,
-    long_value,
-    ulong_value,
-    llong_value,
-    ullong_value,
-    float_value,
-    double_value,
-    string_value,
-    bytes_value,
-    container_value,
-    array_value
+    null_value,         ///< Represents an empty or null value.
+    bool_value,         ///< Boolean true/false value.
+    short_value,        ///< Signed short integer.
+    ushort_value,       ///< Unsigned short integer.
+    int_value,          ///< Signed integer.
+    uint_value,         ///< Unsigned integer.
+    long_value,         ///< Signed long integer.
+    ulong_value,        ///< Unsigned long integer.
+    llong_value,        ///< Signed long long integer.
+    ullong_value,       ///< Unsigned long long integer.
+    float_value,        ///< Single-precision floating point.
+    double_value,       ///< Double-precision floating point.
+    string_value,       ///< UTF-8 string value.
+    bytes_value,        ///< Raw byte array.
+    container_value,    ///< Nested value_container (key-value map).
+    array_value         ///< Array of values.
 };
 
 // Compile-time type mapping
@@ -113,7 +114,9 @@ constexpr std::array<std::pair<std::string_view, value_types>, 16> type_map{{
 }};
 
 /**
- * @brief Compile-time conversion from string to value_types
+ * @brief Compile-time conversion from string to value_types.
+ * @param str The string representation of the type (e.g., "0" for null).
+ * @return The corresponding value_types enum value, or null_value if not found.
  */
 constexpr value_types get_type_from_string(std::string_view str) noexcept {
     for (const auto& [key, type] : type_map) {
@@ -123,7 +126,9 @@ constexpr value_types get_type_from_string(std::string_view str) noexcept {
 }
 
 /**
- * @brief Compile-time conversion from value_types to string
+ * @brief Compile-time conversion from value_types to string.
+ * @param type The value_types enum value to convert.
+ * @return The string representation (e.g., "0" for null), or "0" if not found.
  */
 constexpr std::string_view get_string_from_type(value_types type) noexcept {
     for (const auto& [key, val] : type_map) {
@@ -134,6 +139,8 @@ constexpr std::string_view get_string_from_type(value_types type) noexcept {
 
 /**
  * @brief Convert a string-based type indicator to a value_types enum.
+ * @param target The string to convert (e.g., "0" for null).
+ * @return The corresponding value_types enum value, or null_value if not found.
  */
 inline value_types convert_value_type(const std::string& target) {
     for (const auto& [key, type] : type_map) {
@@ -144,6 +151,8 @@ inline value_types convert_value_type(const std::string& target) {
 
 /**
  * @brief Convert a value_types enum to its associated string indicator.
+ * @param target The value_types enum to convert.
+ * @return The string representation of the type.
  */
 inline std::string convert_value_type(const value_types& target) {
     return std::string(get_string_from_type(target));
@@ -193,25 +202,36 @@ using value_variant = std::variant<
 // =============================================================================
 
 /**
- * @brief Optimized value storage with Small Object Optimization
+ * @struct optimized_value
+ * @brief Optimized value storage with Small Object Optimization.
  */
 struct optimized_value {
-    std::string name;
-    value_types type;
-    value_variant data;
+    std::string name;       ///< Name identifier for this value.
+    value_types type;       ///< The data type of this value.
+    value_variant data;     ///< The actual stored data using variant-based SOO.
 
+    /// @brief Construct a default null value.
     optimized_value()
         : name("")
         , type(value_types::null_value)
         , data(std::monostate{})
     {}
 
+    /**
+     * @brief Construct a named value with the given type (data defaults to monostate).
+     * @param n The name of this value.
+     * @param t The value type.
+     */
     optimized_value(const std::string& n, value_types t)
         : name(n)
         , type(t)
         , data(std::monostate{})
     {}
 
+    /**
+     * @brief Calculate the approximate memory footprint of this value.
+     * @return The estimated total memory usage in bytes.
+     */
     size_t memory_footprint() const {
         size_t base = sizeof(optimized_value);
         base += name.capacity();
@@ -223,6 +243,10 @@ struct optimized_value {
         return base;
     }
 
+    /**
+     * @brief Check whether this value's data is stored on the stack (not heap-allocated).
+     * @return true if the value type uses stack-based storage, false otherwise.
+     */
     bool is_stack_allocated() const {
         return type != value_types::string_value &&
                type != value_types::bytes_value &&
@@ -235,15 +259,24 @@ struct optimized_value {
 // =============================================================================
 
 /**
- * @brief Pool statistics structure
+ * @struct pool_stats
+ * @brief Statistics for object pool usage tracking.
  */
 struct pool_stats {
-    size_t hits{0};
-    size_t misses{0};
-    size_t available{0};
-    double hit_rate{0.0};
+    size_t hits{0};         ///< Number of successful pool retrievals (cache hits).
+    size_t misses{0};       ///< Number of pool misses requiring new allocation.
+    size_t available{0};    ///< Current number of available objects in the pool.
+    double hit_rate{0.0};   ///< Computed hit rate as hits / (hits + misses).
 
+    /// @brief Default constructor with zero-initialized statistics.
     pool_stats() = default;
+
+    /**
+     * @brief Construct pool stats with the given counters.
+     * @param h Number of cache hits.
+     * @param m Number of cache misses.
+     * @param a Number of available objects.
+     */
     pool_stats(size_t h, size_t m, size_t a)
         : hits(h), misses(m), available(a)
         , hit_rate(h + m > 0 ? static_cast<double>(h) / (h + m) : 0.0)
@@ -257,7 +290,9 @@ struct pool_stats {
 namespace variant_helpers {
 
 /**
- * @brief Escape a string for JSON output per RFC 8259
+ * @brief Escape a string for JSON output per RFC 8259.
+ * @param input The raw string to escape.
+ * @return A JSON-safe escaped string.
  */
 inline std::string json_escape(std::string_view input) {
     std::string result;
@@ -303,7 +338,9 @@ inline std::string json_escape(std::string_view input) {
 }
 
 /**
- * @brief Encode a string for XML output per XML 1.0 specification
+ * @brief Encode a string for XML output per XML 1.0 specification.
+ * @param input The raw string to encode.
+ * @return An XML-safe encoded string.
  */
 inline std::string xml_encode(std::string_view input) {
     std::string result;


### PR DESCRIPTION
## Summary
- Add C++20 module support and enable tree view, cross-references, and template relations in Doxyfile
- Remove dead `CLANG_OPTIONS` setting (was no-op since `CLANG_ASSISTED_PARSING = NO`)
- Add full Doxygen markup to `fast_parser.h` (was zero Doxygen)
- Document all 16 `value_types` enumerators with per-value descriptions
- Add `@param`/`@return` to all free functions in `container.cppm`
- Add `@struct`, member docs, and method docs to `optimized_value` and `pool_stats`

## Test plan
- [ ] Run `doxygen Doxyfile` and verify no new warnings
- [ ] Verify `value_types` enumerators appear in documentation
- [ ] Verify `fast_parser.h` types appear in documentation
- [ ] Verify `.cppm` files are included in documentation

Closes #411