### PR TITLE
chore(deps): Remove fmt-support feature from vcpkg manifest

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -29,15 +29,6 @@
         }
       ]
     },
-    "fmt-support": {
-      "description": "Use fmt library for formatting (fallback for compilers without std::format)",
-      "dependencies": [
-        {
-          "name": "fmt",
-          "version>=": "10.0.0"
-        }
-      ]
-    },
     "samples": {
       "description": "Build sample applications",
       "dependencies": []


### PR DESCRIPTION
## Summary
- Remove dead `fmt-support` feature from `vcpkg.json`

## Why
The build system requires C++20 `std::format` (CMakeLists.txt line 347: "C++20 std::format is required"). The `fmt-support` vcpkg feature was never consumed by the build — enabling it had no effect.

Closes #425

## Test plan
- [ ] `vcpkg.json` remains valid JSON
- [ ] Build succeeds without changes (feature was unused)