### PR TITLE
feat(container): add STL allocator_traits compatibility layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ set(INTERNAL_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/internal/variant_value_factory.h
     ${CMAKE_CURRENT_SOURCE_DIR}/internal/memory_pool.h
     ${CMAKE_CURRENT_SOURCE_DIR}/internal/pool_allocator.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/internal/pool_allocator_adapter.h
     ${CMAKE_CURRENT_SOURCE_DIR}/internal/thread_safe_container.h
     ${CMAKE_CURRENT_SOURCE_DIR}/internal/thread_safe_container.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/internal/simd_processor.h

--- a/internal/pool_allocator_adapter.h
+++ b/internal/pool_allocator_adapter.h
@@ -1,0 +1,159 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+/**
+ * @file internal/pool_allocator_adapter.h
+ * @brief STL-compatible allocator adapter over @ref pool_allocator
+ *
+ * Provides an `std::allocator_traits`-compliant wrapper around the existing
+ * thread-local @ref kcenon::container::internal::pool_allocator singleton so
+ * that standard library containers (std::vector, std::list,
+ * std::unordered_map, etc.) can use the pool transparently.
+ *
+ * Design notes:
+ * - Stateless: all instances are interchangeable. `is_always_equal = true_type`.
+ * - Uses the thread-local singleton from pool_allocator.h for the actual
+ *   small/medium size-class allocation fast path. Allocations that exceed the
+ *   pool's medium threshold fall back to the singleton's heap path, matching
+ *   the existing behaviour.
+ * - `propagate_on_container_*` are all `false_type` (the default) because the
+ *   allocator is stateless and always equal.
+ * - Supports rebind through the class template itself (see @c rebind nested
+ *   template), which in turn makes it compatible with pre-C++20 allocator
+ *   machinery in addition to @c std::allocator_traits.
+ */
+
+#include "pool_allocator.h"
+
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <new>
+#include <type_traits>
+
+namespace kcenon::container::internal {
+
+/**
+ * @brief STL-compatible allocator adapter that routes allocations through
+ *        @ref pool_allocator.
+ *
+ * Satisfies the C++ AllocatorAwareContainer and Allocator named requirements
+ * so it can be used as the template argument to any STL container.
+ *
+ * Example:
+ * @code
+ *   std::vector<int, kcenon::container::internal::pool_allocator_adapter<int>> v;
+ *   v.reserve(16);
+ *   v.push_back(42);
+ * @endcode
+ *
+ * @tparam T Element type. Must be destructible.
+ */
+template<typename T>
+class pool_allocator_adapter {
+public:
+    using value_type = T;
+    using pointer = T*;
+    using const_pointer = const T*;
+    using reference = T&;
+    using const_reference = const T&;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+
+    // Propagation traits: adapter is stateless, so propagation is unnecessary.
+    using propagate_on_container_copy_assignment = std::false_type;
+    using propagate_on_container_move_assignment = std::false_type;
+    using propagate_on_container_swap = std::false_type;
+    using is_always_equal = std::true_type;
+
+    /**
+     * @brief Rebind mechanism required for node-based containers
+     *        (e.g. std::list, std::map) that allocate internal node types.
+     */
+    template<typename U>
+    struct rebind {
+        using other = pool_allocator_adapter<U>;
+    };
+
+    /// Default constructor. The adapter is stateless.
+    constexpr pool_allocator_adapter() noexcept = default;
+
+    /// Copy constructor. Stateless: nothing to copy.
+    constexpr pool_allocator_adapter(const pool_allocator_adapter&) noexcept = default;
+
+    /// Rebind constructor. Required by std::allocator_traits.
+    template<typename U>
+    constexpr pool_allocator_adapter(const pool_allocator_adapter<U>&) noexcept {}
+
+    ~pool_allocator_adapter() = default;
+
+    /**
+     * @brief Allocate storage for @p n objects of type @c T.
+     *
+     * Routes through the thread-local @ref pool_allocator singleton, which
+     * selects the small, medium, or heap path based on total byte size. Throws
+     * @c std::bad_alloc on failure to mirror @c std::allocator behaviour.
+     *
+     * @param n Number of elements to allocate.
+     * @return Pointer to uninitialised storage for @p n objects.
+     */
+    [[nodiscard]] pointer allocate(size_type n) {
+        if (n == 0) {
+            return nullptr;
+        }
+        if (n > max_size()) {
+            throw std::bad_alloc();
+        }
+
+        const size_type bytes = n * sizeof(T);
+        void* ptr = pool_allocator::instance().allocate(bytes);
+        if (!ptr) {
+            throw std::bad_alloc();
+        }
+        return static_cast<pointer>(ptr);
+    }
+
+    /**
+     * @brief Deallocate storage previously obtained from @ref allocate.
+     *
+     * @param p Pointer returned by a prior call to @ref allocate.
+     * @param n Number of elements originally requested.
+     */
+    void deallocate(pointer p, size_type n) noexcept {
+        if (!p) {
+            return;
+        }
+        const size_type bytes = n * sizeof(T);
+        pool_allocator::instance().deallocate(static_cast<void*>(p), bytes);
+    }
+
+    /**
+     * @brief Maximum number of elements that can be allocated in a single call.
+     */
+    constexpr size_type max_size() const noexcept {
+        return std::numeric_limits<size_type>::max() / sizeof(T);
+    }
+};
+
+/**
+ * @brief Equality: all adapter instances are interchangeable (stateless).
+ */
+template<typename T, typename U>
+constexpr bool operator==(const pool_allocator_adapter<T>&,
+                          const pool_allocator_adapter<U>&) noexcept {
+    return true;
+}
+
+/**
+ * @brief Inequality: negation of @ref operator==.
+ */
+template<typename T, typename U>
+constexpr bool operator!=(const pool_allocator_adapter<T>& a,
+                          const pool_allocator_adapter<U>& b) noexcept {
+    return !(a == b);
+}
+
+} // namespace kcenon::container::internal

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,7 @@ set(TEST_SOURCES
     fast_parser_integration_tests.cpp
     serializer_factory_tests.cpp
     iterator_tests.cpp
+    allocator_adapter_tests.cpp
 )
 
 # Add async tests if coroutines are enabled

--- a/tests/allocator_adapter_tests.cpp
+++ b/tests/allocator_adapter_tests.cpp
@@ -1,0 +1,339 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2026, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file allocator_adapter_tests.cpp
+ * @brief Unit tests for pool_allocator_adapter STL allocator compatibility
+ *
+ * Covers:
+ * - std::allocator_traits completeness
+ * - Rebind mechanism for node-based containers
+ * - Direct allocate/deallocate round trip
+ * - Integration with std::vector, std::list, std::unordered_map
+ * - Equality / is_always_equal invariants
+ * - Counting allocator using rebound pool_allocator_adapter internally
+ *
+ * Closes #525
+ */
+
+#include <gtest/gtest.h>
+
+#include <internal/pool_allocator_adapter.h>
+
+#include <atomic>
+#include <list>
+#include <memory>
+#include <numeric>
+#include <scoped_allocator>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+using kcenon::container::internal::pool_allocator;
+using kcenon::container::internal::pool_allocator_adapter;
+
+// ============================================================================
+// Static compile-time checks for allocator_traits
+// ============================================================================
+
+static_assert(std::is_same_v<
+        std::allocator_traits<pool_allocator_adapter<int>>::value_type, int>,
+    "allocator_traits<pool_allocator_adapter<int>>::value_type must be int");
+
+static_assert(std::is_same_v<
+        std::allocator_traits<pool_allocator_adapter<int>>::pointer, int*>,
+    "allocator_traits<pool_allocator_adapter<int>>::pointer must be int*");
+
+static_assert(std::is_same_v<
+        std::allocator_traits<pool_allocator_adapter<int>>::size_type, std::size_t>,
+    "allocator_traits size_type mismatch");
+
+static_assert(std::allocator_traits<pool_allocator_adapter<int>>::is_always_equal::value,
+    "pool_allocator_adapter must advertise is_always_equal = true");
+
+static_assert(!std::allocator_traits<pool_allocator_adapter<int>>
+        ::propagate_on_container_copy_assignment::value,
+    "stateless adapter should not propagate on copy assignment");
+
+static_assert(!std::allocator_traits<pool_allocator_adapter<int>>
+        ::propagate_on_container_move_assignment::value,
+    "stateless adapter should not propagate on move assignment");
+
+static_assert(!std::allocator_traits<pool_allocator_adapter<int>>
+        ::propagate_on_container_swap::value,
+    "stateless adapter should not propagate on swap");
+
+static_assert(std::is_same_v<
+        std::allocator_traits<pool_allocator_adapter<int>>::rebind_alloc<double>,
+        pool_allocator_adapter<double>>,
+    "rebind<double>::other must be pool_allocator_adapter<double>");
+
+// std::allocator is nothrow default constructible; the adapter follows suit.
+static_assert(std::is_nothrow_default_constructible_v<pool_allocator_adapter<int>>,
+    "pool_allocator_adapter must be nothrow default constructible");
+
+static_assert(std::is_nothrow_copy_constructible_v<pool_allocator_adapter<int>>,
+    "pool_allocator_adapter must be nothrow copy constructible");
+
+// ============================================================================
+// Direct allocate/deallocate
+// ============================================================================
+
+TEST(PoolAllocatorAdapter, AllocateDeallocateSingleObject) {
+    pool_allocator_adapter<int> alloc;
+    int* p = alloc.allocate(1);
+    ASSERT_NE(p, nullptr);
+    *p = 42;
+    EXPECT_EQ(*p, 42);
+    alloc.deallocate(p, 1);
+}
+
+TEST(PoolAllocatorAdapter, AllocateZeroReturnsNullptr) {
+    pool_allocator_adapter<int> alloc;
+    EXPECT_EQ(alloc.allocate(0), nullptr);
+    // Deallocate of nullptr must be safe.
+    alloc.deallocate(nullptr, 0);
+}
+
+TEST(PoolAllocatorAdapter, AllocateArrayOfObjects) {
+    pool_allocator_adapter<int> alloc;
+    constexpr std::size_t n = 8;
+    int* p = alloc.allocate(n);
+    ASSERT_NE(p, nullptr);
+    for (std::size_t i = 0; i < n; ++i) {
+        p[i] = static_cast<int>(i);
+    }
+    for (std::size_t i = 0; i < n; ++i) {
+        EXPECT_EQ(p[i], static_cast<int>(i));
+    }
+    alloc.deallocate(p, n);
+}
+
+TEST(PoolAllocatorAdapter, MaxSizeIsSensible) {
+    pool_allocator_adapter<int> alloc;
+    EXPECT_GT(alloc.max_size(), std::size_t{0});
+    // Cannot exceed numeric_limits<size_t>::max() / sizeof(int).
+    EXPECT_LE(alloc.max_size(),
+              std::numeric_limits<std::size_t>::max() / sizeof(int));
+}
+
+TEST(PoolAllocatorAdapter, AllocateOverflowThrowsBadAlloc) {
+    pool_allocator_adapter<int> alloc;
+    const std::size_t too_many = alloc.max_size() + 1;
+    EXPECT_THROW(alloc.allocate(too_many), std::bad_alloc);
+}
+
+// ============================================================================
+// Equality and statelessness
+// ============================================================================
+
+TEST(PoolAllocatorAdapter, InstancesAreAlwaysEqual) {
+    pool_allocator_adapter<int> a;
+    pool_allocator_adapter<int> b;
+    EXPECT_TRUE(a == b);
+    EXPECT_FALSE(a != b);
+}
+
+TEST(PoolAllocatorAdapter, DifferentValueTypesCompareEqual) {
+    pool_allocator_adapter<int> a;
+    pool_allocator_adapter<double> b;
+    EXPECT_TRUE(a == b);
+    EXPECT_FALSE(a != b);
+}
+
+TEST(PoolAllocatorAdapter, CrossTypeConstructorCompiles) {
+    pool_allocator_adapter<int> a;
+    pool_allocator_adapter<double> b(a);
+    (void)b;
+    SUCCEED();
+}
+
+TEST(PoolAllocatorAdapter, RebindThroughTraitsProducesCorrectType) {
+    using traits_int = std::allocator_traits<pool_allocator_adapter<int>>;
+    using rebound = traits_int::rebind_alloc<std::string>;
+    static_assert(std::is_same_v<rebound, pool_allocator_adapter<std::string>>,
+                  "rebind_alloc<string> must produce the string specialisation");
+    rebound r;
+    std::string* s = r.allocate(1);
+    ASSERT_NE(s, nullptr);
+    std::allocator_traits<rebound>::construct(r, s, "hello");
+    EXPECT_EQ(*s, "hello");
+    std::allocator_traits<rebound>::destroy(r, s);
+    r.deallocate(s, 1);
+}
+
+// ============================================================================
+// STL container integration
+// ============================================================================
+
+TEST(PoolAllocatorAdapter, StdVectorBasicUsage) {
+    std::vector<int, pool_allocator_adapter<int>> v;
+    v.reserve(16);
+    for (int i = 0; i < 100; ++i) {
+        v.push_back(i);
+    }
+    ASSERT_EQ(v.size(), 100u);
+    EXPECT_EQ(v.front(), 0);
+    EXPECT_EQ(v.back(), 99);
+
+    long long sum = std::accumulate(v.begin(), v.end(), 0LL);
+    EXPECT_EQ(sum, 99LL * 100 / 2);
+}
+
+TEST(PoolAllocatorAdapter, StdVectorCopyAndMove) {
+    using vec = std::vector<int, pool_allocator_adapter<int>>;
+    vec a;
+    for (int i = 0; i < 10; ++i) {
+        a.push_back(i * 2);
+    }
+
+    vec b(a);            // copy
+    EXPECT_EQ(b.size(), a.size());
+    EXPECT_EQ(b.back(), 18);
+
+    vec c(std::move(a)); // move
+    EXPECT_EQ(c.size(), 10u);
+    EXPECT_EQ(c.back(), 18);
+}
+
+TEST(PoolAllocatorAdapter, StdListRequiresRebind) {
+    // std::list internally allocates node types, exercising rebind.
+    std::list<int, pool_allocator_adapter<int>> l;
+    for (int i = 0; i < 32; ++i) {
+        l.push_back(i);
+    }
+    EXPECT_EQ(l.size(), 32u);
+
+    int expected = 0;
+    for (int v : l) {
+        EXPECT_EQ(v, expected++);
+    }
+}
+
+TEST(PoolAllocatorAdapter, StdUnorderedMapWithStringKeys) {
+    using pair_t = std::pair<const std::string, int>;
+    std::unordered_map<std::string, int, std::hash<std::string>,
+                       std::equal_to<std::string>,
+                       pool_allocator_adapter<pair_t>> m;
+
+    m.emplace("alpha", 1);
+    m.emplace("beta", 2);
+    m.emplace("gamma", 3);
+
+    EXPECT_EQ(m.size(), 3u);
+    EXPECT_EQ(m.at("alpha"), 1);
+    EXPECT_EQ(m.at("beta"), 2);
+    EXPECT_EQ(m.at("gamma"), 3);
+}
+
+TEST(PoolAllocatorAdapter, ScopedAllocatorAdaptorSmoke) {
+    // Outer container uses pool_allocator_adapter; inner containers (strings)
+    // will also use it thanks to scoped_allocator_adaptor.
+    using inner_alloc = pool_allocator_adapter<char>;
+    using inner_string = std::basic_string<char, std::char_traits<char>, inner_alloc>;
+    using outer_alloc = std::scoped_allocator_adaptor<pool_allocator_adapter<inner_string>>;
+
+    std::vector<inner_string, outer_alloc> v;
+    v.emplace_back("short");
+    v.emplace_back("a somewhat longer string that may heap-allocate");
+    ASSERT_EQ(v.size(), 2u);
+    EXPECT_EQ(v[0], "short");
+    EXPECT_EQ(v[1].substr(0, 8), "a somewh");
+}
+
+// ============================================================================
+// Pool routing verification
+// ============================================================================
+
+TEST(PoolAllocatorAdapter, SmallAllocationRoutesThroughPool) {
+    // Small allocation (<= 64 bytes) should increment small pool counter
+    // when CONTAINER_USE_MEMORY_POOL is enabled.
+    pool_allocator::instance().reset_stats();
+
+    {
+        pool_allocator_adapter<int> alloc;
+        int* p = alloc.allocate(4);      // 16 bytes -> small pool
+        ASSERT_NE(p, nullptr);
+        alloc.deallocate(p, 4);
+    }
+
+    auto stats = pool_allocator::instance().get_stats();
+#if CONTAINER_USE_MEMORY_POOL
+    EXPECT_GE(stats.small_pool_allocs, 1u);
+    EXPECT_GE(stats.pool_hits, 1u);
+#endif
+    EXPECT_GE(stats.deallocations, 1u);
+}
+
+// ============================================================================
+// Counting adapter wrapping pool_allocator_adapter
+// ============================================================================
+
+namespace {
+
+// Test-only counting allocator that forwards to pool_allocator_adapter. Demonstrates
+// the adapter composes cleanly with other std-compliant allocators.
+template<typename T>
+struct counting_allocator {
+    using value_type = T;
+
+    std::atomic<std::size_t>* allocs;
+    std::atomic<std::size_t>* deallocs;
+
+    counting_allocator(std::atomic<std::size_t>* a,
+                       std::atomic<std::size_t>* d) noexcept
+        : allocs(a), deallocs(d) {}
+
+    template<typename U>
+    counting_allocator(const counting_allocator<U>& other) noexcept
+        : allocs(other.allocs), deallocs(other.deallocs) {}
+
+    T* allocate(std::size_t n) {
+        allocs->fetch_add(1, std::memory_order_relaxed);
+        pool_allocator_adapter<T> inner;
+        return inner.allocate(n);
+    }
+
+    void deallocate(T* p, std::size_t n) noexcept {
+        deallocs->fetch_add(1, std::memory_order_relaxed);
+        pool_allocator_adapter<T> inner;
+        inner.deallocate(p, n);
+    }
+
+    template<typename U>
+    bool operator==(const counting_allocator<U>& other) const noexcept {
+        return allocs == other.allocs && deallocs == other.deallocs;
+    }
+    template<typename U>
+    bool operator!=(const counting_allocator<U>& other) const noexcept {
+        return !(*this == other);
+    }
+};
+
+} // namespace
+
+TEST(PoolAllocatorAdapter, CountingAllocatorObservesContainerActivity) {
+    std::atomic<std::size_t> allocs{0};
+    std::atomic<std::size_t> deallocs{0};
+
+    {
+        std::vector<int, counting_allocator<int>> v{
+            counting_allocator<int>(&allocs, &deallocs)};
+        v.reserve(8);
+        v.push_back(1);
+        v.push_back(2);
+        v.push_back(3);
+    }
+
+    EXPECT_GE(allocs.load(), 1u);
+    EXPECT_GE(deallocs.load(), 1u);
+    EXPECT_EQ(allocs.load(), deallocs.load());
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## What

### Summary
Introduces `pool_allocator_adapter<T>` - a stateless, `std::allocator_traits`
compliant wrapper around the existing thread-local `pool_allocator` singleton.
Standard library containers (`std::vector`, `std::list`, `std::unordered_map`,
etc.) can now use the project's pool allocator transparently.

### Change Type
- [x] Feature (new functionality, additions only)
- [ ] Bugfix
- [ ] Refactor

### Affected Components
| Path | Role |
|------|------|
| `internal/pool_allocator_adapter.h` | New header: STL allocator adapter |
| `tests/allocator_adapter_tests.cpp` | New test suite (static_asserts + runtime) |
| `CMakeLists.txt` | Register the new header with the build |
| `tests/CMakeLists.txt` | Register the new test executable |

## Why

Issue #525: `pool_allocator` exposed only raw `allocate()` / `deallocate()` on
a singleton and was not usable as a drop-in `std::allocator`. Consumers had to
roll their own wrappers, contradicting the "batteries included" promise and
blocking straightforward benchmarking of pool vs default allocation with stock
STL containers.

### Related Issues
- Closes #525
- Relates to #526 / PR #529 (STL iterator interface - this continues the STL
  compatibility work on the same container surface area)

## Who

### Reviewers
- @kcenon - maintainer review

## When

### Urgency
- [x] Normal

### Target Release
Next container_system minor release (additive, no breaking change).

## Where

### Files Changed
| Directory | Files | Type |
|-----------|-------|------|
| `internal/` | 1 new header | Addition |
| `tests/` | 1 new test file | Addition |
| root / tests | `CMakeLists.txt` updates | 1-line each |

### API Surface Added
| Symbol | Kind | Header |
|--------|------|--------|
| `pool_allocator_adapter<T>` | class template | `internal/pool_allocator_adapter.h` |
| `pool_allocator_adapter<T>::value_type` | typedef | same |
| `pool_allocator_adapter<T>::pointer` / `const_pointer` | typedef | same |
| `pool_allocator_adapter<T>::size_type` / `difference_type` | typedef | same |
| `pool_allocator_adapter<T>::reference` / `const_reference` | typedef | same |
| `pool_allocator_adapter<T>::propagate_on_container_*` | `false_type` | same |
| `pool_allocator_adapter<T>::is_always_equal` | `true_type` | same |
| `pool_allocator_adapter<T>::rebind<U>::other` | nested template | same |
| `pool_allocator_adapter<T>()` | constructor | same |
| `pool_allocator_adapter<T>(const pool_allocator_adapter<U>&)` | cross-type ctor | same |
| `allocate(size_type) -> T*` | member function | same |
| `deallocate(T*, size_type) noexcept` | member function | same |
| `max_size() const noexcept` | member function | same |
| `operator==` / `operator!=` | free function template | same |

No existing API is modified or removed.

### STL Compatibility Matrix

| Standard requirement | Status |
|----------------------|--------|
| `Allocator` named requirements | satisfied |
| `std::allocator_traits<pool_allocator_adapter<T>>::value_type` | `T` |
| `std::allocator_traits<...>::pointer` | `T*` |
| `std::allocator_traits<...>::size_type` | `std::size_t` |
| `std::allocator_traits<...>::rebind_alloc<U>` | `pool_allocator_adapter<U>` |
| `std::allocator_traits<...>::is_always_equal` | `true_type` |
| `std::allocator_traits<...>::propagate_on_container_*` | all `false_type` |
| Stateless / interchangeable instances | yes |
| Usable with `std::scoped_allocator_adaptor` | yes |

## How

### Implementation Details
- Stateless template `pool_allocator_adapter<T>` with all required typedefs
  and a nested `rebind` template for node-based containers (`std::list`,
  hash map buckets, etc.).
- `allocate(n)` computes `n * sizeof(T)` and routes through
  `pool_allocator::instance().allocate(bytes)`. The singleton chooses the
  small (<=64B), medium (<=256B), or heap path - behaviour unchanged.
- Throws `std::bad_alloc` on `n > max_size()` and when the pool returns
  `nullptr`, matching `std::allocator` semantics.
- `deallocate(p, n)` forwards to `pool_allocator::instance().deallocate`.
- `operator==` always returns `true`; `is_always_equal = true_type` so
  propagation traits are all `false_type` (safe default for stateless
  allocators).

### Testing Done
- Compile-time: 9 `static_assert`s covering `allocator_traits` typedefs,
  propagation traits, `is_always_equal`, rebind, and nothrow construction.
- Runtime: direct allocate/deallocate, zero-size edge case, overflow
  (`bad_alloc`), equality, rebind via traits, `std::vector` copy/move,
  `std::list`, `std::unordered_map<string, int, ..., adapter>`,
  `std::scoped_allocator_adaptor`, pool-routing stats verification, and a
  counting allocator that composes over the adapter.

### Test Plan for Reviewers
1. Configure: `cmake -S . -B build -DBUILD_TESTS=ON`
2. Build: `cmake --build build`
3. Run: `ctest --test-dir build -R allocator_adapter_tests --output-on-failure`
4. Sanitizers (optional but recommended for allocator code):
   `cmake -B build-asan --preset asan && cmake --build build-asan && ctest --test-dir build-asan -R allocator_adapter_tests`

### Breaking Changes
None. Additions only.

### Rollback Plan
Revert the PR. No on-disk format, ABI, or existing header is touched.

## Checklist

- [x] Additions only; no existing API modified
- [x] English only; no AI attribution; no emoji
- [x] Conventional Commit message (`feat(container): ...`)
- [x] Tests added covering static traits + container integration
- [x] Linked to #525 with closing keyword