### PR TITLE
chore(ci): add automated vcpkg registry sync on release

### DIFF
--- a/.github/workflows/on-release-sync-registry.yml
+++ b/.github/workflows/on-release-sync-registry.yml
@@ -1,0 +1,14 @@
+name: Sync Registry on Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  sync:
+    uses: kcenon/common_system/.github/workflows/sync-vcpkg-registry.yml@main
+    with:
+      port-name: kcenon-container-system
+      version: ${{ github.event.release.tag_name }}
+    secrets:
+      REGISTRY_PAT: ${{ secrets.VCPKG_REGISTRY_PAT }}


### PR DESCRIPTION
## Summary

- Add `on-release-sync-registry.yml` trigger workflow that calls the centralized reusable workflow from `common_system`
- When a release is published, the workflow automatically syncs `kcenon-container-system` port to `kcenon/vcpkg-registry`

## Related

- Part of kcenon/common_system#543

## Test plan

- [ ] Workflow file is valid YAML and references `kcenon/common_system/.github/workflows/sync-vcpkg-registry.yml@main`
- [ ] Port name is correct: `kcenon-container-system`
- [ ] Secret reference matches: `VCPKG_REGISTRY_PAT`