### PR TITLE
chore(ci): add automated vcpkg registry sync on release

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "5716e4f6b36108cebeacec52bbc42502dd1e9c48",
+      "baseline": "50d89f5b1962e811dfb779bc46fa3d251db42ce7",
       "packages": [
         "kcenon-*"
       ]


### PR DESCRIPTION
## Summary

- Add `on-release-sync-registry.yml` trigger workflow
- References centralized `sync-vcpkg-registry.yml` in common_system
- On release publish, automatically syncs port to vcpkg-registry

## Prerequisites

`VCPKG_REGISTRY_PAT` secret must be configured in repo settings.

## Related

- Part of kcenon/common_system#543
- Part of kcenon/common_system#541 (Ecosystem vcpkg Registry Sync Automation)

## Test Plan

- Verify workflow YAML is valid (CI validates)
- Full verification on next release