### PR TITLE
docs: fix traceability matrix doc_id collision with production quality

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,7 @@ Total documents: **55**
 | 38 | CNT-INTR-003 | Integration Guide - Container System | [INTEGRATION.md](./guides/INTEGRATION.md) | Released |
 | 39 | CNT-QUAL-001 | Container System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
 | 40 | CNT-QUAL-002 | Container System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
-| 41 | CNT-QUAL-002 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
+| 41 | CNT-QUAL-007 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
 | 42 | CNT-QUAL-003 | Exception Safety Guarantees | [EXCEPTION_SAFETY.md](./advanced/EXCEPTION_SAFETY.md) | Released |
 | 43 | CNT-QUAL-004 | Container System Testing Guide | [TESTING.md](./contributing/TESTING.md) | Released |
 | 44 | CNT-QUAL-005 | Sanitizer 테스트 결과 | [SANITIZER_TEST_RESULTS.kr.md](./performance/SANITIZER_TEST_RESULTS.kr.md) | Released |
@@ -156,7 +156,7 @@ Total documents: **55**
 |--------|-------|----------|--------|
 | CNT-QUAL-001 | Container System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
 | CNT-QUAL-002 | Container System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
-| CNT-QUAL-002 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
+| CNT-QUAL-007 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
 | CNT-QUAL-003 | Exception Safety Guarantees | [EXCEPTION_SAFETY.md](./advanced/EXCEPTION_SAFETY.md) | Released |
 | CNT-QUAL-004 | Container System Testing Guide | [TESTING.md](./contributing/TESTING.md) | Released |
 | CNT-QUAL-005 | Sanitizer 테스트 결과 | [SANITIZER_TEST_RESULTS.kr.md](./performance/SANITIZER_TEST_RESULTS.kr.md) | Released |

--- a/docs/TRACEABILITY.md
+++ b/docs/TRACEABILITY.md
@@ -1,5 +1,5 @@
 ---
-doc_id: "CNT-QUAL-002"
+doc_id: "CNT-QUAL-007"
 doc_title: "Feature-Test-Module Traceability Matrix"
 doc_version: "1.0.0"
 doc_date: "2026-04-04"


### PR DESCRIPTION
## Summary

- Fix doc_id collision: `TRACEABILITY.md` and `PRODUCTION_QUALITY.md` both used `CNT-QUAL-002`
- Assign unique `CNT-QUAL-007` to `TRACEABILITY.md` (next available QUAL number)
- Update SSOT registry (`docs/README.md`) to reflect the corrected doc_id

Related to kcenon/common_system#566

## What

The traceability matrix document (`docs/TRACEABILITY.md`) was sharing `CNT-QUAL-002` with `PRODUCTION_QUALITY.md`. Each document in the SSOT registry must have a unique `doc_id`. This PR assigns `CNT-QUAL-007` to the traceability matrix.

## How

- Updated `doc_id` in `docs/TRACEABILITY.md` YAML frontmatter from `CNT-QUAL-002` to `CNT-QUAL-007`
- Updated both entries in `docs/README.md` (numbered table and category index)

## Test Plan

- [x] Verify `CNT-QUAL-007` is not used by any other document
- [x] Verify TRACEABILITY.md YAML frontmatter matches README.md registry entry
- [x] Verify all feature-test mappings are accurate (test files exist)
- [x] Verify coverage summary totals match actual feature count (26)