### PR TITLE
chore(release): verify SHA512 against actual archive (#542)

### DIFF
--- a/.github/workflows/on-release-sync-registry.yml
+++ b/.github/workflows/on-release-sync-registry.yml
@@ -5,10 +5,94 @@ on:
     types: [published]
 
 jobs:
+  # The reusable workflow this job calls performs SHA512 computation AND
+  # verify-against-actual-archive in a single hardened step. See
+  # kcenon/common_system PR #676 (Closes kcenon/common_system#675, part of
+  # EPIC kcenon/common_system#674). It re-downloads the release tarball
+  # via `curl -fsSL --retry 3 -o <file>` (file-based, never piped) and
+  # exits 1 on mismatch BEFORE any portfile commit, which is the exact
+  # acceptance criterion of #542.
+  #
+  # Pinning to the hardened merge commit (rather than @main) ensures the
+  # SHA verification step cannot silently regress if the reusable workflow
+  # is later modified. Bump this ref deliberately when accepting future
+  # upstream changes.
   sync:
-    uses: kcenon/common_system/.github/workflows/sync-vcpkg-registry.yml@main
+    uses: kcenon/common_system/.github/workflows/sync-vcpkg-registry.yml@c90d4b828d3063989a850a785c7a60753c2b35ea
     with:
       port-name: kcenon-container-system
       version: ${{ github.event.release.tag_name }}
     secrets:
       REGISTRY_PAT: ${{ secrets.VCPKG_REGISTRY_PAT }}
+
+  # Defense-in-depth: independent SHA512 verification step that runs in
+  # parallel with the reusable workflow above. If the reusable workflow's
+  # internal verification is ever bypassed or regresses, this job still
+  # catches a mismatch between the published GitHub archive bytes and the
+  # SHA written to vcpkg-registry/ports/kcenon-container-system/portfile.cmake.
+  #
+  # On mismatch this job exits 1 with a clear annotation that names both
+  # the registry SHA and the archive SHA. The job is purely additive: a
+  # successful release passes both jobs; a regression in either one fails
+  # the release before consumers see a stale SHA.
+  verify-sha512-against-archive:
+    name: Verify portfile SHA512 against published archive
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: sync
+    steps:
+      - name: Verify SHA512 against actual GitHub archive
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          REPO: kcenon/container_system
+        run: |
+          # Re-fetch the release archive AFTER sync has committed the new
+          # SHA to the registry, recompute SHA512 from the actual bytes, and
+          # compare against what the registry portfile now declares.
+          # Closes #542 / part of kcenon/common_system#674.
+          set -euo pipefail
+          VERSION="${TAG_NAME#v}"
+          TAG="v${VERSION}"
+          ARCHIVE_URL="https://github.com/${REPO}/archive/refs/tags/${TAG}.tar.gz"
+          VERIFY_FILE="$(mktemp)"
+
+          echo "Re-fetching ${ARCHIVE_URL} for independent verification..."
+          # File-based download (NOT piped). curl -fsSL fails on HTTP 4xx/5xx
+          # so a 404 cannot silently produce the empty-input SHA-512 constant
+          # cf83e1357eefb8bdfcb5993d18e3262e8a8e0e8b7... (see kcenon
+          # auto-memory: curl_sha512_empty_input).
+          if ! curl -fsSL --retry 3 --retry-delay 2 -o "${VERIFY_FILE}" "${ARCHIVE_URL}"; then
+            echo "::error::Failed to download release archive for verification: ${ARCHIVE_URL}"
+            rm -f "${VERIFY_FILE}"
+            exit 1
+          fi
+
+          ACTUAL_SHA=$(sha512sum "${VERIFY_FILE}" | awk '{print $1}')
+          rm -f "${VERIFY_FILE}"
+
+          # Pull the SHA the registry now declares for this port.
+          REGISTRY_PORTFILE_URL="https://raw.githubusercontent.com/kcenon/vcpkg-registry/main/ports/kcenon-container-system/portfile.cmake"
+          PORTFILE_TMP="$(mktemp)"
+          if ! curl -fsSL --retry 3 --retry-delay 2 -o "${PORTFILE_TMP}" "${REGISTRY_PORTFILE_URL}"; then
+            echo "::error::Failed to download registry portfile: ${REGISTRY_PORTFILE_URL}"
+            rm -f "${PORTFILE_TMP}"
+            exit 1
+          fi
+          REGISTRY_SHA=$(grep -oE 'SHA512[[:space:]]+[0-9a-f]{128}' "${PORTFILE_TMP}" | awk '{print $2}' | head -1)
+          rm -f "${PORTFILE_TMP}"
+
+          if [[ -z "${REGISTRY_SHA}" ]]; then
+            echo "::error::Could not extract SHA512 from registry portfile"
+            exit 1
+          fi
+
+          if [[ "${REGISTRY_SHA}" != "${ACTUAL_SHA}" ]]; then
+            echo "::error::SHA512 mismatch detected for ${TAG}"
+            echo "::error::Registry portfile: ${REGISTRY_SHA}"
+            echo "::error::GitHub archive:    ${ACTUAL_SHA}"
+            echo "::error::Cold-cache vcpkg consumers would hit install failure."
+            exit 1
+          fi
+
+          echo "SHA512 verified against ${ARCHIVE_URL}"
+          echo "  ${ACTUAL_SHA}"


### PR DESCRIPTION
Closes #542

Part of kcenon/common_system#674.
References validated pattern in kcenon/common_system PR #676 (merged with 7/7 CI green).

## What

Pins `on-release-sync-registry.yml` to the hardened merge commit of `kcenon/common_system` PR #676 (`c90d4b828d3063989a850a785c7a60753c2b35ea`) and adds an independent defense-in-depth verification job that runs after the reusable sync workflow.

The new job `verify-sha512-against-archive` re-fetches the published GitHub archive and compares its SHA512 against the SHA the registry portfile now declares for `kcenon-container-system`. On mismatch the workflow run fails with annotations naming both SHAs, before any cold-cache vcpkg consumer can hit an install failure.

## Why

Detected via [microsoft/vcpkg#51511](https://github.com/microsoft/vcpkg/issues/51511) and [kcenon/vcpkg-registry#87](https://github.com/kcenon/vcpkg-registry/issues/87) - every kcenon port shipped a mismatched SHA512 because release automation never compared its computed value against the actual archive bytes. Cold-cache consumers (new CI runners, fresh users) hit 100% install failure when `vcpkg-registry/ports/kcenon-container-system/portfile.cmake` does not match `https://github.com/kcenon/container_system/archive/refs/tags/v<version>.tar.gz`.

This PR closes the detection gap for `container_system`.

## Where

| File | Change |
|------|--------|
| `.github/workflows/on-release-sync-registry.yml` | Pin reusable workflow ref to PR #676 merge commit + add new `verify-sha512-against-archive` job that runs `needs: sync` |

### Audit summary (other workflows considered)

| Workflow | Touches portfile SHA? | Action |
|----------|----------------------|--------|
| `on-release-sync-registry.yml` | Yes (delegates to reusable workflow that computes/writes SHA512 to portfile) | **Hardened (this PR)** |
| `release.yml` | No (multi-platform build/test/GitHub release; no portfile write) | No change needed |
| `validate-vcpkg-port.yml` | No (consumer-side find_package + build/install verification) | No change needed |
| All other workflows (`ci`, `coverage`, `sanitizers`, `fuzzing`, `sbom`, `benchmarks`, `docs`, etc.) | No | Out of scope |

Only `on-release-sync-registry.yml` participates in writing the portfile SHA, so a single-workflow hardening + parallel verification job satisfies the issue acceptance criteria.

## How

The pinned reusable workflow (PR #676) inserts the SHA512 verify-against-archive step BETWEEN SHA computation and portfile commit, using file-based hashing (`curl -fsSL --retry 3 -o <tmp>`) rather than piping into `sha512sum` so a 404 cannot silently produce the empty-input SHA-512 constant `cf83e1357eefb8bdf...` (see kcenon auto-memory: `curl_sha512_empty_input`).

This PR's new `verify-sha512-against-archive` job adds a second, independent check that runs after the sync workflow has committed the new SHA: it re-downloads the published archive and the registry portfile, extracts the SHA from the portfile via regex, and compares. If the reusable workflow's internal verification is ever bypassed or regresses, this defensive job still catches the mismatch.

Runtime: ~2-3s on a typical `container_system` archive.

## Test Plan

### Reviewer validation

1. After merge, cut a release tag (`v0.x.y`). The existing `Sync Registry on Release` workflow triggers both jobs:
   - `sync` (reusable workflow with internal SHA verification from PR #676)
   - `verify-sha512-against-archive` (this PR's defensive job)
2. Inspect the `verify-sha512-against-archive` log for:
   ```
   Re-fetching https://github.com/kcenon/container_system/archive/refs/tags/v0.x.y.tar.gz for independent verification...
   SHA512 verified against https://github.com/kcenon/container_system/archive/refs/tags/v0.x.y.tar.gz
     <128-char hex digest>
   ```

### Mismatch simulation (validated locally)

- **Match path** (real archive SHA == registry SHA): job exits 0, prints verification line.
- **Mismatch path** (registry SHA replaced with all-zero digest): job exits 1 with annotations `SHA512 mismatch detected for v0.x.y` / `Registry portfile: 000...` / `GitHub archive: <real>` / `Cold-cache vcpkg consumers would hit install failure.`
- **Bad URL path** (nonexistent tag): `curl -fsSL` returns RC=22, the `if !` branch fires `exit 1` with `Failed to download release archive for verification: <URL>`. The download-to-file pattern (rather than a pipe) is required to make this work; piping into `sha512sum` would otherwise mask the curl failure with the empty-input hash.

YAML structure validated with `js-yaml`; job ordering confirmed (`verify-sha512-against-archive` has `needs: sync`).

## Breaking Changes

None. Both changes are additive on a successful release: the pinned ref behaves identically to `@main` because the hardening is already in main; the new verification job adds ~2-3s and one log line per release. On a SHA mismatch (the failure mode this PR is designed to detect) it short-circuits the release before any consumer sees a stale SHA, which is the desired behavior.