### PR TITLE
docs: add YAML frontmatter to all docs/ markdown files

### DIFF
--- a/docs/API_REFERENCE.kr.md
+++ b/docs/API_REFERENCE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-API-001"
+doc_title: "container_system API 레퍼런스"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "API"
+---
+
 # container_system API 레퍼런스
 
 > **버전**: 0.2.1

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-API-002"
+doc_title: "container_system API Reference"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "API"
+---
+
 # container_system API Reference
 
 > **Version**: 0.3.0.0

--- a/docs/ARCHITECTURE.kr.md
+++ b/docs/ARCHITECTURE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-ARCH-001"
+doc_title: "아키텍처 문서 - Container System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "ARCH"
+---
+
 # 아키텍처 문서 - Container System
 
 > **버전:** 0.1.0.0

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-ARCH-002"
+doc_title: "Architecture Documentation - Container System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "ARCH"
+---
+
 # Architecture Documentation - Container System
 
 > **Version:** 0.1.0.0

--- a/docs/ASYNC_GUIDE.md
+++ b/docs/ASYNC_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-GUID-001"
+doc_title: "C++20 Coroutine and Async Framework"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "GUID"
+---
+
 # C++20 Coroutine and Async Framework
 
 **Date**: 2026-02-09

--- a/docs/BENCHMARKS.kr.md
+++ b/docs/BENCHMARKS.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-PERF-001"
+doc_title: "Container System 성능 벤치마크"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "PERF"
+---
+
 # Container System 성능 벤치마크
 
 **언어:** [English](BENCHMARKS.md) | **한국어**

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-PERF-002"
+doc_title: "Container System Performance Benchmarks"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "PERF"
+---
+
 # Container System Performance Benchmarks
 
 **Last Updated**: 2025-11-15

--- a/docs/CHANGELOG.kr.md
+++ b/docs/CHANGELOG.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-PROJ-001"
+doc_title: "변경 이력"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "PROJ"
+---
+
 # 변경 이력
 
 Container System 프로젝트의 모든 주요 변경 사항이 이 파일에 문서화됩니다.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-PROJ-002"
+doc_title: "Changelog"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "PROJ"
+---
+
 # Changelog
 
 All notable changes to the Container System project will be documented in this file.

--- a/docs/FEATURES.kr.md
+++ b/docs/FEATURES.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-FEAT-001"
+doc_title: "Container System - 상세 기능"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "FEAT"
+---
+
 # Container System - 상세 기능
 
 **언어:** [English](README.md) | **한국어**

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-FEAT-002"
+doc_title: "Container System Features"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "FEAT"
+---
+
 # Container System Features
 
 **Last Updated**: 2026-02-08

--- a/docs/PRODUCTION_QUALITY.kr.md
+++ b/docs/PRODUCTION_QUALITY.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-QUAL-001"
+doc_title: "Container System 프로덕션 품질"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "QUAL"
+---
+
 # Container System 프로덕션 품질
 
 **언어:** [English](PRODUCTION_QUALITY.md) | **한국어**

--- a/docs/PRODUCTION_QUALITY.md
+++ b/docs/PRODUCTION_QUALITY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-QUAL-002"
+doc_title: "Container System Production Quality"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "QUAL"
+---
+
 # Container System Production Quality
 
 **Last Updated**: 2025-11-15

--- a/docs/PROJECT_STRUCTURE.kr.md
+++ b/docs/PROJECT_STRUCTURE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-PROJ-003"
+doc_title: "Container System 프로젝트 구조"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "PROJ"
+---
+
 # Container System 프로젝트 구조
 
 **언어:** [English](PROJECT_STRUCTURE.md) | **한국어**

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-PROJ-004"
+doc_title: "Container System Project Structure"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "PROJ"
+---
+
 # Container System Project Structure
 
 **Last Updated**: 2025-12-10

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-GUID-002"
+doc_title: "Container System Documentation"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "GUID"
+---
+
 # Container System Documentation
 
 > **Language:** **English** | [한국어](README.kr.md)

--- a/docs/SERIALIZATION_SCHEMA_POLICY_GUIDE.md
+++ b/docs/SERIALIZATION_SCHEMA_POLICY_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-GUID-003"
+doc_title: "Serialization, Schema, and Policy Framework"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "GUID"
+---
+
 # Serialization, Schema, and Policy Framework
 
 **Date**: 2026-02-09

--- a/docs/SOUP.md
+++ b/docs/SOUP.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-PROJ-005"
+doc_title: "SOUP List &mdash; container_system"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "PROJ"
+---
+
 # SOUP List &mdash; container_system
 
 > **Software of Unknown Provenance (SOUP) Register per IEC 62304:2006+AMD1:2015 &sect;8.1.2**

--- a/docs/advanced/ADR-001-Type-System-Unification.md
+++ b/docs/advanced/ADR-001-Type-System-Unification.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-ADR-001"
+doc_title: "ADR-001: Type System Unification"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "ADR"
+---
+
 # ADR-001: Type System Unification
 
 **Date**: 2025-11-08

--- a/docs/advanced/ARRAY_VALUE_GUIDE.md
+++ b/docs/advanced/ARRAY_VALUE_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-GUID-004"
+doc_title: "ArrayValue Implementation Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "GUID"
+---
+
 # ArrayValue Implementation Guide
 
 ## Table of Contents

--- a/docs/advanced/DOMAIN_SEPARATION_GUIDE.md
+++ b/docs/advanced/DOMAIN_SEPARATION_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-ARCH-003"
+doc_title: "Domain Separation Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "ARCH"
+---
+
 # Domain Separation Guide
 
 **Date**: 2025-11-09

--- a/docs/advanced/EXCEPTION_SAFETY.md
+++ b/docs/advanced/EXCEPTION_SAFETY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-QUAL-003"
+doc_title: "Exception Safety Guarantees"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "QUAL"
+---
+
 # Exception Safety Guarantees
 
 **Date**: 2025-11-09

--- a/docs/advanced/INTERFACE_SEGREGATION.md
+++ b/docs/advanced/INTERFACE_SEGREGATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-ARCH-004"
+doc_title: "Interface Segregation in container_system"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "ARCH"
+---
+
 # Interface Segregation in container_system
 
 **Date**: 2025-11-09

--- a/docs/advanced/LOCK_FREE.md
+++ b/docs/advanced/LOCK_FREE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-ARCH-005"
+doc_title: "Lock-Free Data Structures"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "ARCH"
+---
+
 # Lock-Free Data Structures
 
 **Date**: 2025-02-09

--- a/docs/advanced/MEMORY_MANAGEMENT.md
+++ b/docs/advanced/MEMORY_MANAGEMENT.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-PERF-003"
+doc_title: "Memory Pool and Allocator Architecture"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "PERF"
+---
+
 # Memory Pool and Allocator Architecture
 
 **Date**: 2025-02-09

--- a/docs/advanced/STRUCTURE.md
+++ b/docs/advanced/STRUCTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-ARCH-006"
+doc_title: "Structure Documentation - Container System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "ARCH"
+---
+
 # Structure Documentation - Container System
 
 > **Version:** 0.1.0.0

--- a/docs/advanced/VALUE_CONTAINER_DECOMPOSITION_EVALUATION.md
+++ b/docs/advanced/VALUE_CONTAINER_DECOMPOSITION_EVALUATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-PROJ-006"
+doc_title: "Value Container Class Decomposition Evaluation"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "PROJ"
+---
+
 # Value Container Class Decomposition Evaluation
 
 **Issue**: #287

--- a/docs/advanced/VALUE_STORE_DESIGN.md
+++ b/docs/advanced/VALUE_STORE_DESIGN.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-ARCH-007"
+doc_title: "value_store Design Document"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "ARCH"
+---
+
 # value_store Design Document
 
 **Date**: 2025-11-09

--- a/docs/advanced/VARIANT_VALUE_V2_MIGRATION_GUIDE.md
+++ b/docs/advanced/VARIANT_VALUE_V2_MIGRATION_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-MIGR-001"
+doc_title: "variant_value_v2 Migration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "MIGR"
+---
+
 # variant_value_v2 Migration Guide
 
 > **Status**: Ready for Production

--- a/docs/advanced/VISITOR_PATTERN_GUIDE.md
+++ b/docs/advanced/VISITOR_PATTERN_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-GUID-005"
+doc_title: "Visitor Pattern with variant_value_v2"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "GUID"
+---
+
 # Visitor Pattern with variant_value_v2
 
 **Date**: 2025-11-09

--- a/docs/architecture/ADR-001-container-system-scope.md
+++ b/docs/architecture/ADR-001-container-system-scope.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-ADR-002"
+doc_title: "ADR-001: Container System Scope and Purpose"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "ADR"
+---
+
 # ADR-001: Container System Scope and Purpose
 
 **Status**: Accepted

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-PROJ-007"
+doc_title: "Contributing to container_system"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "PROJ"
+---
+
 <!-- BSD 3-Clause License
      Copyright (c) 2025, kcenon
      See the LICENSE file in the project root for full license information. -->

--- a/docs/contributing/TESTING.md
+++ b/docs/contributing/TESTING.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-QUAL-004"
+doc_title: "Container System Testing Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "QUAL"
+---
+
 # Container System Testing Guide
 
 > **Last Updated**: 2025-11-07

--- a/docs/grpc/GRPC_INTEGRATION_PROPOSAL.kr.md
+++ b/docs/grpc/GRPC_INTEGRATION_PROPOSAL.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-INTR-001"
+doc_title: "Container System gRPC/Protocol Buffers 통합 제안서"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "INTR"
+---
+
 # Container System gRPC/Protocol Buffers 통합 제안서
 
 > **Language:** [English](GRPC_INTEGRATION_PROPOSAL.md) | **한국어**

--- a/docs/grpc/GRPC_INTEGRATION_PROPOSAL.md
+++ b/docs/grpc/GRPC_INTEGRATION_PROPOSAL.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-INTR-002"
+doc_title: "Container System gRPC/Protocol Buffers Integration Proposal"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "INTR"
+---
+
 # Container System gRPC/Protocol Buffers Integration Proposal
 
 > **Language:** **English** | [한국어](GRPC_INTEGRATION_PROPOSAL.kr.md)

--- a/docs/guides/FAQ.md
+++ b/docs/guides/FAQ.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-GUID-006"
+doc_title: "Container System - Frequently Asked Questions"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "GUID"
+---
+
 # Container System - Frequently Asked Questions
 
 > **Version:** 0.1.0

--- a/docs/guides/INTEGRATION.md
+++ b/docs/guides/INTEGRATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-INTR-003"
+doc_title: "Integration Guide - Container System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "INTR"
+---
+
 # Integration Guide - Container System
 
 > **Language:** **English** | [한국어](INTEGRATION.kr.md)

--- a/docs/guides/MIGRATION.md
+++ b/docs/guides/MIGRATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-MIGR-002"
+doc_title: "Migration Guide - Container System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "MIGR"
+---
+
 # Migration Guide - Container System
 
 > **Language:** **English** | [한국어](MIGRATION.kr.md)

--- a/docs/guides/NAMESPACE_MIGRATION.kr.md
+++ b/docs/guides/NAMESPACE_MIGRATION.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-MIGR-003"
+doc_title: "네임스페이스 마이그레이션 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "MIGR"
+---
+
 # 네임스페이스 마이그레이션 가이드
 
 > **Language:** [English](NAMESPACE_MIGRATION.md) | **한국어**

--- a/docs/guides/NAMESPACE_MIGRATION.md
+++ b/docs/guides/NAMESPACE_MIGRATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-MIGR-004"
+doc_title: "Namespace Migration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "MIGR"
+---
+
 # Namespace Migration Guide
 
 > **Language:** **English** | [한국어](NAMESPACE_MIGRATION.kr.md)

--- a/docs/guides/QUICK_START.kr.md
+++ b/docs/guides/QUICK_START.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-GUID-007"
+doc_title: "빠른 시작 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "GUID"
+---
+
 # 빠른 시작 가이드
 
 5분 만에 container_system을 시작하세요.

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-GUID-008"
+doc_title: "Quick Start Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "GUID"
+---
+
 # Quick Start Guide
 
 Get started with container_system in 5 minutes.

--- a/docs/guides/RESULT_API_MIGRATION_GUIDE.md
+++ b/docs/guides/RESULT_API_MIGRATION_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-MIGR-005"
+doc_title: "Result API Migration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "MIGR"
+---
+
 # Result API Migration Guide
 
 > **Status**: Ready for Production

--- a/docs/guides/RESULT_PATTERN_MIGRATION.md
+++ b/docs/guides/RESULT_PATTERN_MIGRATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-MIGR-006"
+doc_title: "Result Pattern Migration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "MIGR"
+---
+
 # Result Pattern Migration Guide
 
 This guide helps you migrate from the traditional exception/bool-based APIs to the new Result-returning APIs in container_system.

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-GUID-009"
+doc_title: "Container System – Troubleshooting Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "GUID"
+---
+
 # Container System – Troubleshooting Guide
 
 This guide consolidates the most common issues reported while using the Container System and explains how to interpret `Result<T>` failures.

--- a/docs/integration/README.md
+++ b/docs/integration/README.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-GUID-010"
+doc_title: "Container System Integration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "GUID"
+---
+
 # Container System Integration Guide
 
 ## Overview

--- a/docs/performance/AUTOMATED_PERFORMANCE_TRACKING.md
+++ b/docs/performance/AUTOMATED_PERFORMANCE_TRACKING.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-PERF-004"
+doc_title: "Automated Performance Tracking System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "PERF"
+---
+
 # Automated Performance Tracking System
 
 > **System Status**: ⚙️ Ready for Installation

--- a/docs/performance/BASELINE.kr.md
+++ b/docs/performance/BASELINE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-PERF-005"
+doc_title: "Container System - Performance Baseline Metrics"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "PERF"
+---
+
 # Container System - Performance Baseline Metrics
 
 **언어 (Language)**: [English](BASELINE.md) | **한국어**

--- a/docs/performance/BASELINE.md
+++ b/docs/performance/BASELINE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-PERF-006"
+doc_title: "Container System - Performance Baseline Metrics"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "PERF"
+---
+
 # Container System - Performance Baseline Metrics
 
 **Language**: **English** | [한국어](BASELINE.kr.md)

--- a/docs/performance/MEMORY_POOL_PERFORMANCE.md
+++ b/docs/performance/MEMORY_POOL_PERFORMANCE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-PERF-007"
+doc_title: "Memory Pool Performance Results"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "PERF"
+---
+
 # Memory Pool Performance Results
 
 > **Last Updated**: Awaiting first benchmark run

--- a/docs/performance/PERFORMANCE.kr.md
+++ b/docs/performance/PERFORMANCE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-PERF-008"
+doc_title: "Container System - Performance Benchmarks & Analysis"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "PERF"
+---
+
 # Container System - Performance Benchmarks & Analysis
 
 **언어 (Language)**: [English](PERFORMANCE.md) | **한국어**

--- a/docs/performance/PERFORMANCE.md
+++ b/docs/performance/PERFORMANCE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-PERF-009"
+doc_title: "📊 Container System - Performance Benchmarks & Analysis"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "PERF"
+---
+
 # 📊 Container System - Performance Benchmarks & Analysis
 
 **Language**: **English** | [한국어](PERFORMANCE.kr.md)

--- a/docs/performance/SANITIZER_TEST_RESULTS.kr.md
+++ b/docs/performance/SANITIZER_TEST_RESULTS.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-QUAL-005"
+doc_title: "Sanitizer 테스트 결과"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "QUAL"
+---
+
 # Sanitizer 테스트 결과
 
 > **Language:** [English](SANITIZER_TEST_RESULTS.md) | **한국어**

--- a/docs/performance/SANITIZER_TEST_RESULTS.md
+++ b/docs/performance/SANITIZER_TEST_RESULTS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "CNT-QUAL-006"
+doc_title: "Sanitizer Test Results"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "container_system"
+category: "QUAL"
+---
+
 # Sanitizer Test Results
 
 > **Language:** **English** | [한국어](SANITIZER_TEST_RESULTS.kr.md)


### PR DESCRIPTION
Part of kcenon/common_system#562

## Summary
- Add standardized YAML frontmatter metadata to 54 markdown files in `docs/`
- Each file gets a unique `doc_id` (`CNT-{CATEGORY}-{NNN}`), title, version, date, status, project, and category

## Category Breakdown (54 files)
| Category | Count | Description |
|----------|-------|-------------|
| ADR | 2 | Decision Records |
| API | 2 | API Reference |
| ARCH | 7 | Architecture |
| FEAT | 2 | Features |
| GUID | 10 | User Guides |
| INTR | 3 | Integration |
| MIGR | 6 | Migration |
| PERF | 9 | Performance |
| PROJ | 7 | Project Info |
| QUAL | 6 | Quality |

## Test Plan
- [x] Script runs idempotently (re-running skips all files)
- [x] No duplicate doc_id values
- [x] Existing document content unchanged (frontmatter prepended only)