### PR TITLE
chore(cmake): standardize minimum CMake version to 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20)
 
 ##################################################
 # Container System CMakeLists.txt


### PR DESCRIPTION
## What

### Summary
Updates `cmake_minimum_required` from 3.16 to 3.20 as part of ecosystem-wide CMake version standardization.

### Change Type
- [x] Chore (maintenance)

## Why

### Related Issues
- Part of kcenon/common_system#504

### Motivation
Standardize all kcenon ecosystem systems to CMake 3.20. The effective minimum was already 3.28 (via common_system dependency), now lowered to 3.20 ecosystem-wide. C++20 module support remains conditionally gated at 3.28.

## Where

| File | Change |
|------|--------|
| `CMakeLists.txt:LINE` | `VERSION 3.16` → `VERSION 3.20` |

## How

Single-line version bump. No functional change — CMake 3.20 is a subset of features already available in 3.16+.