### PR TITLE
chore(deps): update grpc, protobuf, gtest, benchmark versions

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
   "default-registry": {
     "kind": "builtin",
-    "baseline": "dd306f32e07d87fdb16837af64f33b6b415c770a"
+    "baseline": "d90a9b159c08169f39adcd1b0f1ac0ca12c4b96c"
   },
   "registries": [
     {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,10 +11,10 @@
     "kcenon-common-system"
   ],
   "overrides": [
-    { "name": "grpc", "version": "1.51.1" },
-    { "name": "protobuf", "version": "3.21.12" },
-    { "name": "gtest", "version": "1.14.0" },
-    { "name": "benchmark", "version": "1.8.3" }
+    { "name": "grpc", "version": "1.60.0" },
+    { "name": "protobuf", "version": "4.25.1" },
+    { "name": "gtest", "version": "1.17.0" },
+    { "name": "benchmark", "version": "1.9.5" }
   ],
   "features": {
     "testing": {


### PR DESCRIPTION
## Summary
- Update dependency overrides for ecosystem consistency (part of kcenon/common_system#486)
- grpc: 1.51.1 → 1.60.0
- protobuf: 3.21.12 → 4.25.1
- gtest: 1.14.0 → 1.17.0
- benchmark: 1.8.3 → 1.9.5
- vcpkg builtin-baseline updated to latest

## Why
- grpc 1.51.1 is from 2022, missing security fixes and performance improvements
- protobuf 4.25.1 maintains v3 API compatibility while getting latest bug fixes
- gtest/benchmark updates are minor version bumps with no breaking changes

## Test plan
- [ ] Verify vcpkg install resolves all dependencies
- [ ] Build with grpc feature enabled succeeds
- [ ] Existing tests pass