### PR TITLE
chore: add local vcpkg portfile for registry synchronization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ compile_commands.json
 !CMakeLists.txt
 !cmake/*.cmake
 !cmake/*.cmake.in
+!vcpkg-ports/**/*.cmake
 
 # Test results
 Testing/

--- a/vcpkg-ports/kcenon-container-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-container-system/portfile.cmake
@@ -1,0 +1,53 @@
+# kcenon-container-system portfile
+# Advanced C++20 Container System with Thread-Safe Operations and Messaging Integration
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO kcenon/container_system
+    REF "v${VERSION}"
+    SHA512 ca2feee08c7cef41d297c49c4a4eb8559dcb4c680d42e70bc011b8928e88b82e16fab3e54f44e15e3c1e1ce0738950de9e8c55fea6d090cd8d3db628a46fb444
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_WITH_COMMON_SYSTEM=ON
+        -DCOMMON_SYSTEM_ROOT=${CURRENT_INSTALLED_DIR}
+        -DBUILD_TESTS=OFF
+        -DCONTAINER_BUILD_INTEGRATION_TESTS=OFF
+        -DCONTAINER_BUILD_BENCHMARKS=OFF
+        -DBUILD_DOCUMENTATION=OFF
+        -DBUILD_CONTAINER_SAMPLES=OFF
+        -DBUILD_CONTAINER_EXAMPLES=OFF
+        -DFETCHCONTENT_FULLY_DISCONNECTED=ON
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME container_system
+    CONFIG_PATH lib/cmake/container_system
+)
+
+# Remove example/sample executables and empty bin directories
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/bin/examples"
+    "${CURRENT_PACKAGES_DIR}/bin/samples"
+    "${CURRENT_PACKAGES_DIR}/debug/bin/examples"
+    "${CURRENT_PACKAGES_DIR}/debug/bin/samples"
+)
+# Clean up empty bin/debug/bin dirs left after removal (no DLLs on non-Windows)
+foreach(_bindir IN ITEMS "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+    if(IS_DIRECTORY "${_bindir}")
+        file(GLOB _remaining "${_bindir}/*")
+        if(NOT _remaining)
+            file(REMOVE_RECURSE "${_bindir}")
+        endif()
+    endif()
+endforeach()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg-ports/kcenon-container-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-container-system/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "name": "kcenon-container-system",
+  "version": "0.1.0",
+  "port-version": 3,
+  "description": "Advanced C++20 Container System with Thread-Safe Operations and Messaging Integration",
+  "homepage": "https://github.com/kcenon/container_system",
+  "license": "BSD-3-Clause",
+  "supports": "!(uwp | xbox)",
+  "dependencies": [
+    "kcenon-common-system",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `vcpkg-ports/kcenon-container-system/` with `portfile.cmake` and `vcpkg.json` mirroring the canonical vcpkg-registry
- Update `.gitignore` to allow cmake files in `vcpkg-ports/`

## Rationale

Standardize portfile management (Strategy B: local + registry sync) across the ecosystem, following the pattern already established by `monitoring_system`. Local portfiles enable atomic source+port changes and CI validation.

## Test plan

- [ ] Verify portfile matches the canonical registry version
- [ ] Verify `.gitignore` correctly allows `vcpkg-ports/**/*.cmake`
- [ ] CI builds pass without regression

Ref: kcenon/vcpkg-registry#36