### PR TITLE
chore(build): add CMakePresets.json for vcpkg build integration

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,169 @@
+{
+    "version": 3,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 16,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "default",
+            "displayName": "Default Config",
+            "description": "Default build using system-installed external packages",
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "BUILD_WITH_COMMON_SYSTEM": "ON",
+                "BUILD_TESTS": "OFF",
+                "BUILD_CONTAINER_SAMPLES": "OFF",
+                "CONTAINER_BUILD_INTEGRATION_TESTS": "OFF"
+            }
+        },
+        {
+            "name": "debug",
+            "displayName": "Debug",
+            "description": "Debug build with tests enabled",
+            "inherits": "default",
+            "binaryDir": "${sourceDir}/build-debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "BUILD_TESTS": "ON",
+                "BUILD_CONTAINER_SAMPLES": "ON",
+                "CONTAINER_BUILD_INTEGRATION_TESTS": "ON"
+            }
+        },
+        {
+            "name": "release",
+            "displayName": "Release",
+            "description": "Optimized release build",
+            "inherits": "default",
+            "binaryDir": "${sourceDir}/build-release",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "core-debug",
+            "displayName": "Core Debug",
+            "description": "Debug build as submodule (core libraries only)",
+            "inherits": "default",
+            "binaryDir": "${sourceDir}/build-core-debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "BUILD_CONTAINERSYSTEM_AS_SUBMODULE": "ON"
+            }
+        },
+        {
+            "name": "core-release",
+            "displayName": "Core Release",
+            "description": "Release build as submodule",
+            "inherits": "default",
+            "binaryDir": "${sourceDir}/build-core-release",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "BUILD_CONTAINERSYSTEM_AS_SUBMODULE": "ON"
+            }
+        },
+        {
+            "name": "asan",
+            "displayName": "AddressSanitizer",
+            "description": "Build with AddressSanitizer",
+            "inherits": "debug",
+            "binaryDir": "${sourceDir}/build-asan",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "-fsanitize=address -fno-omit-frame-pointer",
+                "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address"
+            }
+        },
+        {
+            "name": "tsan",
+            "displayName": "ThreadSanitizer",
+            "description": "Build with ThreadSanitizer",
+            "inherits": "debug",
+            "binaryDir": "${sourceDir}/build-tsan",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "-fsanitize=thread",
+                "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=thread"
+            }
+        },
+        {
+            "name": "ubsan",
+            "displayName": "UndefinedBehaviorSanitizer",
+            "description": "Build with UndefinedBehaviorSanitizer",
+            "inherits": "debug",
+            "binaryDir": "${sourceDir}/build-ubsan",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "-fsanitize=undefined",
+                "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=undefined"
+            }
+        },
+        {
+            "name": "ci",
+            "displayName": "CI Build",
+            "description": "Configuration for continuous integration",
+            "inherits": "default",
+            "binaryDir": "${sourceDir}/build-ci",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "BUILD_TESTS": "ON",
+                "CONTAINER_BUILD_BENCHMARKS": "ON",
+                "CONTAINER_BUILD_INTEGRATION_TESTS": "ON"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "default",
+            "configurePreset": "default"
+        },
+        {
+            "name": "debug",
+            "configurePreset": "debug"
+        },
+        {
+            "name": "release",
+            "configurePreset": "release"
+        },
+        {
+            "name": "core-debug",
+            "configurePreset": "core-debug"
+        },
+        {
+            "name": "core-release",
+            "configurePreset": "core-release"
+        },
+        {
+            "name": "asan",
+            "configurePreset": "asan"
+        },
+        {
+            "name": "tsan",
+            "configurePreset": "tsan"
+        },
+        {
+            "name": "ubsan",
+            "configurePreset": "ubsan"
+        },
+        {
+            "name": "ci",
+            "configurePreset": "ci"
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "default",
+            "configurePreset": "default",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "ci",
+            "configurePreset": "ci",
+            "output": {
+                "outputOnFailure": true,
+                "verbosity": "verbose"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## What

### Summary
Add standardized `CMakePresets.json` to container_system, aligning with the ecosystem pattern used by common_system, thread_system, network_system, and pacs_system.

### Change Type
- [x] Chore (build configuration)

## Why

### Related Issues
- Closes #437

### Motivation
container_system is one of 4 ecosystem repos missing CMakePresets.json, forcing users to manually specify cache variables. Includes core (submodule) presets for embedded use.

## Where

### Files Changed
| File | Type of Change |
|------|----------------|
| `CMakePresets.json` | New file |

## How

### Presets Included

| Preset | Build Type | Tests | Submodule | Notes |
|--------|-----------|-------|-----------|-------|
| `default` | Release | OFF | OFF | Minimal build |
| `debug` | Debug | ON | OFF | Development build |
| `release` | Release | OFF | OFF | Optimized build |
| `core-debug` | Debug | OFF | ON | Submodule mode |
| `core-release` | Release | OFF | ON | Submodule mode |
| `asan` | Debug | ON | OFF | AddressSanitizer |
| `tsan` | Debug | ON | OFF | ThreadSanitizer |
| `ubsan` | Debug | ON | OFF | UBSanitizer |
| `ci` | RelWithDebInfo | ON | OFF | CI pipeline build |

### Testing Done
- [x] Preset structure follows ecosystem pattern (version 3, CMake 3.16+)
- [x] All cache variables match existing CMakeLists.txt options