### PR TITLE
fix(ci): add permissions to Generate-Documentation workflow

### DIFF
--- a/.github/workflows/build-Doxygen.yaml
+++ b/.github/workflows/build-Doxygen.yaml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   docs:
     uses: kcenon/common_system/.github/workflows/doxygen.yml@main


### PR DESCRIPTION
## Summary
- Add `permissions: contents: write` to caller workflow (`build-Doxygen.yaml`) to fix `startup_failure` in Generate-Documentation CI

## Related
- Closes #465
- Part of kcenon/common_system#531