### PR TITLE
fix(include): use relative paths in forwarding headers for downstream compatibility

### DIFF
--- a/core/concepts.h
+++ b/core/concepts.h
@@ -1,3 +1,3 @@
 #pragma once
 // Forwarding header — canonical location: include/kcenon/container/concepts.h
-#include <kcenon/container/concepts.h>
+#include "../include/kcenon/container/concepts.h"

--- a/core/container.h
+++ b/core/container.h
@@ -1,3 +1,3 @@
 #pragma once
 // Forwarding header — canonical location: include/kcenon/container/container.h
-#include <kcenon/container/container.h>
+#include "../include/kcenon/container/container.h"

--- a/core/optimized_container.h
+++ b/core/optimized_container.h
@@ -1,3 +1,3 @@
 #pragma once
 // Forwarding header — canonical location: include/kcenon/container/optimized_container.h
-#include <kcenon/container/optimized_container.h>
+#include "../include/kcenon/container/optimized_container.h"

--- a/core/policy_container.h
+++ b/core/policy_container.h
@@ -1,3 +1,3 @@
 #pragma once
 // Forwarding header — canonical location: include/kcenon/container/policy_container.h
-#include <kcenon/container/policy_container.h>
+#include "../include/kcenon/container/policy_container.h"

--- a/core/simd_batch.h
+++ b/core/simd_batch.h
@@ -1,3 +1,3 @@
 #pragma once
 // Forwarding header — canonical location: include/kcenon/container/simd_batch.h
-#include <kcenon/container/simd_batch.h>
+#include "../include/kcenon/container/simd_batch.h"

--- a/core/storage_policy.h
+++ b/core/storage_policy.h
@@ -1,3 +1,3 @@
 #pragma once
 // Forwarding header — canonical location: include/kcenon/container/storage_policy.h
-#include <kcenon/container/storage_policy.h>
+#include "../include/kcenon/container/storage_policy.h"

--- a/core/typed_container.h
+++ b/core/typed_container.h
@@ -1,3 +1,3 @@
 #pragma once
 // Forwarding header — canonical location: include/kcenon/container/typed_container.h
-#include <kcenon/container/typed_container.h>
+#include "../include/kcenon/container/typed_container.h"

--- a/core/value_store.h
+++ b/core/value_store.h
@@ -1,3 +1,3 @@
 #pragma once
 // Forwarding header — canonical location: include/kcenon/container/value_store.h
-#include <kcenon/container/value_store.h>
+#include "../include/kcenon/container/value_store.h"

--- a/core/value_types.h
+++ b/core/value_types.h
@@ -1,3 +1,3 @@
 #pragma once
 // Forwarding header — canonical location: include/kcenon/container/value_types.h
-#include <kcenon/container/value_types.h>
+#include "../include/kcenon/container/value_types.h"


### PR DESCRIPTION
## Summary
Forwarding headers in `core/` used `#include <kcenon/container/...>` which
requires the `include/` directory to be in the compiler include path.
Downstream consumers (e.g., network_system CI) that only add `core/` or
the repo root to their include path fail with:

```
fatal error C1083: Cannot open include file: 'kcenon/container/container.h'
```

## Fix
Use relative paths (`#include "../include/kcenon/container/..."`) so
forwarding headers resolve correctly regardless of include path config.

## Test plan
- [ ] container_system builds and tests pass
- [ ] network_system Windows MSVC CI passes (currently blocked by this issue)