### PR TITLE
fix(cmake): update install rules for migrated header paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -566,9 +566,11 @@ set(CONTAINER_SYSTEM_CMAKE_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/container_
 #
 # The following directories are installed:
 #   - include/kcenon/container/  (canonical public headers)
+#   - include/container/         (forwarding headers for #include <container/...> paths)
 #   - core/      (forwarding headers for backward compatibility)
 #   - internal/  (internal implementation details)
 #   - integration/ (integration adapters)
+#   - messaging/ (domain-specific messaging container)
 # =============================================================================
 install(FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/container.h
@@ -594,11 +596,22 @@ install(DIRECTORY
     PATTERN "*.hpp"
 )
 
+# Forwarding headers under include/container/ (for #include <container/...> paths)
+install(DIRECTORY
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/container
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    COMPONENT Development
+    FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.hpp"
+)
+
 # Backward-compatible forwarding headers and internal implementation
 install(DIRECTORY
     ${CMAKE_CURRENT_SOURCE_DIR}/core
     ${CMAKE_CURRENT_SOURCE_DIR}/internal
     ${CMAKE_CURRENT_SOURCE_DIR}/integration
+    ${CMAKE_CURRENT_SOURCE_DIR}/messaging
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     COMPONENT Development
     FILES_MATCHING


### PR DESCRIPTION
## Summary
- Add missing `include/container/` forwarding headers to cmake install rules (for `#include <container/...>` paths)
- Add missing `messaging/` directory to cmake install rules (`message_container.h`)

## Why

PR #440 migrated headers from `core/` to `include/kcenon/container/`, but the cmake install rules were not fully updated. When `network_system` CI runs `cmake --install` on `container_system`, the new forwarding headers under `include/container/` and the `messaging/` directory headers are not installed, causing downstream build failures on Windows MSVC (and potentially other platforms).

Relates to network_system PRs #864, #865, #866 which fail on Windows due to this.

## Where

- `CMakeLists.txt` (install rules section, lines ~588-620)

## How

### Changes
1. Added install rule for `include/container/` directory (forwarding headers that bridge `#include <container/optimizations/fast_parser.h>` to the canonical `include/kcenon/container/` location)
2. Added `messaging/` to the existing backward-compatible install rule (alongside `core/`, `internal/`, `integration/`)
3. Updated the install section documentation comment to reflect all installed directories

### Verification
- Built successfully: `cmake --build build`
- Installed to temp prefix: `cmake --install build --prefix /tmp/container_install_test`
- Confirmed all headers are present in the install tree:
  - `include/kcenon/container/` (canonical headers)
  - `include/container/optimizations/fast_parser.h` (forwarding header, previously missing)
  - `include/messaging/message_container.h` (previously missing)
  - `include/core/`, `include/internal/`, `include/integration/` (unchanged)

## Test plan
- [ ] CI passes on all platforms (Linux, macOS, Windows MSVC)
- [ ] Verify network_system CI can find container_system headers after this fix