### PR TITLE
fix(serialization): implement in-place binary deserialization for value_store payload

### DIFF
--- a/include/kcenon/container/value_store.h
+++ b/include/kcenon/container/value_store.h
@@ -148,6 +148,17 @@ public:
      */
     static std::unique_ptr<value_store> deserialize_binary(const std::vector<uint8_t>& binary_data);
 
+    /**
+     * @brief Deserialize binary format into an existing value_store
+     * @param store Target value_store populated in place on success
+     * @param binary_data Binary data
+     * @throws std::runtime_error if deserialization fails
+     * @note Required because value_store is non-copyable/non-movable; on a
+     *       malformed/truncated input the target store is left unmodified.
+     */
+    static void deserialize_binary_into(value_store& store,
+                                        const std::vector<uint8_t>& binary_data);
+
 #if CONTAINER_HAS_COMMON_RESULT
     // =========================================================================
     // Result-based Deserialization (no-throw alternatives)

--- a/src/core/value_store.cpp
+++ b/src/core/value_store.cpp
@@ -148,7 +148,12 @@ std::unique_ptr<value_store> value_store::deserialize(std::string_view /*json_da
 
 std::unique_ptr<value_store> value_store::deserialize_binary(const std::vector<uint8_t>& binary_data) {
     auto store = std::make_unique<value_store>();
+    deserialize_binary_into(*store, binary_data);
+    return store;
+}
 
+void value_store::deserialize_binary_into(value_store& store,
+                                          const std::vector<uint8_t>& binary_data) {
     if (binary_data.size() < 1 + sizeof(uint32_t)) {
         throw std::runtime_error("value_store::deserialize_binary() - invalid data: too small");
     }
@@ -166,6 +171,9 @@ std::unique_ptr<value_store> value_store::deserialize_binary(const std::vector<u
     uint32_t count;
     std::memcpy(&count, binary_data.data() + offset, sizeof(count));
     offset += sizeof(count);
+
+    // Parse into a temporary map so a malformed input leaves the target unmodified
+    std::unordered_map<std::string, value> parsed;
 
     // Read each key-value pair
     for (uint32_t i = 0; i < count; ++i) {
@@ -204,14 +212,16 @@ std::unique_ptr<value_store> value_store::deserialize_binary(const std::vector<u
 
         auto value_opt = value::deserialize(value_data);
         if (value_opt) {
-            store->values_[key] = std::move(*value_opt);
+            parsed[key] = std::move(*value_opt);
         } else {
             throw std::runtime_error("value_store::deserialize_binary() - failed to deserialize value for key: "
                                     + key);
         }
     }
 
-    return store;
+    // Commit parsed entries atomically once the whole buffer is validated
+    std::unique_lock lock(store.mutex_);
+    store.values_ = std::move(parsed);
 }
 
 size_t value_store::get_read_count() const {

--- a/src/messaging/message_container.cpp
+++ b/src/messaging/message_container.cpp
@@ -226,10 +226,13 @@ std::unique_ptr<message_container> message_container::deserialize_binary(const s
     // This is a simplified version - proper JSON parsing would be needed
 #endif
 
-    // Read payload data
-    // TODO: Implement in-place deserialization for value_store
-    // std::vector<uint8_t> payload_data(binary_data.begin() + 4 + header_size, binary_data.end());
-    // container->payload_ would need to be deserialized in place
+    // Read payload data and deserialize it in place into payload_
+    // (value_store is non-copyable/non-movable, so an in-place loader is required)
+    if (binary_data.size() > 4 + header_size) {
+        std::vector<uint8_t> payload_data(binary_data.begin() + 4 + header_size,
+                                          binary_data.end());
+        value_store::deserialize_binary_into(container->payload_, payload_data);
+    }
 
     return container;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,7 @@ set(TEST_SOURCES
     serializer_factory_tests.cpp
     iterator_tests.cpp
     allocator_adapter_tests.cpp
+    message_container_serialization_tests.cpp
 )
 
 # Add async tests if coroutines are enabled

--- a/tests/message_container_serialization_tests.cpp
+++ b/tests/message_container_serialization_tests.cpp
@@ -1,0 +1,163 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file message_container_serialization_tests.cpp
+ * @brief Round-trip tests for message_container binary serialization
+ *
+ * Covers the in-place binary deserialization path for the value_store
+ * payload (kcenon/container_system#545).
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/container/messaging/message_container.h>
+#include <kcenon/container/value_store.h>
+#include <kcenon/container/internal/value.h>
+
+#include <stdexcept>
+#include <vector>
+
+using namespace kcenon::container;
+
+// =============================================================================
+// message_container binary round-trip
+// =============================================================================
+
+TEST(MessageContainerBinaryTest, RoundTripPreservesHeader) {
+    message_container source;
+    source.set_source("src_id", "src_sub");
+    source.set_target("tgt_id", "tgt_sub");
+    source.set_message_type("request");
+    source.set_version("1.0");
+
+    auto binary = source.serialize_binary();
+    auto restored = message_container::deserialize_binary(binary);
+    ASSERT_NE(restored, nullptr);
+
+    EXPECT_EQ(restored->source_id(), "src_id");
+    EXPECT_EQ(restored->source_sub_id(), "src_sub");
+    EXPECT_EQ(restored->target_id(), "tgt_id");
+    EXPECT_EQ(restored->target_sub_id(), "tgt_sub");
+    EXPECT_EQ(restored->message_type(), "request");
+    EXPECT_EQ(restored->version(), "1.0");
+}
+
+TEST(MessageContainerBinaryTest, RoundTripPreservesPayload) {
+    message_container source;
+    source.set_message_type("data");
+    source.payload().add("integer", value("integer", int32_t(42)));
+    source.payload().add("text", value("text", std::string("hello world")));
+    source.payload().add("flag", value("flag", true));
+    source.payload().add("decimal", value("decimal", double(3.14)));
+
+    auto binary = source.serialize_binary();
+    auto restored = message_container::deserialize_binary(binary);
+    ASSERT_NE(restored, nullptr);
+
+    EXPECT_EQ(restored->payload().size(), 4u);
+
+    auto int_val = restored->payload().get("integer");
+    ASSERT_TRUE(int_val.has_value());
+    auto int_opt = int_val->get<int32_t>();
+    ASSERT_TRUE(int_opt.has_value());
+    EXPECT_EQ(*int_opt, 42);
+
+    auto str_val = restored->payload().get("text");
+    ASSERT_TRUE(str_val.has_value());
+    auto str_opt = str_val->get<std::string>();
+    ASSERT_TRUE(str_opt.has_value());
+    EXPECT_EQ(*str_opt, "hello world");
+
+    auto bool_val = restored->payload().get("flag");
+    ASSERT_TRUE(bool_val.has_value());
+    auto bool_opt = bool_val->get<bool>();
+    ASSERT_TRUE(bool_opt.has_value());
+    EXPECT_EQ(*bool_opt, true);
+
+    auto dbl_val = restored->payload().get("decimal");
+    ASSERT_TRUE(dbl_val.has_value());
+    auto dbl_opt = dbl_val->get<double>();
+    ASSERT_TRUE(dbl_opt.has_value());
+    EXPECT_DOUBLE_EQ(*dbl_opt, 3.14);
+}
+
+TEST(MessageContainerBinaryTest, RoundTripEmptyPayload) {
+    message_container source;
+    source.set_message_type("ping");
+
+    auto binary = source.serialize_binary();
+    auto restored = message_container::deserialize_binary(binary);
+    ASSERT_NE(restored, nullptr);
+
+    EXPECT_TRUE(restored->payload().empty());
+    EXPECT_EQ(restored->message_type(), "ping");
+}
+
+// =============================================================================
+// value_store in-place deserialization
+// =============================================================================
+
+TEST(ValueStoreInPlaceDeserializeTest, PopulatesExistingStore) {
+    value_store source;
+    source.add("key1", value("key1", int32_t(100)));
+    source.add("key2", value("key2", std::string("test")));
+
+    auto binary = source.serialize_binary();
+
+    value_store target;
+    value_store::deserialize_binary_into(target, binary);
+
+    EXPECT_EQ(target.size(), 2u);
+    EXPECT_TRUE(target.contains("key1"));
+    EXPECT_TRUE(target.contains("key2"));
+}
+
+TEST(ValueStoreInPlaceDeserializeTest, ReplacesPreviousContents) {
+    value_store source;
+    source.add("new_key", value("new_key", int32_t(7)));
+    auto binary = source.serialize_binary();
+
+    value_store target;
+    target.add("stale_key", value("stale_key", int32_t(1)));
+
+    value_store::deserialize_binary_into(target, binary);
+
+    EXPECT_EQ(target.size(), 1u);
+    EXPECT_FALSE(target.contains("stale_key"));
+    EXPECT_TRUE(target.contains("new_key"));
+}
+
+TEST(ValueStoreInPlaceDeserializeTest, MalformedInputLeavesStoreUnmodified) {
+    value_store target;
+    target.add("existing", value("existing", int32_t(99)));
+
+    std::vector<uint8_t> too_small = {1};
+    EXPECT_THROW(value_store::deserialize_binary_into(target, too_small),
+                 std::runtime_error);
+
+    std::vector<uint8_t> bad_version = {99, 0, 0, 0, 0};
+    EXPECT_THROW(value_store::deserialize_binary_into(target, bad_version),
+                 std::runtime_error);
+
+    // Truncated: claims one entry but provides no entry data
+    std::vector<uint8_t> truncated = {1, 1, 0, 0, 0};
+    EXPECT_THROW(value_store::deserialize_binary_into(target, truncated),
+                 std::runtime_error);
+
+    // Store must retain its original state after each failure
+    EXPECT_EQ(target.size(), 1u);
+    EXPECT_TRUE(target.contains("existing"));
+}
+
+TEST(ValueStoreInPlaceDeserializeTest, FactoryStillWorks) {
+    value_store source;
+    source.add("k", value("k", int32_t(5)));
+    auto binary = source.serialize_binary();
+
+    auto restored = value_store::deserialize_binary(binary);
+    ASSERT_NE(restored, nullptr);
+    EXPECT_EQ(restored->size(), 1u);
+    EXPECT_TRUE(restored->contains("k"));
+}


### PR DESCRIPTION
## What

Implements in-place binary deserialization for the `value_store` payload inside `message_container::deserialize_binary`.

Sub-issue A of #544.

## Why

`message_container::payload_` is a `value_store` held **by value**, and `value_store` has its copy and move constructors/assignment `delete`d (because of its `std::shared_mutex` member). As a result `message_container::deserialize_binary` previously parsed the header but **discarded the payload bytes** (TODO at `src/messaging/message_container.cpp:230`). `value_store::deserialize_binary` already works, but it returns a `std::unique_ptr<value_store>` whose contents cannot be moved into the existing `payload_`. An in-place loader was therefore required.

## How

- Add `value_store::deserialize_binary_into(value_store&, const std::vector<uint8_t>&)` — a static in-place loader that populates an existing `value_store` from a binary buffer.
- Refactor the existing `deserialize_binary` factory to delegate to the new loader; it stays behavior-identical (same wire format, same `std::runtime_error` messages).
- The loader parses entries into a temporary map and only commits to `values_` once the whole buffer is validated, under a write lock — so malformed/truncated input throws **without leaving partial state**.
- Wire the loader into `message_container::deserialize_binary` so payload bytes after the header are deserialized into `payload_`. The placeholder TODO is removed.

The binary wire format (version byte + entry count + length-prefixed key/value pairs) is unchanged.

## Where

- `include/kcenon/container/value_store.h`
- `src/core/value_store.cpp`
- `src/messaging/message_container.cpp`
- `tests/message_container_serialization_tests.cpp` (new)
- `tests/CMakeLists.txt`

## Test plan

New `tests/message_container_serialization_tests.cpp` registered in `tests/CMakeLists.txt`:

- `message_container` binary round trip — header fields preserved
- `message_container` binary round trip — populated payload preserved (int/string/bool/double)
- `message_container` binary round trip — empty payload
- `value_store::deserialize_binary_into` populates an existing store
- `value_store::deserialize_binary_into` replaces prior contents
- malformed/truncated input throws `std::runtime_error` and leaves the store unmodified
- existing `deserialize_binary` factory still works

Verified via `workflow_dispatch` runs of `build-linux-arm64.yml` and `integration-tests.yml` on the feature branch (develop-targeted PRs do not trigger CI automatically).

Closes #545
