### PR TITLE
docs: fix incorrect CMake target name in README vcpkg example

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ vcpkg install kcenon-container-system
 In your `CMakeLists.txt`:
 ```cmake
 find_package(container_system CONFIG REQUIRED)
-target_link_libraries(your_target PRIVATE kcenon::container_system)
+target_link_libraries(your_target PRIVATE container_system::container)
 ```
 
 ### Basic Usage Example


### PR DESCRIPTION
## Summary

- Fix the vcpkg usage example in README.md to reference the actual exported CMake target `container_system::container` instead of the incorrect `kcenon::container_system`

## Test plan

- [ ] Verify the README displays the correct target name
- [ ] Confirm `container_system::container` matches the exported target in `cmake/container_system-config.cmake.in`

Closes #454