### PR TITLE
docs(readme): add License badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Static Analysis](https://github.com/kcenon/container_system/actions/workflows/static-analysis.yml/badge.svg)](https://github.com/kcenon/container_system/actions/workflows/static-analysis.yml)
 [![Security Scan](https://github.com/kcenon/container_system/actions/workflows/dependency-security-scan.yml/badge.svg)](https://github.com/kcenon/container_system/actions/workflows/dependency-security-scan.yml)
 [![Documentation](https://github.com/kcenon/container_system/actions/workflows/build-Doxygen.yaml/badge.svg)](https://github.com/kcenon/container_system/actions/workflows/build-Doxygen.yaml)
+[![License](https://img.shields.io/github/license/kcenon/container_system)](https://github.com/kcenon/container_system/blob/main/LICENSE)
 
 # Container System
 


### PR DESCRIPTION
Part of kcenon/common_system#467

## Summary
- Add License badge for BSD-3-Clause to match ecosystem standard

## Test plan
- [ ] Badge renders correctly on GitHub