### PR TITLE
fix(vcpkg): sync local portfile CONFIG_PATH with v0.1.0 release tag

### DIFF
--- a/vcpkg-ports/kcenon-container-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-container-system/portfile.cmake
@@ -26,8 +26,8 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
-    PACKAGE_NAME container_system
-    CONFIG_PATH lib/cmake/container_system
+    PACKAGE_NAME ContainerSystem
+    CONFIG_PATH lib/cmake/ContainerSystem
 )
 
 # Remove example/sample executables and empty bin directories

--- a/vcpkg-ports/kcenon-container-system/usage
+++ b/vcpkg-ports/kcenon-container-system/usage
@@ -1,0 +1,4 @@
+The package kcenon-container-system provides CMake targets:
+
+    find_package(container_system CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE container_system::container)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-container-system",
   "version-semver": "0.1.0",
-  "port-version": 0,
+  "port-version": 3,
   "description": "Thread-safe serializable container library with advanced features",
   "homepage": "https://github.com/kcenon/container_system",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## Summary
- Fix `vcpkg_cmake_config_fixup` PACKAGE_NAME and CONFIG_PATH to match v0.1.0 release tag (PascalCase)
- Sync root `vcpkg.json` port-version from 0 to 3
- Add missing `usage` file to local port directory

## Related
- Closes #477
- Related: kcenon/vcpkg-registry#48

## Test plan
- [ ] Verify portfile PACKAGE_NAME matches release tag install path
- [ ] Verify root vcpkg.json port-version matches port definition