### PR TITLE
fix(cmake): standardize exported target name to container_system::container_system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,13 +260,14 @@ if(BUILD_WITH_COMMON_SYSTEM)
 endif()
 
 # Create aliases for consistent naming and messaging system compatibility
-add_library(container_system::container ALIAS container_system)
+add_library(container_system::container_system ALIAS container_system)  # Canonical <package>::<package>
+add_library(container_system::container ALIAS container_system)  # Backward compatibility
 add_library(ContainerSystem::container ALIAS container_system)  # Backward compatibility
 add_library(MessagingSystem::container ALIAS container_system)  # For messaging system compatibility
 
 # Set target properties
 set_target_properties(container_system PROPERTIES
-    EXPORT_NAME container
+    EXPORT_NAME container_system
     POSITION_INDEPENDENT_CODE ON
     CXX_STANDARD 20
     CXX_STANDARD_REQUIRED ON

--- a/cmake/container_system-config.cmake.in
+++ b/cmake/container_system-config.cmake.in
@@ -13,6 +13,11 @@ find_dependency(common_system CONFIG REQUIRED)
 # Include targets
 include("${CMAKE_CURRENT_LIST_DIR}/container_system-targets.cmake")
 
+# Backward compatibility alias (container_system::container → container_system::container_system)
+if(NOT TARGET container_system::container)
+    add_library(container_system::container ALIAS container_system::container_system)
+endif()
+
 # Verify targets exist
 check_required_components(container_system)
 
@@ -22,13 +27,13 @@ set(container_system_FOUND TRUE)
 # Provide information about the package
 set(container_system_VERSION @PROJECT_VERSION@)
 set(container_system_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
-set(container_system_LIBRARIES container_system::container)
+set(container_system_LIBRARIES container_system::container_system)
 
 # Backward compatibility aliases (ContainerSystem:: → container_system::)
 if(NOT TARGET ContainerSystem::container)
     add_library(ContainerSystem::container INTERFACE IMPORTED)
     set_target_properties(ContainerSystem::container PROPERTIES
-        INTERFACE_LINK_LIBRARIES container_system::container
+        INTERFACE_LINK_LIBRARIES container_system::container_system
     )
 endif()
 


### PR DESCRIPTION
## What

### Summary
Standardize the CMake exported target name from `container_system::container` to
`container_system::container_system`, following the `<package>::<package>` convention.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `CMakeLists.txt` - Changed `EXPORT_NAME` and added canonical alias
- `cmake/container_system-config.cmake.in` - Added backward compatibility alias

## Why

### Problem Solved
After `find_package(container_system)`, consumers previously got
`container_system::container` instead of the conventional
`container_system::container_system`. This deviates from the standard
`<package>::<package>` naming convention used by most CMake packages.

### Related Issues
- Part of kcenon/vcpkg-registry#78

## Where

### Files Changed
| File | Type of Change |
|------|----------------|
| `CMakeLists.txt` | Changed `EXPORT_NAME`, added canonical alias |
| `cmake/container_system-config.cmake.in` | Added alias + updated target references |

## How

### Implementation Details
1. Changed `EXPORT_NAME` from `container` to `container_system` in
   `set_target_properties()` so the exported target becomes
   `container_system::container_system`.

2. Added `container_system::container_system` as a build-tree alias for
   in-tree consumers (unified builds).

3. Added a backward-compatible alias in the config template:
   ```cmake
   if(NOT TARGET container_system::container)
       add_library(container_system::container ALIAS container_system::container_system)
   endif()
   ```

4. Updated `ContainerSystem::container` legacy alias to link against
   `container_system::container_system` instead of `container_system::container`.

5. Updated `container_system_LIBRARIES` variable to use the new canonical name.

### Breaking Changes
None - existing consumers using `container_system::container` or
`ContainerSystem::container` will continue to work via backward-compatible aliases.