### PR TITLE
feat(container): add standard forward/bidirectional iterator interface

### DIFF
--- a/include/kcenon/container/container.h
+++ b/include/kcenon/container/container.h
@@ -46,6 +46,13 @@
 #include <unordered_map>
 #include <optional>
 #include <span>
+#include <iterator>
+
+#if defined(__has_include)
+#  if __has_include(<concepts>)
+#    include <concepts>
+#  endif
+#endif
 
 namespace kcenon::container
 {
@@ -857,7 +864,16 @@ namespace kcenon::container
 	 * @name STL Iterator Support
 	 * @brief Provides Standard Library-compatible iteration over container values
 	 *
-	 * Enables range-based for loops and STL algorithm usage:
+	 * Satisfies the STL iterator requirements so that range-based for loops,
+	 * standard algorithms, and iterator-based utilities (`std::distance`,
+	 * `std::advance`, `std::reverse`, ...) work directly on `value_container`.
+	 *
+	 * The iterator delegates to the underlying `std::vector<optimized_value>`
+	 * iterator. That alias satisfies `std::contiguous_iterator` (and therefore
+	 * `std::random_access_iterator`, `std::bidirectional_iterator`, and
+	 * `std::forward_iterator`) per [vector.iterators]. The public type aliases
+	 * below expose this as a standard container interface.
+	 *
 	 * @code
 	 *   value_container container;
 	 *   for (const auto& val : container) {
@@ -866,39 +882,86 @@ namespace kcenon::container
 	 *
 	 *   auto it = std::find_if(container.begin(), container.end(),
 	 *       [](const auto& v) { return v.type == value_types::int_value; });
+	 *
+	 *   // Bidirectional traversal:
+	 *   for (auto rit = container.rbegin(); rit != container.rend(); ++rit) {
+	 *       // Process values in reverse
+	 *   }
 	 * @endcode
 	 * @{
 	 */
 
-	/** @brief Iterator type for non-const traversal */
+	/** @brief Standard container type aliases (see [container.reqmts]) */
+	using value_type      = optimized_value;
+	using reference       = optimized_value&;
+	using const_reference = const optimized_value&;
+	using pointer         = optimized_value*;
+	using const_pointer   = const optimized_value*;
+	using size_type       = std::vector<optimized_value>::size_type;
+	using difference_type = std::vector<optimized_value>::difference_type;
+
+	/** @brief Iterator type for non-const traversal (contiguous iterator) */
 	using iterator = std::vector<optimized_value>::iterator;
 
-	/** @brief Iterator type for const traversal */
+	/** @brief Iterator type for const traversal (contiguous iterator) */
 	using const_iterator = std::vector<optimized_value>::const_iterator;
 
+	/** @brief Reverse iterator for bidirectional traversal */
+	using reverse_iterator = std::vector<optimized_value>::reverse_iterator;
+
+	/** @brief Const reverse iterator for bidirectional traversal */
+	using const_reverse_iterator =
+		std::vector<optimized_value>::const_reverse_iterator;
+
 	/** @brief Returns iterator to beginning of values */
-	iterator begin() { return optimized_units_.begin(); }
+	iterator begin() noexcept { return optimized_units_.begin(); }
 
 	/** @brief Returns iterator to end of values */
-	iterator end() { return optimized_units_.end(); }
+	iterator end() noexcept { return optimized_units_.end(); }
 
 	/** @brief Returns const iterator to beginning of values */
-	const_iterator begin() const { return optimized_units_.begin(); }
+	const_iterator begin() const noexcept { return optimized_units_.begin(); }
 
 	/** @brief Returns const iterator to end of values */
-	const_iterator end() const { return optimized_units_.end(); }
+	const_iterator end() const noexcept { return optimized_units_.end(); }
 
 	/** @brief Returns const iterator to beginning of values */
-	const_iterator cbegin() const { return optimized_units_.cbegin(); }
+	const_iterator cbegin() const noexcept { return optimized_units_.cbegin(); }
 
 	/** @brief Returns const iterator to end of values */
-	const_iterator cend() const { return optimized_units_.cend(); }
+	const_iterator cend() const noexcept { return optimized_units_.cend(); }
+
+	/** @brief Returns reverse iterator to last value */
+	reverse_iterator rbegin() noexcept { return optimized_units_.rbegin(); }
+
+	/** @brief Returns reverse iterator past the first value */
+	reverse_iterator rend() noexcept { return optimized_units_.rend(); }
+
+	/** @brief Returns const reverse iterator to last value */
+	const_reverse_iterator rbegin() const noexcept {
+		return optimized_units_.rbegin();
+	}
+
+	/** @brief Returns const reverse iterator past the first value */
+	const_reverse_iterator rend() const noexcept {
+		return optimized_units_.rend();
+	}
+
+	/** @brief Returns const reverse iterator to last value */
+	const_reverse_iterator crbegin() const noexcept {
+		return optimized_units_.crbegin();
+	}
+
+	/** @brief Returns const reverse iterator past the first value */
+	const_reverse_iterator crend() const noexcept {
+		return optimized_units_.crend();
+	}
 
 	/** @brief Returns number of values in container */
-	size_t size() const { return optimized_units_.size(); }
+	size_type size() const noexcept { return optimized_units_.size(); }
 
 	/** @brief Returns whether container is empty */
-	bool empty() const { return optimized_units_.empty(); }
+	bool empty() const noexcept { return optimized_units_.empty(); }
 
 	/** @} */
 
@@ -1110,5 +1173,22 @@ namespace kcenon::container
 	 * @since 2.0.0
 	 */
 	using message_buffer = value_container;
+
+	// =======================================================================
+	// Compile-time iterator conformance checks (Issue #526)
+	// =======================================================================
+
+#if defined(__cpp_lib_concepts) && __cpp_lib_concepts >= 202002L
+	static_assert(std::forward_iterator<value_container::iterator>,
+		"value_container::iterator must satisfy std::forward_iterator");
+	static_assert(std::forward_iterator<value_container::const_iterator>,
+		"value_container::const_iterator must satisfy std::forward_iterator");
+	static_assert(std::bidirectional_iterator<value_container::iterator>,
+		"value_container::iterator must satisfy std::bidirectional_iterator");
+	static_assert(
+		std::bidirectional_iterator<value_container::const_iterator>,
+		"value_container::const_iterator must satisfy "
+		"std::bidirectional_iterator");
+#endif
 
 } // namespace kcenon::container

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,6 +67,7 @@ set(TEST_SOURCES
     policy_container_tests.cpp
     fast_parser_integration_tests.cpp
     serializer_factory_tests.cpp
+    iterator_tests.cpp
 )
 
 # Add async tests if coroutines are enabled

--- a/tests/iterator_tests.cpp
+++ b/tests/iterator_tests.cpp
@@ -1,0 +1,390 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2026, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file iterator_tests.cpp
+ * @brief Unit tests for the STL iterator interface on value_container
+ *
+ * Covers:
+ * - iterator_traits completeness and iterator categories
+ * - Range-based for loops (const and non-const)
+ * - std::distance and std::advance
+ * - STL algorithms (find_if, count_if, copy, accumulate, all_of)
+ * - Const correctness (const_iterator, cbegin/cend)
+ * - Bidirectional traversal via reverse_iterator/rbegin/rend
+ * - Equality/inequality invariants
+ *
+ * Closes #526
+ */
+
+#include <gtest/gtest.h>
+#include "test_compat.h"
+
+#include <algorithm>
+#include <iterator>
+#include <numeric>
+#include <type_traits>
+#include <vector>
+
+#if defined(__has_include)
+#  if __has_include(<concepts>)
+#    include <concepts>
+#  endif
+#endif
+
+#if defined(__has_include)
+#  if __has_include(<ranges>)
+#    include <ranges>
+#  endif
+#endif
+
+using namespace kcenon::container;
+
+namespace {
+
+// Helper: populate container in-place with N int values named "k<i>".
+// (The move constructor of value_container does not transfer the value list,
+//  so we avoid return-by-value here.)
+void populate(value_container& c, int n) {
+    for (int i = 0; i < n; ++i) {
+        c.set("k" + std::to_string(i), i);
+    }
+}
+
+} // namespace
+
+// ============================================================================
+// Iterator Trait Checks (compile-time)
+// ============================================================================
+
+TEST(ContainerIteratorTraits, TypeAliasesExist) {
+    using I = value_container::iterator;
+    using CI = value_container::const_iterator;
+    using RI = value_container::reverse_iterator;
+    using CRI = value_container::const_reverse_iterator;
+
+    static_assert(std::is_same_v<value_container::value_type, optimized_value>);
+    static_assert(std::is_same_v<value_container::reference,
+                                 optimized_value&>);
+    static_assert(std::is_same_v<value_container::const_reference,
+                                 const optimized_value&>);
+    static_assert(std::is_same_v<value_container::pointer,
+                                 optimized_value*>);
+    static_assert(std::is_same_v<value_container::const_pointer,
+                                 const optimized_value*>);
+
+    using traits = std::iterator_traits<I>;
+    static_assert(std::is_same_v<traits::value_type, optimized_value>);
+    static_assert(std::is_same_v<traits::reference, optimized_value&>);
+    static_assert(std::is_same_v<traits::pointer, optimized_value*>);
+    static_assert(std::is_signed_v<traits::difference_type>);
+
+    using ctraits = std::iterator_traits<CI>;
+    static_assert(std::is_same_v<ctraits::reference,
+                                 const optimized_value&>);
+    static_assert(std::is_same_v<ctraits::pointer,
+                                 const optimized_value*>);
+
+    // Compiles if reverse iterators expose a reverse_iterator category.
+    static_assert(std::is_same_v<
+        std::iterator_traits<RI>::value_type, optimized_value>);
+    static_assert(std::is_same_v<
+        std::iterator_traits<CRI>::value_type, optimized_value>);
+
+    SUCCEED();
+}
+
+TEST(ContainerIteratorTraits, ForwardAndBidirectionalCategories) {
+    using I = value_container::iterator;
+    using CI = value_container::const_iterator;
+
+    // iterator_category must exist and be derived from forward_iterator_tag.
+    using cat = std::iterator_traits<I>::iterator_category;
+    using ccat = std::iterator_traits<CI>::iterator_category;
+
+    static_assert(std::is_base_of_v<std::forward_iterator_tag, cat>);
+    static_assert(std::is_base_of_v<std::bidirectional_iterator_tag, cat>);
+    static_assert(std::is_base_of_v<std::forward_iterator_tag, ccat>);
+    static_assert(
+        std::is_base_of_v<std::bidirectional_iterator_tag, ccat>);
+
+#if defined(__cpp_lib_concepts) && __cpp_lib_concepts >= 202002L
+    static_assert(std::forward_iterator<I>);
+    static_assert(std::forward_iterator<CI>);
+    static_assert(std::bidirectional_iterator<I>);
+    static_assert(std::bidirectional_iterator<CI>);
+#endif
+
+    SUCCEED();
+}
+
+// ============================================================================
+// Range-based for loops
+// ============================================================================
+
+TEST(ContainerIterator, RangeForTraversalVisitsAllValues) {
+    value_container c;
+    populate(c, 5);
+
+    int visited = 0;
+    for (const auto& v : c) {
+        EXPECT_FALSE(v.name.empty());
+        ++visited;
+    }
+    EXPECT_EQ(visited, 5);
+}
+
+TEST(ContainerIterator, RangeForOnConstReference) {
+    value_container tmp;
+    populate(tmp, 3);
+    const value_container& c = tmp;
+
+    int visited = 0;
+    for (const auto& v : c) {
+        (void)v;
+        ++visited;
+    }
+    EXPECT_EQ(visited, 3);
+}
+
+// ============================================================================
+// std::distance, std::advance
+// ============================================================================
+
+TEST(ContainerIterator, DistanceMatchesSize) {
+    value_container c;
+    populate(c, 7);
+
+    auto d = std::distance(c.begin(), c.end());
+    EXPECT_EQ(static_cast<value_container::size_type>(d), c.size());
+    EXPECT_EQ(d, 7);
+}
+
+TEST(ContainerIterator, DistanceOnEmptyContainerIsZero) {
+    value_container c;
+    EXPECT_EQ(std::distance(c.begin(), c.end()), 0);
+    EXPECT_TRUE(c.empty());
+}
+
+TEST(ContainerIterator, AdvanceMovesForwardAndBackward) {
+    value_container c;
+    populate(c, 5);
+
+    auto it = c.begin();
+    std::advance(it, 3);
+    ASSERT_NE(it, c.end());
+    EXPECT_EQ(it->name, "k3");
+
+    // Bidirectional: advance backward
+    std::advance(it, -2);
+    EXPECT_EQ(it->name, "k1");
+}
+
+// ============================================================================
+// STL algorithms
+// ============================================================================
+
+TEST(ContainerIterator, StdFindIfLocatesMatchingValue) {
+    value_container c;
+    populate(c, 10);
+
+    auto it = std::find_if(c.begin(), c.end(),
+        [](const optimized_value& v) { return v.name == "k4"; });
+
+    ASSERT_NE(it, c.end());
+    EXPECT_EQ(it->name, "k4");
+}
+
+TEST(ContainerIterator, StdFindIfReturnsEndWhenMissing) {
+    value_container c;
+    populate(c, 3);
+
+    auto it = std::find_if(c.begin(), c.end(),
+        [](const optimized_value& v) { return v.name == "missing"; });
+    EXPECT_EQ(it, c.end());
+}
+
+TEST(ContainerIterator, StdCountIfCountsMatches) {
+    value_container c;
+    populate(c, 6);
+
+    auto n = std::count_if(c.cbegin(), c.cend(),
+        [](const optimized_value& v) {
+            return !v.name.empty() && v.name[0] == 'k';
+        });
+    EXPECT_EQ(n, 6);
+}
+
+TEST(ContainerIterator, StdAllOfOverConstIterators) {
+    value_container tmp;
+    populate(tmp, 4);
+    const value_container& c = tmp;
+
+    bool ok = std::all_of(c.begin(), c.end(),
+        [](const optimized_value& v) { return !v.name.empty(); });
+    EXPECT_TRUE(ok);
+}
+
+TEST(ContainerIterator, StdCopyIntoVectorProducesEqualSequence) {
+    value_container c;
+    populate(c, 4);
+
+    std::vector<optimized_value> out;
+    out.reserve(c.size());
+    std::copy(c.begin(), c.end(), std::back_inserter(out));
+
+    ASSERT_EQ(out.size(), c.size());
+    for (std::size_t i = 0; i < out.size(); ++i) {
+        EXPECT_EQ(out[i].name, "k" + std::to_string(i));
+    }
+}
+
+TEST(ContainerIterator, StdAccumulateOnNameLengths) {
+    value_container c;
+    populate(c, 4);
+
+    auto total = std::accumulate(c.begin(), c.end(), std::size_t{0},
+        [](std::size_t acc, const optimized_value& v) {
+            return acc + v.name.size();
+        });
+
+    // "k0","k1","k2","k3" -> 8 characters total.
+    EXPECT_EQ(total, 8u);
+}
+
+// ============================================================================
+// Const correctness
+// ============================================================================
+
+TEST(ContainerIterator, CbeginCendReturnConstIterators) {
+    value_container c;
+    c.set("a", 1);
+
+    auto it = c.cbegin();
+    auto end = c.cend();
+
+    static_assert(
+        std::is_same_v<decltype(it), value_container::const_iterator>);
+    static_assert(
+        std::is_same_v<decltype(end), value_container::const_iterator>);
+
+    ASSERT_NE(it, end);
+    EXPECT_EQ(it->name, "a");
+}
+
+TEST(ContainerIterator, ConstContainerYieldsConstIterators) {
+    value_container tmp;
+    populate(tmp, 2);
+    const value_container& c = tmp;
+
+    auto it = c.begin();
+    static_assert(
+        std::is_same_v<decltype(it), value_container::const_iterator>);
+    (void)it;
+    SUCCEED();
+}
+
+// ============================================================================
+// Bidirectional / reverse traversal
+// ============================================================================
+
+TEST(ContainerIterator, ReverseIteratorTraversesInReverse) {
+    value_container c;
+    populate(c, 4);
+
+    std::vector<std::string> names;
+    for (auto it = c.rbegin(); it != c.rend(); ++it) {
+        names.push_back(it->name);
+    }
+
+    ASSERT_EQ(names.size(), 4u);
+    EXPECT_EQ(names[0], "k3");
+    EXPECT_EQ(names[1], "k2");
+    EXPECT_EQ(names[2], "k1");
+    EXPECT_EQ(names[3], "k0");
+}
+
+TEST(ContainerIterator, CrbeginCrendAreConstReverseIterators) {
+    value_container tmp;
+    populate(tmp, 2);
+    const value_container& c = tmp;
+
+    auto it = c.crbegin();
+    auto end = c.crend();
+    static_assert(std::is_same_v<decltype(it),
+                                 value_container::const_reverse_iterator>);
+    static_assert(std::is_same_v<decltype(end),
+                                 value_container::const_reverse_iterator>);
+
+    ASSERT_NE(it, end);
+    EXPECT_EQ(it->name, "k1");
+}
+
+TEST(ContainerIterator, BidirectionalDecrementReturnsToPrevious) {
+    value_container c;
+    populate(c, 3);
+
+    auto it = c.begin();
+    ++it;
+    ++it;
+    EXPECT_EQ(it->name, "k2");
+    --it;
+    EXPECT_EQ(it->name, "k1");
+    --it;
+    EXPECT_EQ(it->name, "k0");
+    EXPECT_EQ(it, c.begin());
+}
+
+// ============================================================================
+// Equality / inequality invariants
+// ============================================================================
+
+TEST(ContainerIterator, BeginEqualsEndOnEmpty) {
+    value_container c;
+    EXPECT_EQ(c.begin(), c.end());
+    EXPECT_EQ(c.cbegin(), c.cend());
+    EXPECT_EQ(c.rbegin(), c.rend());
+    EXPECT_EQ(c.crbegin(), c.crend());
+}
+
+TEST(ContainerIterator, BeginDiffersFromEndOnNonEmpty) {
+    value_container c;
+    populate(c, 1);
+    EXPECT_NE(c.begin(), c.end());
+    EXPECT_NE(c.cbegin(), c.cend());
+}
+
+TEST(ContainerIterator, IncrementEqualityAfterSize) {
+    value_container c;
+    populate(c, 3);
+
+    auto it = c.begin();
+    ++it;
+    ++it;
+    ++it;
+    EXPECT_EQ(it, c.end());
+}
+
+TEST(ContainerIterator, ConstAndNonConstIteratorsCompareEqual) {
+    value_container c;
+    populate(c, 2);
+    const value_container& cref = c;
+
+    EXPECT_EQ(c.begin(), cref.begin());
+    EXPECT_EQ(c.end(), cref.end());
+}
+
+// ============================================================================
+// Range concept (C++20 ranges)
+// ============================================================================
+
+#if defined(__cpp_lib_ranges) && __cpp_lib_ranges >= 201911L
+TEST(ContainerIterator, SatisfiesStdRangesRange) {
+    static_assert(std::ranges::range<value_container>);
+    static_assert(std::ranges::range<const value_container>);
+    static_assert(std::ranges::forward_range<value_container>);
+    static_assert(std::ranges::bidirectional_range<value_container>);
+    SUCCEED();
+}
+#endif


### PR DESCRIPTION
## What

Expose `kcenon::container::value_container` as an STL-conforming sequence
container by adding the standard nested type aliases and reverse
iterator support. The existing `begin`/`end`/`cbegin`/`cend` were kept
stable and only annotated `noexcept`.

### Iterator category compliance

| Iterator                              | Category (via `iterator_traits`)         | Concepts satisfied                                              |
|---------------------------------------|------------------------------------------|-----------------------------------------------------------------|
| `value_container::iterator`           | `std::random_access_iterator_tag` (+contiguous) | `forward_iterator`, `bidirectional_iterator`, `random_access_iterator` |
| `value_container::const_iterator`     | `std::random_access_iterator_tag` (+contiguous) | `forward_iterator`, `bidirectional_iterator`, `random_access_iterator` |
| `value_container::reverse_iterator`   | `std::random_access_iterator_tag`        | bidirectional, random_access                                    |
| `value_container::const_reverse_iterator` | `std::random_access_iterator_tag`    | bidirectional, random_access                                    |

The iterator aliases delegate to `std::vector<optimized_value>::iterator`,
which is already `std::contiguous_iterator` per `[vector.iterators]`.
Issue #526 requires at least `std::forward_iterator`; both
forward and bidirectional are satisfied (and random_access as a side
effect of the chosen implementation strategy).

### STL compatibility notes

- Full `iterator_traits` specializations are available.
- Range-based `for`, `std::distance`, `std::advance`, `std::find_if`,
  `std::count_if`, `std::all_of`, `std::copy`, `std::accumulate` all work.
- `std::ranges::bidirectional_range<value_container>` holds under
  `__cpp_lib_ranges`.
- Namespace-scope `static_assert`s (guarded on `__cpp_lib_concepts`)
  lock in the `forward_iterator` and `bidirectional_iterator` contract.

## Why

- Baseline ISO C++ iterator conformance unlocks `<algorithm>`, `<ranges>`,
  and idiomatic range-for usage for downstream consumers.
- Prepares the container for `std::ranges` and range-based adaptors
  without further API churn.
- Closes #526.

## Where

- `include/kcenon/container/container.h`
  - Added `value_type`, `reference`, `const_reference`, `pointer`,
    `const_pointer`, `size_type`, `difference_type`.
  - Added `reverse_iterator`, `const_reverse_iterator`.
  - Added `rbegin/rend/crbegin/crend` accessors.
  - Added `noexcept` to existing `begin/end/cbegin/cend/size/empty`.
  - Added namespace-scope `static_assert`s on iterator concepts.
  - Added `<iterator>` and conditional `<concepts>` includes.
- `tests/iterator_tests.cpp` (new) + `tests/CMakeLists.txt` registration.

## How

### Implementation

The iterator types are aliases of `std::vector<optimized_value>`
iterators. No new iterator class is introduced: the existing storage
already models `contiguous_iterator`, so re-wrapping would only reduce
capability.

### Testing

`iterator_tests.cpp` exercises:

- `iterator_traits` completeness and category tags.
- C++20 `std::forward_iterator` / `std::bidirectional_iterator`
  concepts.
- Range-based for loops (const and non-const).
- `std::distance`, `std::advance` (including negative advance).
- Const correctness (`cbegin`, `cend`, const-reference iteration).
- Reverse traversal (`rbegin`, `rend`, `crbegin`, `crend`).
- STL algorithms: `find_if`, `count_if`, `all_of`, `copy`,
  `accumulate`.
- Equality / inequality invariants (empty, non-empty, const vs
  non-const).
- `std::ranges::bidirectional_range` (when `__cpp_lib_ranges`).

### Breaking changes

None. The public API only gains new members; existing return types and
signatures are preserved.

### Rollback

Revert this PR; no data migration required.

Closes #526