### PR TITLE
chore(cmake): Standardize namespace to snake_case (ContainerSystem:: → container_system::)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,8 @@ if(BUILD_WITH_COMMON_SYSTEM)
 endif()
 
 # Create aliases for consistent naming and messaging system compatibility
-add_library(ContainerSystem::container ALIAS container_system)
+add_library(container_system::container ALIAS container_system)
+add_library(ContainerSystem::container ALIAS container_system)  # Backward compatibility
 add_library(MessagingSystem::container ALIAS container_system)  # For messaging system compatibility
 
 # Set target properties
@@ -593,7 +594,7 @@ install(DIRECTORY
 
 install(EXPORT container_system-targets
     FILE container_system-targets.cmake
-    NAMESPACE ContainerSystem::
+    NAMESPACE container_system::
     DESTINATION ${CONTAINER_SYSTEM_CMAKE_INSTALL_DIR}
 )
 
@@ -618,7 +619,7 @@ install(FILES
 
 export(EXPORT container_system-targets
     FILE "${CMAKE_CURRENT_BINARY_DIR}/container_system-targets.cmake"
-    NAMESPACE ContainerSystem::
+    NAMESPACE container_system::
 )
 
 ##################################################

--- a/cmake/container_system-config.cmake.in
+++ b/cmake/container_system-config.cmake.in
@@ -22,7 +22,15 @@ set(container_system_FOUND TRUE)
 # Provide information about the package
 set(container_system_VERSION @PROJECT_VERSION@)
 set(container_system_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
-set(container_system_LIBRARIES ContainerSystem::container)
+set(container_system_LIBRARIES container_system::container)
+
+# Backward compatibility aliases (ContainerSystem:: → container_system::)
+if(NOT TARGET ContainerSystem::container)
+    add_library(ContainerSystem::container INTERFACE IMPORTED)
+    set_target_properties(ContainerSystem::container PROPERTIES
+        INTERFACE_LINK_LIBRARIES container_system::container
+    )
+endif()
 
 # Legacy variables for backward compatibility
 set(ContainerSystem_FOUND TRUE)


### PR DESCRIPTION
## Summary
- Change CMake export namespace from `ContainerSystem::` to `container_system::` to follow the ecosystem snake_case convention
- Add backward compatibility aliases so existing consumers using `ContainerSystem::container` continue to work
- Update the config template (`container_system-config.cmake.in`) to create an INTERFACE IMPORTED target for backward compatibility

## Related Issues
- Closes #427
- Part of kcenon/common_system#456

## What Changed

### `CMakeLists.txt`
| Change | Before | After |
|--------|--------|-------|
| Build alias | `ContainerSystem::container` | `container_system::container` (primary) + `ContainerSystem::container` (compat) |
| `install(EXPORT)` namespace | `ContainerSystem::` | `container_system::` |
| `export(EXPORT)` namespace | `ContainerSystem::` | `container_system::` |

### `cmake/container_system-config.cmake.in`
| Change | Before | After |
|--------|--------|-------|
| `container_system_LIBRARIES` | `ContainerSystem::container` | `container_system::container` |
| Backward compat alias | (none) | `ContainerSystem::container` INTERFACE IMPORTED → forwards to `container_system::container` |

## Backward Compatibility
Existing consumers using `find_package(container_system)` + `target_link_libraries(... ContainerSystem::container)` will continue to work via:
1. **Build tree**: `add_library(ContainerSystem::container ALIAS container_system)` kept as backward compat alias
2. **Install tree**: Config template creates `ContainerSystem::container` as an INTERFACE IMPORTED target that forwards to `container_system::container`

## Test plan
- [ ] Build container_system standalone -- verify `container_system::container` alias works
- [ ] Build a downstream project using `ContainerSystem::container` -- verify backward compat alias works
- [ ] Install and verify `find_package(container_system)` provides both namespaced targets
- [ ] CI passes on all platforms (Linux, macOS, Windows)