### PR TITLE
chore(cmake): normalize project VERSION for vcpkg deployment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ cmake_minimum_required(VERSION 3.16)
 
 # Project definition
 project(container_system
-    VERSION 0.1.0.0
+    VERSION 0.1.0
     DESCRIPTION "Advanced C++20 Container System with Thread-Safe Operations and Messaging Integration"
     LANGUAGES CXX
 )


### PR DESCRIPTION
## Summary

- Normalize `project(VERSION 0.1.0.0)` to `project(VERSION 0.1.0)` for semver consistency with vcpkg manifest
- The 4-component version caused `write_basic_package_version_file` to emit `0.1.0.0`, creating potential mismatch with vcpkg's `0.1.0`

**Note**: The remaining items in #416 (git tag creation, portfile SHA512 recomputation, CMake option name fixes) will be addressed in the vcpkg-registry after this PR merges and a `v0.1.0` tag is created.

## Test plan

- [ ] CI passes on all platforms
- [ ] `PROJECT_VERSION` evaluates to `0.1.0` (3-component)

Part of #416