### PR TITLE
feat(value_store): add Result<T>-based deserialization methods

### DIFF
--- a/core/value_store.cpp
+++ b/core/value_store.cpp
@@ -227,4 +227,115 @@ void value_store::reset_statistics() {
     write_count_.store(0, std::memory_order_relaxed);
 }
 
+#if CONTAINER_HAS_COMMON_RESULT
+kcenon::common::Result<std::unique_ptr<value_store>>
+value_store::deserialize_result(std::string_view /*json_data*/) noexcept {
+    return kcenon::common::Result<std::unique_ptr<value_store>>(
+        kcenon::common::error_info{
+            error_codes::deserialization_failed,
+            "value_store::deserialize_result() requires JSON parser - use deserialize_binary_result() instead",
+            "container_system"});
+}
+
+kcenon::common::Result<std::unique_ptr<value_store>>
+value_store::deserialize_binary_result(const std::vector<uint8_t>& binary_data) noexcept {
+    try {
+        auto store = std::make_unique<value_store>();
+
+        if (binary_data.size() < 1 + sizeof(uint32_t)) {
+            return kcenon::common::Result<std::unique_ptr<value_store>>(
+                kcenon::common::error_info{
+                    error_codes::corrupted_data,
+                    "value_store::deserialize_binary_result() - invalid data: too small",
+                    "container_system"});
+        }
+
+        size_t offset = 0;
+
+        uint8_t version = binary_data[offset++];
+        if (version != 1) {
+            return kcenon::common::Result<std::unique_ptr<value_store>>(
+                kcenon::common::error_info{
+                    error_codes::version_mismatch,
+                    "value_store::deserialize_binary_result() - unsupported version: "
+                        + std::to_string(version),
+                    "container_system"});
+        }
+
+        uint32_t count;
+        std::memcpy(&count, binary_data.data() + offset, sizeof(count));
+        offset += sizeof(count);
+
+        for (uint32_t i = 0; i < count; ++i) {
+            if (offset + sizeof(uint32_t) > binary_data.size()) {
+                return kcenon::common::Result<std::unique_ptr<value_store>>(
+                    kcenon::common::error_info{
+                        error_codes::corrupted_data,
+                        "value_store::deserialize_binary_result() - truncated data at entry "
+                            + std::to_string(i),
+                        "container_system"});
+            }
+
+            uint32_t key_len;
+            std::memcpy(&key_len, binary_data.data() + offset, sizeof(key_len));
+            offset += sizeof(key_len);
+
+            if (offset + key_len + sizeof(uint32_t) > binary_data.size()) {
+                return kcenon::common::Result<std::unique_ptr<value_store>>(
+                    kcenon::common::error_info{
+                        error_codes::corrupted_data,
+                        "value_store::deserialize_binary_result() - truncated key data",
+                        "container_system"});
+            }
+
+            std::string key(binary_data.begin() + offset,
+                           binary_data.begin() + offset + key_len);
+            offset += key_len;
+
+            uint32_t value_len;
+            std::memcpy(&value_len, binary_data.data() + offset, sizeof(value_len));
+            offset += sizeof(value_len);
+
+            if (offset + value_len > binary_data.size()) {
+                return kcenon::common::Result<std::unique_ptr<value_store>>(
+                    kcenon::common::error_info{
+                        error_codes::corrupted_data,
+                        "value_store::deserialize_binary_result() - truncated value data",
+                        "container_system"});
+            }
+
+            std::vector<uint8_t> value_data(binary_data.begin() + offset,
+                                            binary_data.begin() + offset + value_len);
+            offset += value_len;
+
+            auto value_opt = value::deserialize(value_data);
+            if (value_opt) {
+                store->values_[key] = std::move(*value_opt);
+            } else {
+                return kcenon::common::Result<std::unique_ptr<value_store>>(
+                    kcenon::common::error_info{
+                        error_codes::value_parse_failed,
+                        "value_store::deserialize_binary_result() - failed to deserialize value for key: "
+                            + key,
+                        "container_system"});
+            }
+        }
+
+        return kcenon::common::ok(std::move(store));
+    } catch (const std::bad_alloc&) {
+        return kcenon::common::Result<std::unique_ptr<value_store>>(
+            kcenon::common::error_info{
+                error_codes::memory_allocation_failed,
+                "value_store::deserialize_binary_result() - memory allocation failed",
+                "container_system"});
+    } catch (const std::exception& e) {
+        return kcenon::common::Result<std::unique_ptr<value_store>>(
+            kcenon::common::error_info{
+                error_codes::deserialization_failed,
+                std::string("value_store::deserialize_binary_result() - unexpected error: ") + e.what(),
+                "container_system"});
+    }
+}
+#endif
+
 } // namespace kcenon::container

--- a/include/kcenon/container/value_store.h
+++ b/include/kcenon/container/value_store.h
@@ -15,6 +15,8 @@
 #pragma once
 
 #include "internal/value.h"
+#include "container/result_integration.h"
+#include "container/error_codes.h"
 
 #include <memory>
 #include <vector>
@@ -145,6 +147,30 @@ public:
      * @throws std::runtime_error if deserialization fails
      */
     static std::unique_ptr<value_store> deserialize_binary(const std::vector<uint8_t>& binary_data);
+
+#if CONTAINER_HAS_COMMON_RESULT
+    // =========================================================================
+    // Result-based Deserialization (no-throw alternatives)
+    // =========================================================================
+
+    /**
+     * @brief Deserialize from JSON string with Result return type
+     * @param json_data JSON string
+     * @return Result containing value_store or error info
+     * @exception_safety No-throw guarantee
+     */
+    [[nodiscard]] static kcenon::common::Result<std::unique_ptr<value_store>>
+        deserialize_result(std::string_view json_data) noexcept;
+
+    /**
+     * @brief Deserialize from binary format with Result return type
+     * @param binary_data Binary data
+     * @return Result containing value_store or error info
+     * @exception_safety No-throw guarantee
+     */
+    [[nodiscard]] static kcenon::common::Result<std::unique_ptr<value_store>>
+        deserialize_binary_result(const std::vector<uint8_t>& binary_data) noexcept;
+#endif
 
     // =========================================================================
     // Statistics (Optional)

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -755,6 +755,52 @@ TEST_F(ValueStoreSerializationTest, LargeValuesSerialization) {
     EXPECT_EQ(bytes_opt->size(), 10000u);
 }
 
+#if CONTAINER_HAS_COMMON_RESULT
+// ============================================================================
+// value_store Result-based Deserialization Tests (Issue #517)
+// ============================================================================
+
+TEST_F(ValueStoreSerializationTest, BinaryDeserializeResultRoundTrip) {
+    value_store store;
+    store.add("integer", value("integer", int32_t(42)));
+    store.add("text", value("text", std::string("hello world")));
+    store.add("flag", value("flag", true));
+
+    auto binary = store.serialize_binary();
+    auto result = value_store::deserialize_binary_result(binary);
+    ASSERT_TRUE(result.is_ok());
+
+    auto& restored = result.value();
+    ASSERT_NE(restored, nullptr);
+    EXPECT_EQ(restored->size(), 3u);
+    EXPECT_TRUE(restored->contains("integer"));
+    EXPECT_TRUE(restored->contains("text"));
+    EXPECT_TRUE(restored->contains("flag"));
+}
+
+TEST_F(ValueStoreSerializationTest, BinaryDeserializeResultInvalidData) {
+    // Empty data
+    std::vector<uint8_t> empty_data;
+    auto result1 = value_store::deserialize_binary_result(empty_data);
+    EXPECT_TRUE(result1.is_err());
+
+    // Too small (only version byte)
+    std::vector<uint8_t> too_small = {1};
+    auto result2 = value_store::deserialize_binary_result(too_small);
+    EXPECT_TRUE(result2.is_err());
+
+    // Invalid version
+    std::vector<uint8_t> bad_version = {99, 0, 0, 0, 0};
+    auto result3 = value_store::deserialize_binary_result(bad_version);
+    EXPECT_TRUE(result3.is_err());
+}
+
+TEST_F(ValueStoreSerializationTest, JSONDeserializeResultNotImplemented) {
+    auto result = value_store::deserialize_result("{}");
+    EXPECT_TRUE(result.is_err());
+}
+#endif
+
 // ============================================================================
 // JSON Escaping Tests (Issue #186)
 // ============================================================================


### PR DESCRIPTION
## What

### Summary
Add no-throw `Result<T>`-based deserialization alternatives to `value_store`, following
the existing `_result` suffix pattern used throughout `value_container`. The original
throwing methods are preserved for backward compatibility.

### Change Type
- [x] Feature (new functionality)

### Affected Components
- `include/kcenon/container/value_store.h` — New method declarations
- `core/value_store.cpp` — Result-based implementations
- `tests/unit_tests.cpp` — Tests for new Result API

## Why

### Problem Solved
v1.0 public APIs should provide no-throw alternatives for all deserialization paths.
`value_store::deserialize_binary()` had 6 `throw` statements with no Result-based
alternative, inconsistent with the rest of the API surface.

### Related Issues
- Closes #517 (Migrate throw statements to Result<T> in value_store)
- Part of #512 (Prepare container_system for v1.0 release)

### Alternative Approaches Considered
1. Replace throwing methods entirely — rejected: breaks existing callers and test expectations
2. Add Result wrappers that catch — rejected: hides real exceptions, not a true migration

Chosen: Add parallel `_result` methods (same pattern as `value_container`)

## How

### Implementation Details
1. Added `deserialize_result(string_view)` — returns error (JSON parser not available)
2. Added `deserialize_binary_result(const vector<uint8_t>&)` — full binary deserialization
   with Result error codes instead of throws
3. Error codes used: `corrupted_data` (204), `version_mismatch` (203), `value_parse_failed` (206),
   `deserialization_failed` (201), `memory_allocation_failed` (400)
4. Guarded by `#if CONTAINER_HAS_COMMON_RESULT` (consistent with project pattern)
5. Outer `try/catch` for `bad_alloc` and unexpected exceptions (noexcept guarantee)

### Testing Done
- [x] 3 new test cases added under `CONTAINER_HAS_COMMON_RESULT` guard
- [x] Round-trip test: serialize → deserialize_binary_result → verify values
- [x] Invalid data tests: empty, too small, bad version
- [x] JSON deserialize_result returns error (not implemented)
- [x] Existing EXPECT_THROW tests unchanged — backward compatible

### Breaking Changes
- None — additive only. Existing throwing methods unchanged.