### PR TITLE
fix(build): resolve incorrect working directory in build.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,9 +9,10 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-# Script directory
+# Script directory and project root
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd "$SCRIPT_DIR"
+PROJECT_ROOT="$( cd "$SCRIPT_DIR/.." && pwd )"
+cd "$PROJECT_ROOT"
 
 # Default values
 BUILD_TYPE="Release"


### PR DESCRIPTION
## Summary
- Fix `scripts/build.sh` changing to `SCRIPT_DIR` (scripts/) instead of project root
- CMake failed with "does not appear to contain CMakeLists.txt" when build.sh was invoked

## Changes
- Compute `PROJECT_ROOT` as `SCRIPT_DIR/..` and `cd` into it
- Build directory is now correctly created at the project root level

## Test plan
- [x] `bash scripts/build.sh --clean` completes successfully
- [x] Build artifacts generated in `build/` at project root