### PR TITLE
fix(vcpkg): sync port-version with registry baseline

### DIFF
--- a/vcpkg-ports/kcenon-container-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-container-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-container-system",
   "version-semver": "0.1.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Advanced C++20 Container System with Thread-Safe Operations and Messaging Integration",
   "homepage": "https://github.com/kcenon/container_system",
   "license": "BSD-3-Clause",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-container-system",
   "version-semver": "0.1.0",
-  "port-version": 3,
+  "port-version": 4,
   "description": "Thread-safe serializable container library with advanced features",
   "homepage": "https://github.com/kcenon/container_system",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## What
Sync port-version from 3 to 4 to match vcpkg-registry baseline.

## Why
Registry PR (kcenon/vcpkg-registry#49) bumped port-version to 4 when restoring FETCHCONTENT flag, but source repo was not updated.

## How
- Updated `vcpkg.json` port-version: 3 → 4
- Updated `vcpkg-ports/kcenon-container-system/vcpkg.json` port-version: 3 → 4

Closes #479