### PR TITLE
docs(doxyfile): Add ecosystem-standard ALIASES

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -284,6 +284,8 @@ PREDEFINED             = HAS_MESSAGING_FEATURES \
 EXPAND_AS_DEFINED      =
 SKIP_FUNCTION_MACROS   = YES
 
+ALIASES                = "thread_safety=@par Thread Safety:^^" \
+                         "performance=@par Performance:^^"
 TAGFILES               =
 GENERATE_TAGFILE       =
 ALLEXTERNALS           = NO


### PR DESCRIPTION
## What

### Summary
Add `@thread_safety` and `@performance` custom ALIASES to Doxyfile, aligning with the ecosystem standard established by monitoring_system.

### Change Type
- [x] Documentation

## Why

### Related Issues
- Part of kcenon/common_system#472

### Motivation
Custom ALIASES enable consistent cross-referencing of thread safety guarantees and performance characteristics in API documentation across all 8 ecosystem libraries.

## How

### Implementation Details
Added two ALIASES entries matching monitoring_system's existing configuration.

### Test Plan
- [ ] Doxygen build succeeds (`build-Doxygen.yaml` workflow)