### PR TITLE
chore: v1.0.0 release preparation — version bump, CHANGELOG, and API stability docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-04-16
+
 ### Added
 
 - Add `recommended_container` alias using `indexed_storage_policy` for O(1) key lookups ([#446](https://github.com/kcenon/container_system/issues/446))
 - Add vcpkg port validation workflow for cross-platform install and consumer-test verification ([#458](https://github.com/kcenon/container_system/issues/458))
 - Add `testing`, `samples`, and `docs` features to vcpkg port manifest, mapped to CMake options via `vcpkg_check_features` ([#501](https://github.com/kcenon/container_system/issues/501))
+- Add Result\<T\>-based deserialization for `value_store` (`deserialize_result`, `deserialize_binary_result`) ([#517](https://github.com/kcenon/container_system/issues/517))
+
+### Changed
+
+- Remove vestigial `is_variant_mode()` and `enable_variant_mode()` no-op methods ([#516](https://github.com/kcenon/container_system/issues/516))
+- Remove unused `CONTAINER_LEGACY_API` CMake option — legacy API was fully removed in prior releases ([#516](https://github.com/kcenon/container_system/issues/516))
+- Remove unused `POLICY_CONTAINER_HAS_COMMON_RESULT` compatibility macro ([#516](https://github.com/kcenon/container_system/issues/516))
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ cmake_minimum_required(VERSION 3.20)
 
 # Project definition
 project(container_system
-    VERSION 0.1.0
+    VERSION 1.0.0
     DESCRIPTION "Advanced C++20 Container System with Thread-Safe Operations and Messaging Integration"
     LANGUAGES CXX
 )

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - [Platform Support](#platform-support)
 - [Thread Safety](#thread-safety)
 - [Error Handling](#error-handling)
+- [API Stability](#api-stability)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -681,6 +682,43 @@ if (!get_result) {
 ```
 
 **Error Codes**: -400 to -499 (centralized in common_system)
+
+## API Stability
+
+Starting with **v1.0.0**, container_system provides the following API guarantees:
+
+### Stable Public API
+
+All types and functions in `include/kcenon/container/` are part of the stable public API:
+
+| Component | Header | Stability |
+|-----------|--------|-----------|
+| `value_container` / `message_buffer` | `container.h` | **Stable** |
+| Value types (`optimized_value`, `value_variant`) | `value_types.h` | **Stable** |
+| Serializer strategy + factory | `serializers/*.h` | **Stable** |
+| Result-based API (`*_result` methods) | `container/result_integration.h` | **Stable** |
+| Error codes | `container/error_codes.h` | **Stable** |
+| Schema validation | `container/schema.h` | **Stable** |
+| Policy containers | `policy_container.h`, `storage_policy.h` | **Stable** |
+
+### Internal API
+
+Headers under `internal/` (e.g., `memory_pool.h`, `simd_processor.h`, `thread_safe_container.h`) are implementation details and may change without notice between minor versions.
+
+### Deprecation Policy
+
+- Deprecated features are marked with `[[deprecated]]` and documented in `CHANGELOG.md`
+- Deprecated features remain available for at least **one minor version** before removal
+- Migration guides are provided in `docs/guides/` for all breaking changes
+
+### Versioning
+
+This project follows [Semantic Versioning](https://semver.org/):
+- **Patch** (1.0.x): Bug fixes, no API changes
+- **Minor** (1.x.0): New features, backward-compatible
+- **Major** (x.0.0): Breaking API changes (with migration guide)
+
+For migration from 0.x, see [docs/guides/MIGRATION.md](docs/guides/MIGRATION.md).
 
 ## Include Paths
 

--- a/docs/API_REFERENCE.kr.md
+++ b/docs/API_REFERENCE.kr.md
@@ -12,7 +12,7 @@ category: "API"
 
 > **SSOT**: This document is the single source of truth for **container_system API 레퍼런스**.
 
-> **버전**: 0.1.0 (`vcpkg.json` 및 `CMakeLists.txt`와 일치)
+> **버전**: 1.0.0 (`vcpkg.json` 및 `CMakeLists.txt`와 일치)
 > **최종 업데이트**: 2026-04-14
 > **상태**: C++20 Concepts 통합 완료, variant_value_v2 마이그레이션 완료. Strategy 패턴을 적용한 통합 직렬화 API (이슈 #313, #314).
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -12,7 +12,7 @@ category: "API"
 
 > **SSOT**: This document is the single source of truth for **container_system API Reference**.
 
-> **Version**: 0.1.0 (aligned with `vcpkg.json` and `CMakeLists.txt`)
+> **Version**: 1.0.0 (aligned with `vcpkg.json` and `CMakeLists.txt`)
 > **Last Updated**: 2026-04-14
 > **Status**: C++20 Concepts integrated, variant_value_v2 migration complete. Unified serialization API with Strategy pattern (Issue #313, #314).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,8 @@
 ---
 doc_id: "CNT-PROJ-002"
 doc_title: "Changelog"
-doc_version: "1.0.0"
-doc_date: "2026-04-04"
+doc_version: "1.0.1"
+doc_date: "2026-04-16"
 doc_status: "Released"
 project: "container_system"
 category: "PROJ"

--- a/vcpkg-ports/kcenon-container-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-container-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-container-system",
-  "version-semver": "0.1.0",
-  "port-version": 5,
+  "version-semver": "1.0.0",
+  "port-version": 0,
   "description": "Advanced C++20 Container System with Thread-Safe Operations and Messaging Integration",
   "homepage": "https://github.com/kcenon/container_system",
   "license": "BSD-3-Clause",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-container-system",
-  "version-semver": "0.1.0",
-  "port-version": 5,
+  "version-semver": "1.0.0",
+  "port-version": 0,
   "description": "Thread-safe serializable container library with advanced features",
   "homepage": "https://github.com/kcenon/container_system",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## What

### Summary
Final preparation for the v1.0.0 release: bump version across all config files,
finalize CHANGELOG entries, and document API stability guarantees in README.

### Change Type
- [x] Chore (version management)
- [x] Documentation

### Affected Components
- `CMakeLists.txt`, `vcpkg.json`, `vcpkg-ports/` — Version 0.1.0 -> 1.0.0
- `CHANGELOG.md`, `docs/CHANGELOG.md` — Release entries finalized
- `README.md` — New "API Stability" section
- `docs/API_REFERENCE.md`, `docs/API_REFERENCE.kr.md` — Version headers updated

## Why

### Problem Solved
The project version (0.1.0) did not match the release target (1.0.0). CHANGELOG had
unreleased entries that needed to be stamped with the release date. README lacked API
stability documentation required by the v1.0 acceptance criteria.

### Related Issues
- Closes #518 (Bump version to 1.0.0 and finalize CHANGELOG)
- Closes #519 (Document v1.0 API guarantees in README)
- Part of #512 (Prepare container_system for v1.0 release)

## How

### Implementation Details

**Commit 1 — Version bump (#518):**
1. `CMakeLists.txt`: VERSION 0.1.0 -> 1.0.0
2. `vcpkg.json` + `vcpkg-ports/`: version-semver 0.1.0 -> 1.0.0, port-version reset to 0
3. Root `CHANGELOG.md`: [Unreleased] entries moved to [1.0.0] - 2026-04-16
4. Added #516 and #517 entries to v1.0 changelog
5. API Reference version headers updated (en/kr)

**Commit 2 — API stability docs (#519):**
1. Added "API Stability" section to README.md with:
   - Stable public API surface table
   - Internal API boundaries
   - Deprecation policy (one minor version notice)
   - Semantic versioning commitment
   - Migration guide reference

### Testing Done
- [x] Version consistency verified across CMakeLists.txt, vcpkg.json, vcpkg-ports
- [x] CHANGELOG format follows Keep a Changelog
- [x] README markdown renders correctly

### Breaking Changes
- None