### PR TITLE
fix(vcpkg): sync root port-version with port manifest

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-container-system",
   "version-semver": "0.1.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Thread-safe serializable container library with advanced features",
   "homepage": "https://github.com/kcenon/container_system",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## What

### Summary
Syncs the `port-version` field between the root `vcpkg.json` and `vcpkg-ports/kcenon-container-system/vcpkg.json`. The root had `port-version: 4` while the port manifest had `port-version: 5`.

### Change Type
- [ ] Feature (new functionality)
- [x] Bugfix (fixes an issue)
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Test

### Affected Components
- `vcpkg.json` — Root vcpkg manifest

## Why

### Problem Solved
Mismatched `port-version` between root and port manifests can cause inconsistent dependency resolution in vcpkg.

### Related Issues
- Closes #503

## How

### Implementation Details
Updated `port-version` from 4 to 5 in the root `vcpkg.json` to match the port manifest value.

### Breaking Changes
None