### PR TITLE
docs(i18n): apply Korean documentation parity with #513

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Enable pointer range validation in release builds for `fixed_block_pool` ([#447](https://github.com/kcenon/container_system/issues/447))
 - Correct vcpkg port `PACKAGE_NAME` and `CONFIG_PATH` from `ContainerSystem` to `container_system` so `vcpkg_cmake_config_fixup` matches the actual install layout (`lib/cmake/container_system`) ([#501](https://github.com/kcenon/container_system/issues/501))
+- Apply Korean documentation parity with the mechanical fixes from [#513](https://github.com/kcenon/container_system/pull/513): remove fabricated `v2.0.0` version claim in `README.kr.md`, drop non-existent `BUILD_GUIDE.md` references in `docs/PROJECT_STRUCTURE.kr.md`, and align `docs/API_REFERENCE.kr.md` version to `0.1.0` matching `vcpkg.json` and `CMakeLists.txt` ([#514](https://github.com/kcenon/container_system/issues/514))
 
 ## [0.1.0] - 2026-03-13
 

--- a/README.kr.md
+++ b/README.kr.md
@@ -240,7 +240,7 @@ auto json = container->serialize(serialization_format::json);
 | API | 헤더 | 설명 |
 |-----|------|------|
 | `value_container` | `container.h` | 핵심 직렬화 가능 컨테이너 |
-| `message_buffer` | `container.h` | v2.0.0부터 권장 이름 |
+| `message_buffer` | `container.h` | `value_container`의 권장 별칭 (v0.1 기준선에서 도입; 자세한 내용은 `CLAUDE.md` 참조) |
 | `messaging_container_builder` | `messaging/message_container.h` | 빌더 패턴 생성 |
 | `thread_safe_container` | `internal/thread_safe_container.h` | 스레드 안전 래퍼 |
 | `simd_processor` | `internal/simd_processor.h` | SIMD 가속 처리 |

--- a/docs/API_REFERENCE.kr.md
+++ b/docs/API_REFERENCE.kr.md
@@ -12,9 +12,9 @@ category: "API"
 
 > **SSOT**: This document is the single source of truth for **container_system API 레퍼런스**.
 
-> **버전**: 0.2.1
-> **최종 업데이트**: 2026-01-10
-> **상태**: C++20 Concepts 통합 완료, variant_value_v2로 마이그레이션 중 (Phase 2 진행 중)
+> **버전**: 0.1.0 (`vcpkg.json` 및 `CMakeLists.txt`와 일치)
+> **최종 업데이트**: 2026-04-14
+> **상태**: C++20 Concepts 통합 완료, variant_value_v2 마이그레이션 완료. Strategy 패턴을 적용한 통합 직렬화 API (이슈 #313, #314).
 
 ## 목차
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -80,6 +80,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Windows `windef.h` defines `TRUE` and `FALSE` as macros which conflict with MessagePack format constants
   - Macros are temporarily undefined during msgpack.h parsing and restored at end of file
   - Fixes compilation errors like `error C2059: syntax error: 'constant'` on MSVC
+- **Korean Documentation Parity** (#514): Apply Korean `.kr.md` parity with the mechanical fixes from [#513](https://github.com/kcenon/container_system/pull/513)
+  - Remove fabricated `v2.0.0` version claim from `README.kr.md` `message_buffer` row
+  - Drop non-existent `BUILD_GUIDE.md` references in `docs/PROJECT_STRUCTURE.kr.md` (tree entry and broken link)
+  - Align `docs/API_REFERENCE.kr.md` header version to `0.1.0` matching `vcpkg.json` and `CMakeLists.txt`
 
 ### Deprecated
 - **Legacy void/bool API Methods** (#241): Mark legacy methods as deprecated in favor of Result-returning APIs

--- a/docs/PROJECT_STRUCTURE.kr.md
+++ b/docs/PROJECT_STRUCTURE.kr.md
@@ -141,7 +141,6 @@ container_system/
 │   ├── MIGRATION.md
 │   ├── INTEGRATION.md
 │   ├── 📁 guides/
-│   │   ├── BUILD_GUIDE.md
 │   │   ├── QUICK_START.md
 │   │   ├── BEST_PRACTICES.md
 │   │   ├── TROUBLESHOOTING.md
@@ -605,7 +604,7 @@ cmake --build build --config Release
 - [BENCHMARKS.md](BENCHMARKS.md) / [BENCHMARKS.kr.md](BENCHMARKS.kr.md) - 성능 벤치마크
 - [PRODUCTION_QUALITY.md](PRODUCTION_QUALITY.md) / [PRODUCTION_QUALITY.kr.md](PRODUCTION_QUALITY.kr.md) - 품질 메트릭
 - [ARCHITECTURE.md](ARCHITECTURE.md) - 아키텍처 가이드
-- [BUILD_GUIDE.md](guides/BUILD_GUIDE.md) - 상세 빌드 지침
+- [QUICK_START.md](guides/QUICK_START.md) - 상세 빌드 지침
 
 ---
 


### PR DESCRIPTION
## What

Bring the Korean `.kr.md` variants in line with the mechanical documentation fixes landed in #513, which had explicitly deferred Korean siblings (see commit `b9e369b` body: *"Korean .kr.md files and CHANGELOG.kr.md version tags are left untouched per task scope"*).

### Change Type

- [x] Documentation
- [ ] Feature
- [ ] Bugfix
- [ ] Refactor

### Affected Files

| File | Change |
|------|--------|
| `README.kr.md` | Line 243: replace fabricated `v2.0.0 부터 권장 이름` with parity phrasing |
| `docs/PROJECT_STRUCTURE.kr.md` | Line 144 removed (`BUILD_GUIDE.md` not in repo); Line 608 retargeted to `QUICK_START.md` |
| `docs/API_REFERENCE.kr.md` | Header version `0.2.1` → `0.1.0`, Last Updated `2026-01-10` → `2026-04-14`, status aligned with English sibling |
| `CHANGELOG.md` | Added `Unreleased / Fixed` mirror entry |
| `docs/CHANGELOG.md` | Added SSOT-side mirror entry |

## Why

### Problem Solved

PR #513 deliberately scoped Korean `.kr.md` files out to keep the mechanical English fix reviewable. That left the Korean documentation:

1. Advertising a **fabricated version claim** (`v2.0.0 부터 권장 이름`) — no v2.0.0 release exists; the latest shipped tag per `CHANGELOG.md` is `v0.1.0`.
2. Referencing **non-existent files** (`BUILD_GUIDE.md` in both the directory tree and the See Also list).
3. Reporting a **different header version** (`0.2.1`) than its English sibling (`0.1.0`), despite both describing the same code.

### Related Issues

- Closes #514
- Part of #512 (v1.0 release readiness — Documentation acceptance criterion)
- Follows #513 (English mechanical doc fixes)

## How

### Implementation Details

Four surgical edits plus two CHANGELOG mirror entries — no content translation, purely mechanical parity work:

1. Replaced the `v2.0.0` claim with the same phrasing used in the English `API_QUICK_REFERENCE.md:16` post-#513 (`message_buffer` as a preferred alias introduced in the v0.1 baseline).
2. Removed the `BUILD_GUIDE.md` tree entry (matches English `docs/PROJECT_STRUCTURE.md` post-#513).
3. Retargeted the broken `[BUILD_GUIDE.md](guides/BUILD_GUIDE.md)` link to `[QUICK_START.md](guides/QUICK_START.md)` (matches English See Also replacement).
4. Aligned `API_REFERENCE.kr.md` header metadata with the English sibling after its #513 correction from `0.3.0.0` → `0.1.0`.

### Out of Scope

- `docs/CHANGELOG.kr.md:531–534` fabricated version tags (`v1.0.0`, `v0.9.0`, `v0.8.0`) — flagged by `DOC_REVIEW_REPORT.md` Phase 2 item 19, deferred to a separate issue per original PR #513 scope boundary.
- Footer metadata (`Last Updated`, `Version`) of `docs/PROJECT_STRUCTURE.kr.md` (lines 611-612) — deferred, not a broken link.
- Translation work — this PR is parity on existing English fixes, not new Korean content.

### Testing

- No code changes — pure documentation parity.
- `git diff --stat`: 3 Korean files + 2 CHANGELOG files, 10 insertions / 6 deletions.
- Links manually verified against repository tree (`QUICK_START.md` exists in `docs/guides/`).

### Breaking Changes

None. Documentation-only changes.

### Rollback Plan

Revert this PR. No data migration or consumer impact.