### PR TITLE
chore(deps): update common_system to latest with ObjectPool fix

### DIFF
--- a/cmake/UnifiedDependencies.cmake
+++ b/cmake/UnifiedDependencies.cmake
@@ -34,7 +34,7 @@ option(UNIFIED_ALLOW_FETCHCONTENT "Allow FetchContent fallback for dependencies"
 # for reproducible builds. Using "main" is a moving target and breaks SOUP traceability.
 # See: https://github.com/kcenon/common_system/issues/402
 set(UNIFIED_COMMON_SYSTEM_GIT_URL "https://github.com/kcenon/common_system.git" CACHE STRING "Git URL for common_system")
-set(UNIFIED_COMMON_SYSTEM_GIT_TAG "v0.1.0" CACHE STRING "Git tag/branch for common_system (use a release tag, not 'main')")
+set(UNIFIED_COMMON_SYSTEM_GIT_TAG "e5adfa9" CACHE STRING "Git tag/branch for common_system (use a release tag or commit hash, not 'main')")
 
 if("${UNIFIED_COMMON_SYSTEM_GIT_TAG}" STREQUAL "main")
     message(WARNING


### PR DESCRIPTION
## What

### Summary
Updates the common_system FetchContent fallback pin from `v0.1.0` to commit `e5adfa9`, which includes the ObjectPool zero-overhead deleter fix (PR kcenon/common_system#488).

### Change Type
- [x] Chore (dependency update)

## Why

### Motivation
The FetchContent tag was pinned at `v0.1.0` (released before the ObjectPool performance fix). Commit `e5adfa9` includes:
- `perf(object-pool): replace std::function deleter with zero-overhead typed struct` (#488)
- Various documentation and CI improvements since v0.2.0

CI workflows already checkout common_system from main via `actions/checkout` (no `ref:` specified), so they naturally get the latest. This change only affects the FetchContent fallback used when common_system is not found locally.

## How

### Testing Done
- [x] CMake configure succeeds with updated pin
- [x] Full build (100%) — no compilation errors
- [x] All 22 unit tests pass

### Breaking Changes
None