### PR TITLE
refactor(build): finalize Doxygen input paths and install rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Repoint Doxygen `INPUT`/`INCLUDE_PATH` and `cmake/documentation.cmake` `DOXYGEN_INPUT` to the canonical `include/kcenon/container/` + `src/` layout. Stale legacy references to `core/`, `internal/`, `integration/`, `values/` were removed; root-level `mainpage.dox` was repointed to the actual `docs/mainpage.dox` and the remaining tutorial/FAQ `.dox` pages were added explicitly. ([#536](https://github.com/kcenon/container_system/issues/536))
+- Tidy `cmake/install.cmake` documentation block to reflect the post-migration install layout (`include/kcenon/container/` canonical + `include/container/` deprecated). The deprecated forwarding tree's removal milestone (v1.2.0) is now recorded as a TODO marker next to its install rule. ([#536](https://github.com/kcenon/container_system/issues/536))
+
 ### Deprecated
 
 - Legacy forwarding header `include/container/optimizations/fast_parser.h` is deprecated; downstream consumers should include `<kcenon/container/optimizations/fast_parser.h>` instead. The legacy header now emits a build-time `#pragma message` warning. Scheduled for removal in the next minor release after v1.1.0. ([#534](https://github.com/kcenon/container_system/issues/534))

--- a/Doxyfile
+++ b/Doxyfile
@@ -93,9 +93,10 @@ WARN_AS_ERROR          = NO
 WARN_IF_INCOMPLETE_DOC = YES
 WARN_FORMAT            = "$file:$line: $text"
 WARN_LOGFILE           =
-# Legacy ./core, ./internal, ./integration paths were removed in the source migration
-# (issue #533). Public headers now live under include/kcenon/container/ and sources
-# under src/. Issue #536 will revisit the full Doxyfile layout.
+# Public headers live under include/kcenon/container/, implementations under src/.
+# Examples and utility helpers are documented for reference. Free-form prose
+# pages are loaded individually as ./docs/*.dox to avoid pulling in unrelated
+# Markdown from the docs/ tree.
 INPUT                  = ./include/kcenon/container \
                          ./src \
                          ./examples \
@@ -284,10 +285,9 @@ MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = NO
 SEARCH_INCLUDES        = YES
 INCLUDE_PATH           = . \
-                         core \
-                         values \
-                         internal \
-                         integration
+                         include \
+                         include/kcenon/container \
+                         src
 INCLUDE_FILE_PATTERNS  = *.h \
                          *.hpp
 PREDEFINED             = HAS_MESSAGING_FEATURES \

--- a/cmake/documentation.cmake
+++ b/cmake/documentation.cmake
@@ -4,9 +4,9 @@
 # convenience `docs` alias. Invocation is gated on Doxygen being installed
 # locally; absence is non-fatal.
 #
-# NOTE: The full Doxyfile/install layout review for documentation belongs to
-# issue #536. This module only relocates the existing logic from the
-# top-level CMakeLists.txt — it does not change any Doxygen settings.
+# Input list mirrors the canonical layout used by the standalone Doxyfile:
+# public headers live under include/kcenon/container/ and implementations
+# under src/. Free-form documentation pages live under docs/*.dox.
 
 # Find Doxygen for documentation generation
 find_package(Doxygen)
@@ -25,17 +25,22 @@ if(DOXYGEN_FOUND)
     set(DOXYGEN_CLASS_GRAPH YES)
     set(DOXYGEN_COLLABORATION_GRAPH YES)
 
-    # Input files and directories
-    # Note: legacy core/, internal/, integration/ paths were removed in the source
-    # migration (issue #533). Public headers now live under include/kcenon/container/
-    # and sources under src/. Issue #536 will revisit the full Doxyfile layout.
+    # Input files and directories.
+    # Restrict to the canonical source roots so generated docs do not pick up
+    # build artifacts or unrelated repo metadata. The standalone Doxyfile uses
+    # the same set of inputs.
     set(DOXYGEN_INPUT
-        ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/container
         ${CMAKE_CURRENT_SOURCE_DIR}/src
         ${CMAKE_CURRENT_SOURCE_DIR}/examples
+        ${CMAKE_CURRENT_SOURCE_DIR}/utilities
         ${CMAKE_CURRENT_SOURCE_DIR}/README.md
-        ${CMAKE_CURRENT_SOURCE_DIR}/mainpage.dox
+        ${CMAKE_CURRENT_SOURCE_DIR}/docs/mainpage.dox
+        ${CMAKE_CURRENT_SOURCE_DIR}/docs/tutorial_containers.dox
+        ${CMAKE_CURRENT_SOURCE_DIR}/docs/tutorial_serialization.dox
+        ${CMAKE_CURRENT_SOURCE_DIR}/docs/tutorial_integration.dox
+        ${CMAKE_CURRENT_SOURCE_DIR}/docs/faq.dox
+        ${CMAKE_CURRENT_SOURCE_DIR}/docs/troubleshooting.dox
     )
 
     # Exclude patterns

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -1,10 +1,7 @@
 # install.cmake - install rules, export set, package config generation
 #
 # Installs the container_system library, public headers, forwarding headers,
-# and CMake package configuration files. The behaviour mirrors the legacy
-# top-level CMakeLists.txt exactly — no destinations, components, or pattern
-# filters were changed by this refactor (issue #535). Issue #536 will revisit
-# the install layout.
+# and CMake package configuration files.
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
@@ -19,12 +16,8 @@ set(CONTAINER_SYSTEM_CMAKE_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/container_
 #     #include <container.h>                    (legacy, via forwarding headers)
 #
 # The following directories are installed:
-#   - include/kcenon/container/  (canonical public headers)
-#   - include/container/         (forwarding headers for #include <container/...> paths)
-#   - core/      (forwarding headers for backward compatibility)
-#   - internal/  (internal implementation details)
-#   - integration/ (integration adapters)
-#   - messaging/ (domain-specific messaging container)
+#   - include/kcenon/container/  (canonical public headers, kcenon ecosystem convention)
+#   - include/container/         (deprecated forwarding headers; see DEPRECATION note below)
 # =============================================================================
 install(FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/container.h
@@ -40,7 +33,7 @@ install(TARGETS container_system
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
-# Canonical public headers (kcenon ecosystem convention)
+# Canonical public headers (kcenon ecosystem convention).
 install(DIRECTORY
     ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
@@ -50,7 +43,10 @@ install(DIRECTORY
     PATTERN "*.hpp"
 )
 
-# Forwarding headers under include/container/ (for #include <container/...> paths)
+# Deprecated forwarding headers under include/container/ (for #include <container/...>
+# paths). Carries a #pragma message deprecation notice (issue #534, PR #539). This
+# install rule will be dropped together with the directory itself in v1.2.0.
+# TODO(v1.2.0): remove the include/container/ install rule and the directory.
 install(DIRECTORY
     ${CMAKE_CURRENT_SOURCE_DIR}/include/container
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
@@ -59,12 +55,6 @@ install(DIRECTORY
     PATTERN "*.h"
     PATTERN "*.hpp"
 )
-
-# Backward-compatible forwarding headers were previously installed from root-level
-# core/, internal/, integration/, messaging/ directories. Those directories were
-# removed in the source migration (issue #533); the corresponding install rule was
-# dropped because the directories no longer exist. Issue #536 will revisit the full
-# install layout.
 
 install(EXPORT container_system-targets
     FILE container_system-targets.cmake

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -66,6 +66,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - All tests now pass with `CONTAINER_NO_LEGACY_API` defined
   - Updated tests that relied on deprecated duplicate-key behavior
 
+- **Doxygen Input Paths and Install Rules Cleanup** (#536): Align Doxygen and `install(DIRECTORY ...)` rules with the canonical post-migration layout
+  - Doxyfile `INPUT` retains the canonical roots (`include/kcenon/container/`, `src/`, `examples/`, `utilities/`) and explicit `docs/*.dox` pages; stale layout-disclaimer comment removed
+  - Doxyfile `INCLUDE_PATH` repointed from removed legacy roots (`core/`, `values/`, `internal/`, `integration/`) to `include/`, `include/kcenon/container/`, and `src/`
+  - `cmake/documentation.cmake` `DOXYGEN_INPUT` repointed: removed source-root catch-all, removed non-existent root `mainpage.dox` reference, added explicit `docs/*.dox` pages, added `utilities/`
+  - `cmake/install.cmake` documentation block tightened to reflect actual install layout (canonical `include/kcenon/container/` + deprecated `include/container/`)
+  - Recorded `v1.2.0` removal milestone for the deprecated `include/container/` install rule alongside the directory itself
+  - Final sub-issue of EPIC #531 (directory layout normalization)
+
 ### Added
 - **Legacy API Deprecation Timeline** (#284): Document clear deprecation timeline in `legacy_api.h`
   - **v2.x**: Deprecated methods available by default with warnings


### PR DESCRIPTION
## What

### Summary
Final sub-issue of EPIC #531. Repoint Doxygen `INPUT`/`INCLUDE_PATH` and `cmake/documentation.cmake` `DOXYGEN_INPUT` to the canonical post-migration layout, and tighten `cmake/install.cmake` to reflect the actual install rules now in effect.

### Change Type
- [ ] Feature
- [ ] Bugfix
- [x] Refactor (no functional changes)
- [ ] Documentation
- [ ] Test
- [ ] Chore

### Affected Components
- `Doxyfile` -- `INPUT`, `INCLUDE_PATH`
- `cmake/documentation.cmake` -- `DOXYGEN_INPUT`
- `cmake/install.cmake` -- documentation block, deprecation marker
- `CHANGELOG.md`, `docs/CHANGELOG.md` -- release notes

## Why

### Problem Solved
After the four prior sub-issues (#532 -- #535) consolidated headers under `include/kcenon/container/`, moved `.cpp` files into `src/<subdir>/`, deprecated the legacy `include/container/` forwarders, and decomposed the top-level CMakeLists.txt into 11 cmake/ modules, three artifacts still carried drift-fix-only state from issue #533 / #535:

1. `Doxyfile INCLUDE_PATH` still referenced removed roots (`core/`, `values/`, `internal/`, `integration/`).
2. `cmake/documentation.cmake DOXYGEN_INPUT` listed `${CMAKE_CURRENT_SOURCE_DIR}` as a catch-all (pulling in build artifacts and unrelated metadata) and pointed at a non-existent root `mainpage.dox`.
3. `cmake/install.cmake` documentation block still enumerated removed root-level forwarding directories, and the deprecated `include/container/` install rule had no recorded removal milestone.

### Related Issues
- Closes #536
- Part of #531 (final sub-issue)

## Who

### Reviewers
- @kcenon

## When

### Urgency
- [x] Normal -- follow standard review process

### Target Release
The cleanup itself is part of `[Unreleased]`. The TODO marker on the deprecated `include/container/` install rule names `v1.2.0` as the removal milestone, matching the deprecation cycle started in #534/PR #539.

## Where

### Files Changed
| File | Change |
|------|--------|
| `Doxyfile` | Repoint `INCLUDE_PATH`; drop temporary layout-disclaimer comment above `INPUT` |
| `cmake/documentation.cmake` | Repoint `DOXYGEN_INPUT`; align comment with the standalone Doxyfile |
| `cmake/install.cmake` | Tidy documentation block; add `v1.2.0` TODO marker; drop dropped-rule breadcrumb |
| `CHANGELOG.md` | Record under `Unreleased > Changed` |
| `docs/CHANGELOG.md` | Mirror under `Unreleased > Changed` |

### API/Database Changes
None. Public C++ API unchanged. CMake export set, package config, target name, namespace, and install destinations are unchanged. The set of installed headers is identical to the pre-refactor state (canonical `include/kcenon/container/` + deprecated `include/container/`).

## How

### Implementation Highlights

**Doxyfile**

`INPUT` was already canonical (set in #538). Only the temporary disclaimer comment was rewritten to describe current state instead of pointing at #533/#536.

`INCLUDE_PATH` previously listed `core values internal integration` -- those root directories were removed in #533/PR #538. Replaced with `include`, `include/kcenon/container`, and `src` so Doxygen's preprocessor can resolve `#include` directives in the new layout.

**cmake/documentation.cmake**

`DOXYGEN_INPUT` previously had two issues:
- `${CMAKE_CURRENT_SOURCE_DIR}` (source root catch-all) -- pulls in `.git/`, `cmake/`, top-level scripts, and the like; doxygen has to filter them via `EXCLUDE` patterns rather than not loading them in the first place.
- `${CMAKE_CURRENT_SOURCE_DIR}/mainpage.dox` -- the file lives at `docs/mainpage.dox`, not at the source root. The path resolved to a non-existent file and would have produced a Doxygen warning had the target been exercised.

Repointed to the same set of inputs as the standalone `Doxyfile`: `include/kcenon/container/`, `src/`, `examples/`, `utilities/`, `README.md`, and the explicit `docs/*.dox` pages.

**cmake/install.cmake**

The install rules themselves are unchanged. Only the comments were rewritten:
- The opening "behaviour mirrors the legacy top-level CMakeLists.txt exactly" disclaimer (true for #535 but no longer relevant) was dropped.
- The "directories installed" comment block listed legacy roots (`core/`, `internal/`, `integration/`, `messaging/`) that haven't been installed since #533. Tightened to the two directories actually being installed.
- The `Forwarding headers under include/container/` comment now records the deprecation cycle (#534, PR #539) and the v1.2.0 removal milestone via a `TODO(v1.2.0)` marker.
- The breadcrumb explaining the dropped root-level core/internal/integration/messaging install rule was removed -- two PRs have shipped since the rule was removed and the file's git history carries the same information.

### Verification

- All 10 `Doxyfile INPUT` paths and all 4 `INCLUDE_PATH` entries exist on disk (verified with `[ -e <path> ]`).
- All 13 `${CMAKE_CURRENT_SOURCE_DIR}/...` paths in `DOXYGEN_INPUT` exist on disk (build/, build_test/, vcpkg/, vcpkg_installed/ are EXCLUDE entries and are expected to be absent until configure/build).
- All install-time paths in `cmake/install.cmake` exist (`container.h`, `include/kcenon`, `include/container`, `cmake/container_system-config.cmake.in`).

Local cmake/g++/doxygen toolchains are unavailable in this sandbox; relying on CI for the cmake configure pass, the multi-platform build, ctest, and the Documentation Audit step (per `ci-resilience.md`).

### Testing Done

- [x] Path-existence sanity check for every `INPUT` and `INCLUDE_PATH` entry
- [x] Path-existence sanity check for every `DOXYGEN_INPUT` and `install(...)` source entry
- [ ] Local Doxygen run -- skipped (`doxygen` not installed in sandbox; CI covers this)
- [ ] Local CMake configure + build + ctest -- skipped (`cmake` not installed in sandbox; CI covers this)
- [ ] Local `cmake --install build/ --prefix /tmp/inst` -- skipped (same reason; install rules unchanged in substance)

### Breaking Changes
None.

### Rollback Plan
Plain revert of this PR. The five EPIC #531 sub-issue PRs land in order #537 -> #538 -> #539 -> #540 -> this one, so reverting in reverse order is safe.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Path-existence verification performed (no `cmake`/`doxygen` available locally)
- [x] CHANGELOG.md and docs/CHANGELOG.md updated
- [x] No sensitive data exposed
- [x] Commit follows Conventional Commits
- [x] Issue linked with closing keyword (`Closes #536`) and EPIC reference (`Part of #531`)
