### PR TITLE
docs: replace GIT_TAG main with tagged versions in FetchContent examples

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -356,7 +356,7 @@ include(FetchContent)
 FetchContent_Declare(
     container_system
     GIT_REPOSITORY https://github.com/kcenon/container_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
 )
 FetchContent_MakeAvailable(container_system)
 ```

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ include(FetchContent)
 FetchContent_Declare(
     container_system
     GIT_REPOSITORY https://github.com/kcenon/container_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
 )
 FetchContent_MakeAvailable(container_system)
 
@@ -491,7 +491,7 @@ include(FetchContent)
 FetchContent_Declare(
     container_system
     GIT_REPOSITORY https://github.com/kcenon/container_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
 )
 
 # common_system will be fetched automatically via UnifiedDependencies.cmake

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -55,7 +55,7 @@ After calling `unified_find_dependency()`, the following variables are set:
 |--------|---------|-------------|
 | `UNIFIED_ALLOW_FETCHCONTENT` | ON | Enable automatic download via FetchContent |
 | `UNIFIED_COMMON_SYSTEM_GIT_URL` | GitHub URL | Git URL for common_system |
-| `UNIFIED_COMMON_SYSTEM_GIT_TAG` | main | Git tag/branch for common_system |
+| `UNIFIED_COMMON_SYSTEM_GIT_TAG` | v0.1.0 | Git tag/branch for common_system |
 
 ### Examples
 
@@ -95,7 +95,7 @@ endif()
 
 # For FetchContent:
 set(UNIFIED_NEW_DEPENDENCY_GIT_URL "https://github.com/org/new_dependency.git" CACHE STRING "")
-set(UNIFIED_NEW_DEPENDENCY_GIT_TAG "main" CACHE STRING "")
+set(UNIFIED_NEW_DEPENDENCY_GIT_TAG "v1.0.0" CACHE STRING "")  # Use a release tag
 ```
 
 ## Other Modules

--- a/docs/architecture/ADR-001-container-system-scope.md
+++ b/docs/architecture/ADR-001-container-system-scope.md
@@ -60,7 +60,7 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG main  # Or specific version tag
+    GIT_TAG v0.2.0  # Pin to a specific release tag; do NOT use main
 )
 
 FetchContent_MakeAvailable(common_system)

--- a/docs/guides/QUICK_START.kr.md
+++ b/docs/guides/QUICK_START.kr.md
@@ -150,7 +150,7 @@ include(FetchContent)
 FetchContent_Declare(
     container_system
     GIT_REPOSITORY https://github.com/kcenon/container_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
 )
 FetchContent_MakeAvailable(container_system)
 target_link_libraries(your_target PRIVATE ContainerSystem::container)

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -150,7 +150,7 @@ include(FetchContent)
 FetchContent_Declare(
     container_system
     GIT_REPOSITORY https://github.com/kcenon/container_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
 )
 FetchContent_MakeAvailable(container_system)
 target_link_libraries(your_target PRIVATE ContainerSystem::container)

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -215,7 +215,7 @@ cd container_system
 include(FetchContent)
 FetchContent_Declare(container_system
     GIT_REPOSITORY https://github.com/kcenon/container_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0
 )
 FetchContent_MakeAvailable(container_system)
 target_link_libraries(your_target PRIVATE ContainerSystem::container)


### PR DESCRIPTION
Part of kcenon/common_system#448

## Summary

- Replace all `GIT_TAG main` references with tagged versions in documentation
- container_system self-references pinned to `v0.1.0`
- common_system reference in ADR-001 pinned to `v0.2.0`
- cmake/README.md default value corrected to match actual CMake code (`v0.1.0`)

## Files Changed

- `README.md` (2 instances)
- `README.kr.md`
- `mainpage.dox`
- `docs/guides/QUICK_START.md`
- `docs/guides/QUICK_START.kr.md`
- `docs/architecture/ADR-001-container-system-scope.md`
- `cmake/README.md` (2 instances)

## Test Plan

- [ ] Verify no remaining `GIT_TAG main` references in documentation
- [ ] Confirm tagged versions match DEPENDENCY_MATRIX.md pinning table