### PR TITLE
refactor(container): deprecate legacy include/container/ forwarding headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- Legacy forwarding header `include/container/optimizations/fast_parser.h` is deprecated; downstream consumers should include `<kcenon/container/optimizations/fast_parser.h>` instead. The legacy header now emits a build-time `#pragma message` warning. Scheduled for removal in the next minor release after v1.1.0. ([#534](https://github.com/kcenon/container_system/issues/534))
+
 ## [1.0.0] - 2026-04-16
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -86,6 +86,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Align `docs/API_REFERENCE.kr.md` header version to `0.1.0` matching `vcpkg.json` and `CMakeLists.txt`
 
 ### Deprecated
+- **Legacy `include/container/` Forwarding Headers** (#534): Mark legacy forwarding headers as deprecated and document the removal target
+  - Deprecate `include/container/optimizations/fast_parser.h` — include `<kcenon/container/optimizations/fast_parser.h>` instead
+  - Mechanism: pure `#include` forwarder, so `[[deprecated]]` attribute cannot attach; uses `#pragma message` (portable across GCC, Clang, MSVC) to emit a build-time warning when consumers include the legacy path
+  - **Removal target**: scheduled for removal in the next minor release after v1.1.0
+  - In-repo legacy use migrated: `tests/fast_parser_integration_tests.cpp` now includes the canonical `<kcenon/container/...>` path
+  - Part of #531 (EPIC: directory layout normalization)
+
 - **Legacy void/bool API Methods** (#241): Mark legacy methods as deprecated in favor of Result-returning APIs
   - Deprecate `serialize()` in favor of `serialize_result()`
   - Deprecate `serialize_array()` in favor of `serialize_array_result()`

--- a/include/container/optimizations/fast_parser.h
+++ b/include/container/optimizations/fast_parser.h
@@ -1,8 +1,19 @@
 /**
  * @file fast_parser.h
  * @brief Forwarding header to canonical fast_parser location.
+ *
+ * @deprecated Since v1.1.0. Use `<kcenon/container/optimizations/fast_parser.h>` instead.
+ *             This forwarding header is scheduled for removal in the next minor release
+ *             after v1.1.0. See CHANGELOG.md > Deprecations.
  */
 
 #pragma once
+
+// Deprecation notice: this header is a pure `#include` forwarder, so the C++
+// `[[deprecated]]` attribute cannot attach to it. We use `#pragma message`
+// (portable across GCC, Clang, and MSVC) to emit a build-time warning when
+// downstream consumers include the legacy path.
+#pragma message("warning: <container/optimizations/fast_parser.h> is deprecated; include <kcenon/container/optimizations/fast_parser.h> instead. Scheduled for removal in the next minor release after v1.1.0.")
+
 // Forwarding header — canonical location: include/kcenon/container/optimizations/fast_parser.h
 #include <kcenon/container/optimizations/fast_parser.h>

--- a/tests/fast_parser_integration_tests.cpp
+++ b/tests/fast_parser_integration_tests.cpp
@@ -18,7 +18,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <include/container/optimizations/fast_parser.h>
+#include <kcenon/container/optimizations/fast_parser.h>
 #include <vector>
 #include <string>
 #include <list>


### PR DESCRIPTION
## What

### Summary
Mark every legacy forwarding header in `include/container/` as deprecated and document the removal target in both `CHANGELOG.md` (downstream-tooling SSOT) and `docs/CHANGELOG.md` (registry SSOT). Migrate the only in-repo translation unit that still used the legacy path so the in-repo build itself stays warning-free.

### Change Type
- [x] Refactor (no functional changes)
- [x] Documentation (CHANGELOG entries)

### Affected Components
- `include/container/optimizations/fast_parser.h` — the only file currently under the legacy `include/container/` tree
- `tests/fast_parser_integration_tests.cpp` — in-repo legacy include migrated to canonical path
- `CHANGELOG.md` — new "Deprecated" entry under [Unreleased]
- `docs/CHANGELOG.md` — mirrored "Deprecated" entry under [Unreleased]

## Why

### Problem Solved
The legacy `include/container/` path predates the canonical `include/kcenon/container/` layout. Today the same headers can be reached via two roots, and downstream consumers keep depending on the legacy path because nothing has signalled that it is going away. After this PR:

- Downstream code that still uses `<container/...>` gets a portable build-time warning to migrate.
- `CHANGELOG.md` records the deprecation and the planned hard-removal release.
- The path is cleared for the actual physical removal at the planned future minor release (out of scope for this PR — deprecation only).

### Related Issues
- Closes #534
- Part of #531 (EPIC: directory layout normalization)

## Where

| File | Change |
|------|--------|
| `include/container/optimizations/fast_parser.h` | Add `#pragma message("warning: …")` deprecation notice + Doxygen `@deprecated` block |
| `tests/fast_parser_integration_tests.cpp` | Migrate `<include/container/...>` → `<kcenon/container/...>` |
| `CHANGELOG.md` | Add `### Deprecated` section under `[Unreleased]` |
| `docs/CHANGELOG.md` | Mirror the `### Deprecated` entry under `[Unreleased]` |

## How

### Per-header deprecation mechanism

The single forwarding header that currently exists in `include/container/` is a **pure `#include` forwarder** (no own type aliases / using-decls / function declarations). The C++ `[[deprecated]]` attribute cannot attach to an `#include` directive, so attribute-based deprecation is not applicable here. The portable alternative is `#pragma message("warning: ...")`, which works on GCC, Clang, and MSVC. (`#warning` is intentionally avoided because not all toolchains in CI accept it consistently — MSVC requires `#pragma message`.)

Mechanism per header:

| Header | Mechanism | Reason |
|--------|-----------|--------|
| `include/container/optimizations/fast_parser.h` | `#pragma message("warning: …")` | Pure `#include` forwarder; attribute cannot attach |

If future sub-issues introduce additional forwarders that re-export type aliases or function declarations, those should prefer `[[deprecated("...")]]` on the declaration; only fall back to `#pragma message` when the construct cannot carry an attribute.

### Removal target version

Project version is currently `1.0.0` (released 2026-04-16, see `CHANGELOG.md` `## [1.0.0]`, `vcpkg.json` `version-semver: "1.0.0"`, and `CMakeLists.txt` `VERSION 1.0.0`). The next minor release is therefore `v1.1.0`. Per the issue brief, the removal target is documented as **"the next minor release after v1.1.0"** so the deprecation gets at least one full minor release for downstream consumers to migrate before the legacy path is removed.

This wording is recorded in three places:
- `include/container/optimizations/fast_parser.h` Doxygen block + `#pragma message` text
- Root `CHANGELOG.md` `[Unreleased] > Deprecated` bullet
- `docs/CHANGELOG.md` `[Unreleased] > Deprecated` bullet

### In-repo legacy use migration

`grep` swept the entire repo for `#include <container/...>` / `#include "container/..."` patterns that are not the canonical `<kcenon/container/...>` path. The only hit was `tests/fast_parser_integration_tests.cpp:21`, which is migrated in this PR to `<kcenon/container/optimizations/fast_parser.h>`. After this PR the in-repo build will not emit the new deprecation warning, and the warning is reserved for external consumers.

### Testing Done
- Local toolchain unavailable in this sandbox (no `cmake` / `g++`); relying on CI for build/test verification, same approach used by #537 and #538.
- Diff is intentionally minimal: only the four files listed above.

### Breaking Changes
None. This is a deprecation-only PR — the legacy header still functions and forwards to the canonical location. Downstream consumers will simply see a new build-time warning until they migrate.

### Rollback Plan
Revert this single squash commit. The forwarder reverts to its pre-PR pure `#include` form; the test reverts to the legacy include; the CHANGELOG entries are removed.

## Out of Scope (sibling sub-issues of EPIC #531)

- Decomposing `CMakeLists.txt` into `cmake/` modules — issue #535
- Doxyfile / install rule rewrite — issue #536
- **Physical removal** of the `include/container/` directory — happens at the planned future minor release, not in this PR
- Updating `grpc/README.md` code samples that reference the legacy path — those are docs about deprecated usage and are appropriate to leave until #536 cleans them up if it touches docs

## Checklist

- [x] Every header under `include/container/` carries a deprecation marker (`#pragma message` for the only existing pure `#include` forwarder)
- [x] `CHANGELOG.md` lists deprecated header + replacement + removal target version
- [x] `docs/CHANGELOG.md` mirrors the same entry (per the SSOT mirroring note in `CHANGELOG.md`)
- [x] No in-repo translation unit uses the legacy paths anymore
- [x] Self-review completed
- [x] Conventional Commits format
- [x] No Claude/AI/Anthropic attribution
- [x] No emojis
- [x] Issue linked with `Closes #534` and `Part of #531`
