### PR TITLE
docs(tutorials): add tutorials, FAQ and troubleshooting guide

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -99,7 +99,12 @@ INPUT                  = ./core \
                          ./integration \
                          ./examples \
                          ./utilities \
-                         ./docs/mainpage.dox
+                         ./docs/mainpage.dox \
+                         ./docs/tutorial_containers.dox \
+                         ./docs/tutorial_serialization.dox \
+                         ./docs/tutorial_integration.dox \
+                         ./docs/faq.dox \
+                         ./docs/troubleshooting.dox
 
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.c \
@@ -111,7 +116,8 @@ FILE_PATTERNS          = *.c \
                          *.hpp \
                          *.tpp \
                          *.cppm \
-                         *.md
+                         *.md \
+                         *.dox
 
 RECURSIVE              = YES
 EXCLUDE                = build \

--- a/docs/faq.dox
+++ b/docs/faq.dox
@@ -1,0 +1,158 @@
+/**
+@page faq Frequently Asked Questions
+
+@tableofcontents
+
+This page answers the questions that come up most often when integrating
+Container System into a new project.
+
+@section faq_value_type Which value type should I use for my data?
+
+Pick the smallest type that fits your range without ambiguity. The general rules:
+
+- **Identifiers** — `int64_value` or `uint64_value`. They round-trip across
+  languages and never overflow at realistic scale.
+- **Counters / sizes** — `uint32_value` for byte counts and small populations,
+  `uint64_value` for memory addresses, monotonic counters, and hashes.
+- **Money / currency** — store as integer minor units (cents) in `int64_value`
+  whenever possible. Use `double_value` only when rounding tolerance is
+  acceptable.
+- **Sensor and graphics data** — `float_value` is fine and halves the wire
+  size relative to `double_value`.
+- **Flags** — `bool_value`. Use `null_value` when "unknown" is meaningful.
+- **Text** — `string_value`. UTF-8 only.
+- **Binary blobs** — `bytes_value`. Anything from compressed payloads to image
+  thumbnails.
+- **Structured records** — `container_value` for nested records; repeated keys
+  or `array` for collections.
+
+See @ref tutorial_containers for the full table and worked examples.
+
+@section faq_simd What are the SIMD requirements and what happens on fallback?
+
+SIMD is opportunistic. The build detects ARM NEON on AArch64 and AVX2 on x86_64
+and links the matching kernels. At run time the dispatcher checks CPUID (or the
+ARM equivalent) and chooses the best available path.
+
+If neither NEON nor AVX2 is available, a portable scalar implementation runs
+instead. The scalar path produces bit-identical results, so payloads are
+interchangeable. The only difference is throughput: numeric batch operations
+are typically 3x faster on Apple Silicon and 2--4x faster on AVX2 hosts than
+on the scalar fallback.
+
+@section faq_thread_safety What are the thread safety guarantees?
+
+`value_container` is not internally synchronized. Concurrent writers from
+multiple threads will race.
+
+For multi-reader / single-writer or multi-reader / multi-writer workloads, use
+`thread_safe_container`. Reads use an RCU-based path (`rcu_value`,
+`epoch_manager`) so they are lock-free in the steady state, while writes are
+serialized by an internal mutex. This is the recommended pattern when many
+threads observe a slowly-changing record.
+
+If your access pattern is purely "build once, share many", construct the
+container on a single thread, freeze it (do not mutate it again), and share the
+`std::shared_ptr` across consumers. That is safe without any extra wrapping.
+
+@section faq_max_size What is the maximum container size?
+
+There is no hard size cap built into the format. In practice you are limited by:
+
+- **Available memory** — the container holds its values in memory.
+- **`std::string` capacity** — the binary serializer returns a `std::string`,
+  which on common platforms supports payloads up to several gigabytes.
+- **Network MTUs and database row size limits** — your transport will usually
+  cap practical sizes well below the format limits.
+
+For very large payloads (tens of megabytes and up), prefer chunking your data
+into multiple smaller messages or storing the bulk content out of band (for
+example, in object storage) and referencing it from the container.
+
+@section faq_nested Can I nest containers?
+
+Yes. `container_value` holds a nested `value_container`, so containers form a
+tree of arbitrary depth. Recursion is the natural traversal pattern; see
+@ref tutorial_containers for an example.
+
+A few caveats:
+
+- Each level of nesting adds a small constant overhead.
+- Avoid deep recursion on untrusted input. Validate the maximum depth of
+  incoming payloads if they cross a trust boundary.
+- Prefer flat layouts when the nesting does not carry semantic meaning. They
+  serialize and traverse faster.
+
+@section faq_performance What kind of performance can I expect?
+
+Indicative numbers from the project benchmarks (see the Performance Benchmarks
+section on @ref index "the main page"):
+
+| Operation              | Throughput            | Notes                          |
+|------------------------|-----------------------|--------------------------------|
+| Container creation     | ~5M/sec               | Empty containers               |
+| String value addition  | ~15M/sec              | Single-threaded                |
+| Binary serialization   | ~2M/sec               | 1 KB containers                |
+| JSON serialization     | ~800K/sec             | 1 KB containers                |
+| SIMD numeric ops       | ~25M ops/sec          | NEON / AVX2                    |
+
+Memory profile:
+
+- Empty container: ~128 bytes baseline.
+- String value: ~64 bytes plus the string contents.
+- Numeric value: ~48 bytes.
+- Binary serialization overhead: ~10%.
+- JSON serialization overhead: ~40%.
+
+Numbers vary by CPU, allocator, and compiler. Run the project benchmarks on
+your target hardware for a definitive view.
+
+@section faq_format_compat Is the binary format compatible across platforms and versions?
+
+Yes. The wire format is little-endian, uses fixed-width integer encodings, and
+carries a format version field in the header. Within a major version, new
+releases stay readable by older clients (additive changes only). Across a
+breaking release, the format version is incremented and the changelog calls
+out the migration path explicitly.
+
+@section faq_custom_types Can I define custom value types?
+
+Not in the same sense as the 16 built-in types. The type tag is a fixed enum
+because it controls the wire format. To carry custom data:
+
+- **Wrap it in `bytes_value`** with an out-of-band schema (for example,
+  Protobuf or FlatBuffers) — useful for opaque payloads.
+- **Wrap it in `string_value`** for textual encodings (JSON, base64).
+- **Decompose it into nested containers** when the fields are independently
+  useful and you want them to remain queryable.
+
+If you find yourself reaching for a brand new primitive type often, open an
+issue describing the use case so it can be evaluated for inclusion.
+
+@section faq_memory_pool Does Container System use memory pooling?
+
+Yes. The `memory_pool` and `pool_allocator` components provide a small-object
+allocator that reduces allocation traffic for the common case of containers
+with many short-lived values. It is enabled by default and controlled by the
+`CONTAINER_USE_MEMORY_POOL` CMake option.
+
+Disable it only if you are integrating with an external allocator that already
+optimizes for small allocations, or if you are profiling and need to attribute
+allocations to a specific upstream allocator.
+
+@section faq_messaging How does Container System integrate with the messaging layer?
+
+The `messaging_container_builder` and `messaging_integration` components in
+the `integration/` directory provide the bridge. The builder gives you a
+fluent construction API, and the integration layer hands the resulting
+container to whichever transport you have configured. See
+@ref tutorial_integration for end-to-end examples.
+
+@section faq_more More Resources
+
+- @ref tutorial_containers for value type and builder basics.
+- @ref tutorial_serialization for wire format and SIMD details.
+- @ref tutorial_integration for combining with network and database layers.
+- @ref troubleshooting if something is misbehaving.
+
+*/

--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -262,6 +262,19 @@ cmake --build build
 | ASIO Integration | @ref asio_integration_example.cpp | Boost.Asio network integration patterns |
 | Real-World Scenarios | @ref real_world_scenarios.cpp | IoT, finance, gaming, and CMS application patterns |
 
+@section learning Learning Resources
+
+New to Container System? Start with the tutorials below and keep the FAQ and
+troubleshooting guide handy as you build.
+
+| Resource | What you will learn |
+|----------|---------------------|
+| @ref tutorial_containers | Value type selection, builder API, iteration patterns |
+| @ref tutorial_serialization | Binary format internals, SIMD acceleration, cross-platform compatibility |
+| @ref tutorial_integration | Wiring Container System into network_system, database_system, and the messaging layer |
+| @ref faq | Quick answers to the questions external developers ask most often |
+| @ref troubleshooting | Symptoms, causes, and fixes for common issues |
+
 @section related Related Systems
 
 Container System is a Tier 1 data serialization layer in the kcenon ecosystem.

--- a/docs/troubleshooting.dox
+++ b/docs/troubleshooting.dox
@@ -1,0 +1,163 @@
+/**
+@page troubleshooting Troubleshooting Guide
+
+@tableofcontents
+
+This page collects the issues most frequently reported by users of Container
+System and the recommended fixes. For each issue you will find a short list of
+symptoms, the typical root cause, and the steps to resolve it.
+
+@section trbl_serialization_mismatch 1. Serialization Format Mismatch
+
+@par Symptoms
+- Deserialization throws or returns an empty container.
+- A field reads back with the wrong type or a corrupted value.
+- The first few bytes of the payload do not match the expected magic.
+
+@par Likely Cause
+The producer and consumer are using different serializers. This commonly
+happens when one side calls `value_container::serialize()` (binary) while the
+other side hands the bytes to `serializer_factory::create("json")`.
+
+@par Resolution
+- Verify both sides use the same format. The default is binary; if you opted
+  into JSON, XML, or MessagePack on the producer, use the same factory key on
+  the consumer.
+- Confirm the format version matches. If the producer is on a newer release,
+  upgrade the consumer or downgrade the producer to a compatible version.
+- For mixed-version environments, add a small "format probe" message at the
+  start of the session that records the producer's library version.
+
+@code{.cpp}
+auto strategy = container_module::serializer_factory::create("msgpack");
+auto restored = strategy->deserialize(wire);
+@endcode
+
+@section trbl_simd_unavailable 2. SIMD Acceleration Not Available
+
+@par Symptoms
+- Numeric workloads run at the speed of the scalar fallback.
+- Logs report "SIMD path: scalar" (when SIMD logging is enabled).
+- Benchmarks show no improvement on hosts that should support AVX2 or NEON.
+
+@par Likely Cause
+- The build was configured for a generic target that disabled SIMD intrinsics.
+- The CPU genuinely does not support AVX2 (older x86_64) or you are running
+  inside a virtualization layer that masks AVX2.
+- The container is full of mixed types, so the SIMD batch path cannot fire.
+
+@par Resolution
+- Rebuild with the matching architecture flags (`-march=native` for local
+  builds, the project's CI presets for production builds).
+- Confirm the host's capabilities (`sysctl -a | grep machdep.cpu.features` on
+  macOS, `lscpu` on Linux). If AVX2 is missing, the scalar fallback is the
+  only option and is producing correct results.
+- For hot loops, group same-typed numeric values together so the SIMD batch
+  path can engage. See the `optimize_for_speed()` builder hint in
+  @ref tutorial_serialization.
+
+@section trbl_thread_safety 3. Thread Safety Violations
+
+@par Symptoms
+- Intermittent crashes under load.
+- Use-after-free reports from a sanitizer.
+- Values reading back as garbage.
+- Tests pass on a single thread but fail under TSAN.
+
+@par Likely Cause
+A bare `value_container` is being mutated from more than one thread, or being
+mutated on one thread while another reads it.
+
+@par Resolution
+- Wrap the container in `thread_safe_container` for multi-writer access. Reads
+  go through the RCU path; writes are serialized internally.
+- For "build once, share many" patterns, finish construction on one thread,
+  then publish the `std::shared_ptr<value_container>` and stop mutating it.
+- Run the test suite under TSAN (`--preset tsan`) to confirm the fix.
+
+@code{.cpp}
+#include <container/internal/thread_safe_container.h>
+using namespace container_module;
+
+thread_safe_container safe;
+safe.set("user_id",  static_cast<int64_t>(99));
+safe.set("username", std::string("alice"));
+
+// readers (multiple threads, lock-free)
+auto snapshot = safe.snapshot();
+@endcode
+
+@section trbl_memory_large 4. Memory Issues With Large Containers
+
+@par Symptoms
+- High resident memory when many containers are alive at once.
+- Allocator thrash showing up as `malloc`/`free` time in profiles.
+- Out-of-memory errors when handling oversized payloads.
+
+@par Likely Cause
+- The container memory pool is disabled, or is undersized for your workload.
+- A single container is genuinely too large for in-memory processing.
+- Many small containers are being allocated and freed in a tight loop without
+  reuse.
+
+@par Resolution
+- Confirm `CONTAINER_USE_MEMORY_POOL=ON` (the default). If you turned it off,
+  consider re-enabling it.
+- For oversized payloads, chunk the data into multiple smaller containers and
+  store the bulk content out of band (for example, in object storage), then
+  reference it from the container.
+- Reuse `messaging_container_builder` instances and `value_container` shells
+  in hot loops instead of constructing fresh ones each iteration.
+- Profile with `heaptrack` (Linux) or `Instruments` (macOS) to identify the
+  exact allocation site before tuning.
+
+@section trbl_conversion_errors 5. Type Conversion Errors
+
+@par Symptoms
+- `to_int()` / `to_double()` / `to_string()` throws or returns an unexpected
+  value.
+- Numeric fields silently truncate.
+- A field stored as a string fails to parse on the consumer.
+
+@par Likely Cause
+- The producer chose a value type that does not match the receiver's
+  expectation (for example, `string_value` containing `"true"` versus
+  `bool_value`).
+- Numeric values exceed the range of the receiver's chosen type
+  (`int32_value` consumer reading data that was produced as `int64_value`).
+- A field is missing entirely on the wire and the receiver dereferences a
+  null lookup.
+
+@par Resolution
+- Always check the type tag before converting:
+
+@code{.cpp}
+auto v = container->get_value("count");
+if (!v) {
+    // missing field
+} else if (v->type() == int64_value) {
+    auto count = v->to_long();
+} else if (v->type() == int32_value) {
+    auto count = v->to_int();
+} else {
+    // unexpected wire type, log and reject
+}
+@endcode
+
+- Standardize on a single canonical type per field across producers and
+  consumers. Document it in your service contract.
+- For optional fields, use `null_value` rather than omitting the field
+  entirely. It makes the schema explicit on both sides.
+- When in doubt, prefer the wider type (`int64_value`, `double_value`,
+  `string_value`) and narrow it on the consumer after a range check.
+
+@section trbl_more More Help
+
+- @ref faq for quick answers.
+- @ref tutorial_containers, @ref tutorial_serialization, and
+  @ref tutorial_integration for the long-form guides.
+- File a new issue at https://github.com/kcenon/container_system/issues if you
+  hit something not listed here. Include the format you are using, the
+  producer and consumer versions, and a minimal payload.
+
+*/

--- a/docs/tutorial_containers.dox
+++ b/docs/tutorial_containers.dox
@@ -1,0 +1,174 @@
+/**
+@page tutorial_containers Tutorial: Container Basics
+
+@tableofcontents
+
+This tutorial walks you through the fundamentals of using the Container System.
+You will learn how to choose the right value type for your data, build containers
+using the fluent builder API, and iterate over their contents.
+
+@section tut_cont_intro Introduction
+
+`value_container` (also exposed as `message_buffer` since v2.0.0) is the primary
+abstraction in Container System. It is a type-safe, serializable, header+body
+structure that can hold any combination of the 16 supported value types,
+including nested containers and arrays.
+
+A typical workflow looks like this:
+
+1. Create a container.
+2. Set the routing header (source, target, message type).
+3. Add typed values via `value_factory` or the builder API.
+4. Serialize, transmit, and deserialize on the receiving side.
+
+@section tut_cont_value_types Value Type Selection Guide
+
+Container System defines 16 value types. Choosing the right type matters because
+it controls:
+
+- **Wire size** — smaller types produce smaller serialized payloads.
+- **Range and precision** — pick a type that comfortably fits your domain values.
+- **SIMD applicability** — fixed-width numeric types benefit from SIMD batches.
+- **Cross-language portability** — fixed-width integers map cleanly to other languages.
+
+The table below summarizes when to pick each type.
+
+| Value Type        | Code | Use it for                                                                  | Avoid when                                            |
+|-------------------|------|-----------------------------------------------------------------------------|-------------------------------------------------------|
+| `null_value`      | '0'  | Optional fields, sentinel placeholders                                      | You need a real value                                 |
+| `bool_value`      | '1'  | Flags, on/off switches                                                      | Tri-state values (use `int8_value` or `null_value`)   |
+| `char_value`      | '2'  | Single ASCII character codes                                                | Multi-byte text (use `string_value`)                  |
+| `int8_value`      | '3'  | Small signed counters, status codes                                         | Values >127 or <-128                                  |
+| `uint8_value`     | '4'  | Bytes, small unsigned counters                                              | Negative numbers                                      |
+| `int16_value`     | '5'  | Mid-range counts, signed IDs                                                | Values outside [-32k, 32k]                            |
+| `uint16_value`    | '6'  | Port numbers, small unsigned IDs                                            | Negative numbers                                      |
+| `int32_value`     | '7'  | General-purpose integers, signed IDs                                        | Values exceeding ±2.1B                                |
+| `uint32_value`    | '8'  | Unix timestamps (seconds), unsigned IDs                                     | Negative numbers, values exceeding 4.2B               |
+| `int64_value`     | '9'  | Large signed IDs, balances, nanosecond timestamps                           | Floating-point fractions                              |
+| `uint64_value`    | 'a'  | Hash values, large counters, monotonic IDs                                  | Negative numbers                                      |
+| `float_value`     | 'b'  | Game coordinates, sensor readings (low precision OK)                        | Financial calculations                                |
+| `double_value`    | 'c'  | Money, scientific data, high-precision math                                 | Bit-exact representation needed (use integer cents)   |
+| `bytes_value`     | 'd'  | Binary blobs, encrypted payloads, image data                                | Human-readable text                                   |
+| `container_value` | 'e'  | Nested structured records                                                   | Flat scalar collections (use `array` or repeat keys)  |
+| `string_value`    | 'f'  | UTF-8 text, names, descriptions                                             | Fixed-width binary                                    |
+
+@subsection tut_cont_type_examples Type Selection Examples
+
+- A user account record: `int64_value` for `user_id`, `string_value` for `username`,
+  `double_value` for `balance`, `bool_value` for `active`.
+- A sensor reading: `uint32_value` for `timestamp`, `float_value` for `temperature`,
+  `uint16_value` for `device_id`.
+- A network packet: `bytes_value` for `payload`, `uint32_value` for `crc`,
+  `uint16_value` for `length`.
+
+@section tut_cont_builder Container Builder
+
+The fluent `messaging_container_builder` API is the most ergonomic way to
+construct containers. It accepts native C++ types and selects the matching
+`value_types` automatically.
+
+@code{.cpp}
+#include <container/integration/messaging_integration.h>
+using namespace container_module::integration;
+
+auto container = messaging_container_builder()
+    .source("client_01", "session_123")
+    .target("server", "main_handler")
+    .message_type("user_data")
+    .add_value("user_id", static_cast<int64_t>(12345))
+    .add_value("username", std::string("john_doe"))
+    .add_value("balance", 1500.75)            // -> double_value
+    .add_value("active", true)                // -> bool_value
+    .optimize_for_speed()
+    .build();
+
+std::string serialized = container->serialize();
+@endcode
+
+@subsection tut_cont_builder_factory Factory-Based Construction
+
+If you need explicit control over each value type (for example, when bridging from
+another type system), use `value_factory` directly.
+
+@code{.cpp}
+#include <container/container.h>
+using namespace container_module;
+
+auto container = std::make_shared<value_container>();
+container->set_source("client_01", "session_123");
+container->set_target("server", "main_handler");
+container->set_message_type("user_data");
+
+std::vector<std::shared_ptr<value>> values{
+    value_factory::create("user_id",  int64_value,  "12345"),
+    value_factory::create("username", string_value, "john_doe"),
+    value_factory::create("balance",  double_value, "1500.75"),
+    value_factory::create("active",   bool_value,   "true")
+};
+
+container->set_values(values);
+std::string serialized = container->serialize();
+@endcode
+
+@section tut_cont_iteration Iteration Patterns
+
+@subsection tut_cont_iter_lookup Direct Lookup
+
+The most common pattern is keyed lookup of a known field.
+
+@code{.cpp}
+auto restored = std::make_shared<value_container>(serialized);
+
+if (auto username = restored->get_value("username"); username) {
+    std::string name = username->to_string();
+    // use name...
+}
+@endcode
+
+@subsection tut_cont_iter_range Range-Based Iteration
+
+`value_container` supports range iteration over its top-level values, so you can
+walk the entire body without knowing the keys in advance.
+
+@code{.cpp}
+for (const auto& v : *restored) {
+    switch (v->type()) {
+        case int64_value:
+            std::cout << v->name() << " = " << v->to_long() << '\n';
+            break;
+        case string_value:
+            std::cout << v->name() << " = " << v->to_string() << '\n';
+            break;
+        case double_value:
+            std::cout << v->name() << " = " << v->to_double() << '\n';
+            break;
+        default:
+            std::cout << v->name() << " (type " << static_cast<int>(v->type()) << ")\n";
+    }
+}
+@endcode
+
+@subsection tut_cont_iter_nested Nested Container Traversal
+
+Nested containers form a tree. Recursion is the natural way to walk it.
+
+@code{.cpp}
+void walk(const std::shared_ptr<value_container>& c, int depth = 0) {
+    std::string indent(depth * 2, ' ');
+    for (const auto& v : *c) {
+        std::cout << indent << v->name() << '\n';
+        if (v->type() == container_value) {
+            walk(v->to_container(), depth + 1);
+        }
+    }
+}
+@endcode
+
+@section tut_cont_next Next Steps
+
+- @ref tutorial_serialization to learn about wire formats and SIMD acceleration.
+- @ref tutorial_integration for connecting Container System to network and database layers.
+- @ref faq for quick answers to common questions.
+- @ref troubleshooting if something is not working as expected.
+
+*/

--- a/docs/tutorial_integration.dox
+++ b/docs/tutorial_integration.dox
@@ -1,0 +1,190 @@
+/**
+@page tutorial_integration Tutorial: Integration Patterns
+
+@tableofcontents
+
+Container System is the data exchange format for the kcenon ecosystem. This
+tutorial shows how to integrate it with the surrounding tiers: network_system,
+database_system, and the messaging layer.
+
+@section tut_int_overview Where Container System Fits
+
+```
+common_system  (Tier 0)  --> shared types, Result<T>, IExecutor
+container_system (Tier 1)  --> serializable typed containers (this project)
+network_system   (Tier 4)  --> wire transport
+database_system  (Tier 3)  --> persistence
+pacs_system      (Tier 5)  --> domain composition
+```
+
+A `value_container` flows from a producer (often built via
+`messaging_container_builder`), is serialized to bytes, transported by
+network_system, optionally persisted by database_system, and finally
+deserialized by the consumer.
+
+@section tut_int_network Integration with network_system
+
+network_system transports raw bytes; Container System turns those bytes into
+typed records. Wrap your serialization on the send side and your deserialization
+on the receive side.
+
+@code{.cpp}
+#include <container/container.h>
+#include <container/integration/messaging_integration.h>
+// network_system is a peer dependency in your build
+#include <kcenon/network/messaging_session.h>
+
+using namespace container_module;
+using namespace container_module::integration;
+
+void send_user_event(kcenon::network::messaging_session& session,
+                     int64_t user_id,
+                     const std::string& action) {
+    auto container = messaging_container_builder()
+        .source("auth_svc", session.id())
+        .target("audit_svc", "events")
+        .message_type("user.event")
+        .add_value("user_id", user_id)
+        .add_value("action",  action)
+        .add_value("ts_ns",   static_cast<int64_t>(now_ns()))
+        .build();
+
+    std::string wire = container->serialize();
+    session.async_write(wire);    // network_system handles framing/transport
+}
+
+void on_message(const std::string& wire) {
+    auto incoming = std::make_shared<value_container>(wire);
+    if (incoming->message_type() != "user.event") return;
+
+    auto user_id = incoming->get_value("user_id")->to_long();
+    auto action  = incoming->get_value("action")->to_string();
+    handle_user_event(user_id, action);
+}
+@endcode
+
+Practical tips:
+
+- Keep `message_type` stable. Consumers route on it.
+- Put routing metadata in the header (`set_source` / `set_target`) and business
+  data in the body. The header is cheap to inspect without full deserialization.
+- Reuse `messaging_container_builder` instances when emitting many similar
+  messages in a hot loop.
+
+@section tut_int_database Integration with database_system
+
+Persisting a container is a matter of serializing once and storing the resulting
+blob alongside any indexable header fields. database_system can store the wire
+form directly.
+
+@code{.cpp}
+#include <container/container.h>
+#include <kcenon/database/connection.h>
+
+using namespace container_module;
+
+void persist_message(kcenon::database::connection& db,
+                     const std::shared_ptr<value_container>& msg) {
+    std::string wire = msg->serialize();
+
+    auto stmt = db.prepare(
+        "INSERT INTO messages (source, target, message_type, ts_ns, payload) "
+        "VALUES (?, ?, ?, ?, ?)"
+    );
+
+    stmt.bind(1, msg->source_id());
+    stmt.bind(2, msg->target_id());
+    stmt.bind(3, msg->message_type());
+    stmt.bind(4, msg->get_value("ts_ns")->to_long());
+    stmt.bind_blob(5, wire);
+    stmt.execute();
+}
+
+std::shared_ptr<value_container> load_message(kcenon::database::connection& db,
+                                              std::int64_t row_id) {
+    auto stmt = db.prepare("SELECT payload FROM messages WHERE id = ?");
+    stmt.bind(1, row_id);
+    auto row = stmt.fetch_one();
+    return std::make_shared<value_container>(row.get_blob("payload"));
+}
+@endcode
+
+Practical tips:
+
+- Index header fields, not the blob. The wire format is compact but not
+  designed for SQL-side filtering.
+- Store the format version (or library version) in a side column if you expect
+  long retention windows.
+- Pair persistence with a clear retention policy. Container payloads are typed
+  and self-describing, but they still cost storage.
+
+@section tut_int_messaging Messaging Integration
+
+The `messaging` and `integration` subsystems give you a higher-level workflow
+for request/response and event-style messaging. The builder is the entry point.
+
+@code{.cpp}
+#include <container/integration/messaging_integration.h>
+#include <container/messaging/message_container.h>
+
+using namespace container_module::integration;
+using namespace container_module::messaging;
+
+auto request = messaging_container_builder()
+    .source("frontend", "web_01")
+    .target("orders",   "primary")
+    .message_type("order.create")
+    .add_value("customer_id", static_cast<int64_t>(99001))
+    .add_value("sku",         std::string("SKU-1234"))
+    .add_value("qty",         static_cast<int32_t>(2))
+    .add_value("currency",    std::string("USD"))
+    .add_value("amount",      149.50)
+    .build();
+
+// Hand the container to the messaging integration layer to dispatch it.
+messaging_integration::send(request);
+@endcode
+
+A typical responder pattern:
+
+@code{.cpp}
+void on_order_create(const std::shared_ptr<value_container>& req) {
+    auto cid = req->get_value("customer_id")->to_long();
+    auto sku = req->get_value("sku")->to_string();
+    auto qty = req->get_value("qty")->to_int();
+
+    auto order_id = create_order(cid, sku, qty);
+
+    auto resp = messaging_container_builder()
+        .source(req->target_id(), req->target_sub_id())
+        .target(req->source_id(), req->source_sub_id())
+        .message_type("order.create.ack")
+        .add_value("order_id", order_id)
+        .add_value("status",   std::string("ok"))
+        .build();
+
+    messaging_integration::send(resp);
+}
+@endcode
+
+@section tut_int_best_practices Best Practices
+
+- **Validate at boundaries** — check `message_type` and required fields right
+  after deserialization, then convert to your domain types.
+- **Treat the wire as opaque** — never hand-edit bytes; always go through the
+  serializer.
+- **Pin types** — when you cross language boundaries, prefer fixed-width
+  integer types and explicit scaling for currency.
+- **Reuse builders** — `messaging_container_builder` is cheap to construct but
+  reusing it in tight loops avoids repeated header setup.
+- **Log header, not body** — the header is small, structured, and safe to
+  emit; the body may contain sensitive data.
+
+@section tut_int_next Next Steps
+
+- @ref tutorial_serialization for the wire format details that make these
+  pipelines work.
+- @ref faq for the most common integration questions.
+- @ref troubleshooting if a producer and consumer disagree on the payload.
+
+*/

--- a/docs/tutorial_serialization.dox
+++ b/docs/tutorial_serialization.dox
@@ -1,0 +1,167 @@
+/**
+@page tutorial_serialization Tutorial: Serialization and SIMD
+
+@tableofcontents
+
+This tutorial explains how Container System serializes data, how SIMD acceleration
+fits into the pipeline, and how to keep payloads compatible across platforms.
+
+@section tut_ser_overview Serialization Overview
+
+Container System uses a strategy-pattern serializer registry. Four formats ship
+out of the box:
+
+| Format       | Strategy class       | Payload     | Typical use case                                    |
+|--------------|----------------------|-------------|-----------------------------------------------------|
+| Binary       | `binary_serializer`  | Compact     | Default. Fastest. Internal RPC, persistence.        |
+| JSON         | `json_serializer`    | Human text  | Web APIs, debugging, config exchange.               |
+| XML          | `xml_serializer`     | Human text  | Legacy interop and document-style payloads.         |
+| MessagePack  | `msgpack_serializer` | Compact bin | Polyglot interop with MessagePack-aware systems.    |
+
+The format is resolved at runtime through `serializer_factory`. The default
+binary format is used when you call `value_container::serialize()` with no
+arguments.
+
+@section tut_ser_binary Binary Format
+
+The binary format is the canonical wire format. It is:
+
+- **Compact** — typically ~10% overhead versus the raw payload.
+- **Type-tagged** — each value carries its `value_types` code, so deserialization
+  is unambiguous.
+- **Streamable** — header and body are written sequentially; no random access
+  required.
+- **Endian-stable** — multi-byte integers are encoded in a fixed byte order so
+  payloads round-trip across architectures.
+- **Versioned** — the header carries a format version field that lets future
+  releases evolve the layout without breaking older readers.
+
+@subsection tut_ser_binary_example Binary Round Trip
+
+@code{.cpp}
+#include <container/container.h>
+using namespace container_module;
+
+auto out = std::make_shared<value_container>();
+out->set_source("svc_a", "shard_01");
+out->set_target("svc_b", "queue_main");
+out->set_message_type("metric.report");
+out->set_values({
+    value_factory::create("ts",   uint64_value, "1717000000000"),
+    value_factory::create("cpu",  double_value, "0.732"),
+    value_factory::create("mem",  uint64_value, "1073741824"),
+});
+
+std::string wire = out->serialize();              // binary by default
+
+// On the receiver side:
+auto in = std::make_shared<value_container>(wire);
+double cpu = in->get_value("cpu")->to_double();
+@endcode
+
+@subsection tut_ser_format_select Selecting a Different Format
+
+You can serialize the same container to JSON, XML, or MessagePack via the
+serializer factory.
+
+@code{.cpp}
+#include <container/core/serializers/serializer_factory.h>
+using namespace container_module;
+
+auto json_strategy = serializer_factory::create("json");
+std::string json   = json_strategy->serialize(*out);
+
+auto msgpack_strategy = serializer_factory::create("msgpack");
+std::string mp        = msgpack_strategy->serialize(*out);
+@endcode
+
+The deserialization side works the same way: pick the right strategy and call
+`deserialize`.
+
+@section tut_ser_simd SIMD Acceleration
+
+Container System includes a `simd_processor` that batches numeric work over
+arrays of fixed-width values. The implementation is selected at build time and
+again at run time:
+
+- **Apple Silicon / ARM64** — ARM NEON intrinsics. ~3.2x speedup on typical
+  numeric batches.
+- **x86_64** — AVX2 intrinsics, with SSE2 fallback when AVX2 is unavailable.
+- **Other / unknown** — A scalar fallback path that produces bit-identical
+  results.
+
+You do not need to opt in. Operations such as bulk numeric serialization,
+checksum computation, and array-of-numeric scans automatically dispatch to the
+SIMD path when the data layout is suitable.
+
+@subsection tut_ser_simd_example Letting SIMD Kick In
+
+The SIMD path activates for batched homogeneous numeric data. Prefer adding
+many same-typed values rather than a mixed bag of types when you want to feed
+the accelerator.
+
+@code{.cpp}
+#include <container/integration/messaging_integration.h>
+using namespace container_module::integration;
+
+messaging_container_builder builder;
+builder.source("ingest", "node_07")
+       .target("aggregator", "stage_1")
+       .message_type("samples.batch");
+
+for (uint32_t i = 0; i < 1024; ++i) {
+    builder.add_value("v" + std::to_string(i), static_cast<double>(i) * 0.5);
+}
+
+auto container = builder.optimize_for_speed().build();
+std::string wire = container->serialize();
+@endcode
+
+When `optimize_for_speed()` is selected, the binary serializer prefers tight
+packed layouts that match SIMD lane widths.
+
+@section tut_ser_compat Cross-Platform Compatibility
+
+The binary format is portable across the supported platforms:
+
+- **Endianness** — fixed little-endian on the wire. Big-endian hosts swap on
+  read/write.
+- **Type widths** — fixed-width integer types (`int8_value`..`uint64_value`)
+  guarantee identical widths everywhere; do not rely on `long`/`long long`
+  ambiguity.
+- **Float layout** — IEEE 754 binary32/binary64. NaN payloads are preserved but
+  non-canonical NaN bit patterns should not be used as semantic data.
+- **String encoding** — UTF-8. Validate inputs before storing if you cannot
+  guarantee UTF-8 from the source.
+- **SIMD parity** — the SIMD and scalar paths produce bit-identical output, so
+  a payload produced on Apple Silicon round-trips losslessly on x86_64 Linux.
+
+@subsection tut_ser_compat_versioning Format Versioning
+
+The header includes a format version field. New releases keep the existing
+format version readable by older clients (additive changes only) until a major
+version bump. When a breaking change is required, the format version is
+incremented and the changelog calls it out explicitly.
+
+A defensive deserialization helper:
+
+@code{.cpp}
+auto try_load(const std::string& wire) -> std::shared_ptr<value_container> {
+    try {
+        return std::make_shared<value_container>(wire);
+    } catch (const std::exception& e) {
+        // Log e.what() and either request a re-send or fall back to a
+        // compatibility shim.
+        return nullptr;
+    }
+}
+@endcode
+
+@section tut_ser_next Next Steps
+
+- @ref tutorial_integration for end-to-end pipelines that move serialized
+  payloads through network and database systems.
+- @ref faq for binary format and SIMD trade-off questions.
+- @ref troubleshooting if you hit a serialization mismatch.
+
+*/


### PR DESCRIPTION
Closes #498

## Summary
- Add 3 tutorials: containers (value type selection, builder, iteration), serialization (binary format, SIMD, cross-platform), and integration (network_system, database_system, messaging)
- Add FAQ page with 10 entries covering value type choice, SIMD requirements, thread safety, max size, nesting, performance, format compatibility, custom types, memory pooling, and messaging integration
- Add troubleshooting guide covering 5 common issues: serialization mismatch, SIMD unavailability, thread safety violations, large container memory issues, and type conversion errors
- Update mainpage.dox with a Learning Resources section linking the new pages
- Update Doxyfile to include the new .dox files and add *.dox to FILE_PATTERNS

## Test plan
- [x] Doxygen builds locally with no warnings on the new files
- [x] All cross-references resolve (`@ref tutorial_containers`, `@ref tutorial_serialization`, `@ref tutorial_integration`, `@ref faq`, `@ref troubleshooting`)
- [x] Each tutorial includes 3+ runnable code examples
- [x] FAQ has 10 entries
- [x] Troubleshooting guide has 5 common issues