### PR TITLE
docs: add @file Doxygen blocks to public API headers

### DIFF
--- a/include/container/optimizations/fast_parser.h
+++ b/include/container/optimizations/fast_parser.h
@@ -1,3 +1,8 @@
+/**
+ * @file fast_parser.h
+ * @brief Forwarding header to canonical fast_parser location.
+ */
+
 #pragma once
 // Forwarding header — canonical location: include/kcenon/container/optimizations/fast_parser.h
 #include <kcenon/container/optimizations/fast_parser.h>

--- a/include/kcenon/container/simd_batch.h
+++ b/include/kcenon/container/simd_batch.h
@@ -3,6 +3,16 @@
 // High-level SIMD-friendly batch container for trivially copyable types.
 // Renamed from typed_container.h for clarity (Issue #328).
 
+/**
+ * @file simd_batch.h
+ * @brief SIMD-friendly batch container for trivially copyable payloads.
+ *
+ * Enforces deterministic layout for SIMD-optimized serialization paths.
+ * Renamed from typed_container.h (Issue #328).
+ *
+ * @see simd_processor For the SIMD acceleration backend
+ */
+
 #pragma once
 
 #include "concepts.h"

--- a/include/kcenon/container/value_store.h
+++ b/include/kcenon/container/value_store.h
@@ -2,6 +2,16 @@
 // Copyright (c) 2021, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file value_store.h
+ * @brief Domain-agnostic key-value storage with type-safe accessors.
+ *
+ * Provides thread-safe named value storage used as the primary data
+ * container throughout the ecosystem.
+ *
+ * @see value_types For supported data types
+ */
+
 #pragma once
 
 #include "internal/value.h"

--- a/include/kcenon/container/value_types.h
+++ b/include/kcenon/container/value_types.h
@@ -2,6 +2,16 @@
 // Copyright (c) 2021, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file value_types.h
+ * @brief Enumeration of the 16 supported value types in the container system.
+ *
+ * Defines value_types enum and compile-time type name mapping used by
+ * value_store, serializers, and container schema validation.
+ *
+ * @see value_store.h For the storage that uses these types
+ */
+
 #pragma once
 
 #include <array>


### PR DESCRIPTION
## Summary

Add `@file` Doxygen documentation blocks to 4 public API headers that were missing them, achieving 100% `@file` coverage across all headers in container_system.

### Headers Updated
- `include/container/optimizations/fast_parser.h`
- `include/kcenon/container/simd_batch.h`
- `include/kcenon/container/value_store.h`
- `include/kcenon/container/value_types.h`

Closes #568

## Test Plan
- [ ] Verify Doxygen generation produces no warnings on updated headers
- [ ] Confirm existing CI checks pass