### PR TITLE
fix(serialization): implement in-place JSON deserialization for value_store payload

### DIFF
--- a/include/kcenon/container/value_store.h
+++ b/include/kcenon/container/value_store.h
@@ -159,6 +159,17 @@ public:
     static void deserialize_binary_into(value_store& store,
                                         const std::vector<uint8_t>& binary_data);
 
+    /**
+     * @brief Deserialize JSON format into an existing value_store
+     * @param store Target value_store populated in place on success
+     * @param json_data JSON string produced by serialize()
+     * @throws std::runtime_error if deserialization fails
+     * @note Required because value_store is non-copyable/non-movable; on a
+     *       malformed input the target store is left unmodified.
+     */
+    static void deserialize_into(value_store& store,
+                                 std::string_view json_data);
+
 #if CONTAINER_HAS_COMMON_RESULT
     // =========================================================================
     // Result-based Deserialization (no-throw alternatives)

--- a/src/core/value_store.cpp
+++ b/src/core/value_store.cpp
@@ -5,8 +5,91 @@
 #include <kcenon/container/value_store.h>
 #include <stdexcept>
 #include <cstring>
+#include <string>
+#include <unordered_map>
+
+#ifdef __has_include
+#if __has_include(<nlohmann/json.hpp>)
+#include <nlohmann/json.hpp>
+#define HAS_NLOHMANN_JSON 1
+#else
+#define HAS_NLOHMANN_JSON -1
+#endif
+#else
+#define HAS_NLOHMANN_JSON -1
+#endif
 
 namespace kcenon::container {
+
+#if HAS_NLOHMANN_JSON == 1
+namespace {
+
+// Reconstruct a single value from its JSON object representation, mirroring
+// the format produced by value::to_json():
+//   {"name":"<name>","type":<int 0-15>,"value":<typed-json>}
+value value_from_json(const std::string& key, const nlohmann::json& node) {
+    if (!node.is_object() || !node.contains("type") || !node.contains("value")) {
+        throw std::runtime_error(
+            "value_store::deserialize() - malformed value object for key: " + key);
+    }
+
+    const std::string name = node.contains("name") && node["name"].is_string()
+                                 ? node["name"].get<std::string>()
+                                 : key;
+    const int type_int = node["type"].get<int>();
+    const nlohmann::json& v = node["value"];
+
+    switch (static_cast<value_types>(type_int)) {
+        case value_types::null_value:
+            return value(name);
+        case value_types::bool_value:
+            return value(name, v.get<bool>());
+        case value_types::short_value:
+            return value(name, static_cast<int16_t>(v.get<int>()));
+        case value_types::ushort_value:
+            return value(name, static_cast<uint16_t>(v.get<unsigned int>()));
+        case value_types::int_value:
+            return value(name, v.get<int32_t>());
+        case value_types::uint_value:
+            return value(name, v.get<uint32_t>());
+        case value_types::long_value:
+        case value_types::llong_value:
+            return value(name, v.get<int64_t>());
+        case value_types::ulong_value:
+        case value_types::ullong_value:
+            return value(name, v.get<uint64_t>());
+        case value_types::float_value:
+            return value(name, v.get<float>());
+        case value_types::double_value:
+            return value(name, v.get<double>());
+        case value_types::string_value:
+            return value(name, v.get<std::string>());
+        case value_types::bytes_value: {
+            // to_json() renders bytes as a lowercase hex string
+            const std::string hex = v.get<std::string>();
+            if (hex.size() % 2 != 0) {
+                throw std::runtime_error(
+                    "value_store::deserialize() - odd-length hex for key: " + key);
+            }
+            std::vector<uint8_t> bytes;
+            bytes.reserve(hex.size() / 2);
+            for (size_t i = 0; i < hex.size(); i += 2) {
+                bytes.push_back(static_cast<uint8_t>(
+                    std::stoul(hex.substr(i, 2), nullptr, 16)));
+            }
+            return value(name, std::move(bytes));
+        }
+        case value_types::container_value:
+        case value_types::array_value:
+        default:
+            throw std::runtime_error(
+                "value_store::deserialize() - unsupported value type for key '" + key
+                + "': " + std::to_string(type_int));
+    }
+}
+
+} // namespace
+#endif
 
 void value_store::add(const std::string& key, value val) {
     // Always acquire lock to eliminate TOCTOU vulnerability (see #190)
@@ -139,11 +222,41 @@ std::vector<uint8_t> value_store::serialize_binary_impl() const {
     return result;
 }
 
-std::unique_ptr<value_store> value_store::deserialize(std::string_view /*json_data*/) {
-    // JSON deserialization requires a JSON parser library
-    // For now, use serialize_binary/deserialize_binary for round-trip serialization
+std::unique_ptr<value_store> value_store::deserialize(std::string_view json_data) {
+#if HAS_NLOHMANN_JSON == 1
+    auto store = std::make_unique<value_store>();
+    deserialize_into(*store, json_data);
+    return store;
+#else
+    (void)json_data;
     throw std::runtime_error(
         "value_store::deserialize() requires JSON parser - use deserialize_binary() instead");
+#endif
+}
+
+void value_store::deserialize_into(value_store& store, std::string_view json_data) {
+#if HAS_NLOHMANN_JSON == 1
+    auto json_obj = nlohmann::json::parse(json_data);
+    if (!json_obj.is_object()) {
+        throw std::runtime_error(
+            "value_store::deserialize() - top-level JSON value must be an object");
+    }
+
+    // Parse into a temporary map so a malformed input leaves the target unmodified
+    std::unordered_map<std::string, value> parsed;
+    for (auto it = json_obj.begin(); it != json_obj.end(); ++it) {
+        parsed.emplace(it.key(), value_from_json(it.key(), it.value()));
+    }
+
+    // Commit parsed entries atomically once the whole document is validated
+    std::unique_lock lock(store.mutex_);
+    store.values_ = std::move(parsed);
+#else
+    (void)store;
+    (void)json_data;
+    throw std::runtime_error(
+        "value_store::deserialize() requires JSON parser - use deserialize_binary() instead");
+#endif
 }
 
 std::unique_ptr<value_store> value_store::deserialize_binary(const std::vector<uint8_t>& binary_data) {
@@ -239,12 +352,33 @@ void value_store::reset_statistics() {
 
 #if CONTAINER_HAS_COMMON_RESULT
 kcenon::common::Result<std::unique_ptr<value_store>>
-value_store::deserialize_result(std::string_view /*json_data*/) noexcept {
+value_store::deserialize_result(std::string_view json_data) noexcept {
+#if HAS_NLOHMANN_JSON == 1
+    try {
+        auto store = std::make_unique<value_store>();
+        deserialize_into(*store, json_data);
+        return kcenon::common::ok(std::move(store));
+    } catch (const std::bad_alloc&) {
+        return kcenon::common::Result<std::unique_ptr<value_store>>(
+            kcenon::common::error_info{
+                error_codes::memory_allocation_failed,
+                "value_store::deserialize_result() - memory allocation failed",
+                "container_system"});
+    } catch (const std::exception& e) {
+        return kcenon::common::Result<std::unique_ptr<value_store>>(
+            kcenon::common::error_info{
+                error_codes::deserialization_failed,
+                std::string("value_store::deserialize_result() - ") + e.what(),
+                "container_system"});
+    }
+#else
+    (void)json_data;
     return kcenon::common::Result<std::unique_ptr<value_store>>(
         kcenon::common::error_info{
             error_codes::deserialization_failed,
             "value_store::deserialize_result() requires JSON parser - use deserialize_binary_result() instead",
             "container_system"});
+#endif
 }
 
 kcenon::common::Result<std::unique_ptr<value_store>>

--- a/src/messaging/message_container.cpp
+++ b/src/messaging/message_container.cpp
@@ -177,13 +177,11 @@ std::unique_ptr<message_container> message_container::deserialize(std::string_vi
         if (header.contains("version")) container->version_ = header["version"];
     }
 
-    // Deserialize payload
-    // Note: payload is already default-constructed, we modify it in place
+    // Deserialize payload in place into payload_
+    // (value_store is non-copyable/non-movable, so an in-place loader is required)
     if (json_obj.contains("payload")) {
         std::string payload_str = json_obj["payload"].dump();
-        // TODO: Implement in-place deserialization for value_store
-        // For now, this is a placeholder - actual implementation would need
-        // value_store to support in-place updates
+        value_store::deserialize_into(container->payload_, payload_str);
     }
 
     return container;

--- a/tests/message_container_serialization_tests.cpp
+++ b/tests/message_container_serialization_tests.cpp
@@ -4,10 +4,11 @@
 
 /**
  * @file message_container_serialization_tests.cpp
- * @brief Round-trip tests for message_container binary serialization
+ * @brief Round-trip tests for message_container binary and JSON serialization
  *
  * Covers the in-place binary deserialization path for the value_store
- * payload (kcenon/container_system#545).
+ * payload (kcenon/container_system#545) and the in-place JSON
+ * deserialization path (kcenon/container_system#546).
  */
 
 #include <gtest/gtest.h>
@@ -17,6 +18,7 @@
 #include <kcenon/container/internal/value.h>
 
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 using namespace kcenon::container;
@@ -160,4 +162,163 @@ TEST(ValueStoreInPlaceDeserializeTest, FactoryStillWorks) {
     ASSERT_NE(restored, nullptr);
     EXPECT_EQ(restored->size(), 1u);
     EXPECT_TRUE(restored->contains("k"));
+}
+
+// =============================================================================
+// value_store JSON deserialization
+// =============================================================================
+
+TEST(ValueStoreJsonDeserializeTest, RoundTripPreservesScalarTypes) {
+    value_store source;
+    source.add("integer", value("integer", int32_t(42)));
+    source.add("text", value("text", std::string("hello world")));
+    source.add("flag", value("flag", true));
+    source.add("decimal", value("decimal", double(3.14)));
+
+    auto json = source.serialize();
+    auto restored = value_store::deserialize(json);
+    ASSERT_NE(restored, nullptr);
+    EXPECT_EQ(restored->size(), 4u);
+
+    auto int_val = restored->get("integer");
+    ASSERT_TRUE(int_val.has_value());
+    ASSERT_TRUE(int_val->get<int32_t>().has_value());
+    EXPECT_EQ(*int_val->get<int32_t>(), 42);
+
+    auto str_val = restored->get("text");
+    ASSERT_TRUE(str_val.has_value());
+    ASSERT_TRUE(str_val->get<std::string>().has_value());
+    EXPECT_EQ(*str_val->get<std::string>(), "hello world");
+
+    auto bool_val = restored->get("flag");
+    ASSERT_TRUE(bool_val.has_value());
+    ASSERT_TRUE(bool_val->get<bool>().has_value());
+    EXPECT_EQ(*bool_val->get<bool>(), true);
+
+    auto dbl_val = restored->get("decimal");
+    ASSERT_TRUE(dbl_val.has_value());
+    ASSERT_TRUE(dbl_val->get<double>().has_value());
+    EXPECT_DOUBLE_EQ(*dbl_val->get<double>(), 3.14);
+}
+
+TEST(ValueStoreJsonDeserializeTest, InPlacePopulatesExistingStore) {
+    value_store source;
+    source.add("a", value("a", int32_t(1)));
+    source.add("b", value("b", std::string("two")));
+
+    auto json = source.serialize();
+
+    value_store target;
+    value_store::deserialize_into(target, json);
+
+    EXPECT_EQ(target.size(), 2u);
+    EXPECT_TRUE(target.contains("a"));
+    EXPECT_TRUE(target.contains("b"));
+}
+
+TEST(ValueStoreJsonDeserializeTest, InPlaceReplacesPreviousContents) {
+    value_store source;
+    source.add("new_key", value("new_key", int32_t(7)));
+    auto json = source.serialize();
+
+    value_store target;
+    target.add("stale_key", value("stale_key", int32_t(1)));
+
+    value_store::deserialize_into(target, json);
+
+    EXPECT_EQ(target.size(), 1u);
+    EXPECT_FALSE(target.contains("stale_key"));
+    EXPECT_TRUE(target.contains("new_key"));
+}
+
+TEST(ValueStoreJsonDeserializeTest, MalformedInputLeavesStoreUnmodified) {
+    value_store target;
+    target.add("existing", value("existing", int32_t(99)));
+
+    EXPECT_ANY_THROW(value_store::deserialize_into(target, "{not valid json"));
+    EXPECT_ANY_THROW(value_store::deserialize_into(target, "[1,2,3]"));
+    EXPECT_ANY_THROW(
+        value_store::deserialize_into(target, "{\"k\":{\"type\":4}}"));
+
+    EXPECT_EQ(target.size(), 1u);
+    EXPECT_TRUE(target.contains("existing"));
+}
+
+TEST(ValueStoreJsonDeserializeTest, EmptyObjectYieldsEmptyStore) {
+    value_store target;
+    target.add("stale", value("stale", int32_t(1)));
+
+    value_store::deserialize_into(target, "{}");
+
+    EXPECT_TRUE(target.empty());
+}
+
+// =============================================================================
+// message_container JSON round-trip
+// =============================================================================
+
+TEST(MessageContainerJsonTest, RoundTripPreservesHeader) {
+    message_container source;
+    source.set_source("src_id", "src_sub");
+    source.set_target("tgt_id", "tgt_sub");
+    source.set_message_type("request");
+    source.set_version("1.0");
+
+    auto json = source.serialize();
+    auto restored = message_container::deserialize(json);
+    ASSERT_NE(restored, nullptr);
+
+    EXPECT_EQ(restored->source_id(), "src_id");
+    EXPECT_EQ(restored->source_sub_id(), "src_sub");
+    EXPECT_EQ(restored->target_id(), "tgt_id");
+    EXPECT_EQ(restored->target_sub_id(), "tgt_sub");
+    EXPECT_EQ(restored->message_type(), "request");
+    EXPECT_EQ(restored->version(), "1.0");
+}
+
+TEST(MessageContainerJsonTest, RoundTripPreservesPayload) {
+    message_container source;
+    source.set_message_type("data");
+    source.payload().add("integer", value("integer", int32_t(42)));
+    source.payload().add("text", value("text", std::string("hello world")));
+    source.payload().add("flag", value("flag", true));
+    source.payload().add("decimal", value("decimal", double(3.14)));
+
+    auto json = source.serialize();
+    auto restored = message_container::deserialize(json);
+    ASSERT_NE(restored, nullptr);
+
+    EXPECT_EQ(restored->payload().size(), 4u);
+
+    auto int_val = restored->payload().get("integer");
+    ASSERT_TRUE(int_val.has_value());
+    ASSERT_TRUE(int_val->get<int32_t>().has_value());
+    EXPECT_EQ(*int_val->get<int32_t>(), 42);
+
+    auto str_val = restored->payload().get("text");
+    ASSERT_TRUE(str_val.has_value());
+    ASSERT_TRUE(str_val->get<std::string>().has_value());
+    EXPECT_EQ(*str_val->get<std::string>(), "hello world");
+
+    auto bool_val = restored->payload().get("flag");
+    ASSERT_TRUE(bool_val.has_value());
+    ASSERT_TRUE(bool_val->get<bool>().has_value());
+    EXPECT_EQ(*bool_val->get<bool>(), true);
+
+    auto dbl_val = restored->payload().get("decimal");
+    ASSERT_TRUE(dbl_val.has_value());
+    ASSERT_TRUE(dbl_val->get<double>().has_value());
+    EXPECT_DOUBLE_EQ(*dbl_val->get<double>(), 3.14);
+}
+
+TEST(MessageContainerJsonTest, RoundTripEmptyPayload) {
+    message_container source;
+    source.set_message_type("ping");
+
+    auto json = source.serialize();
+    auto restored = message_container::deserialize(json);
+    ASSERT_NE(restored, nullptr);
+
+    EXPECT_TRUE(restored->payload().empty());
+    EXPECT_EQ(restored->message_type(), "ping");
 }


### PR DESCRIPTION
## What

Implements in-place JSON deserialization for the `value_store` payload inside `message_container::deserialize`, including the underlying JSON parser for `value_store`.

Sub-issue B of #544, sequenced after #545 (binary in-place loader, PR #547). Reuses the in-place loader pattern established there.

## Why

`message_container::deserialize` parsed the JSON header but discarded the payload behind a TODO placeholder. The JSON path was additionally blocked because `value_store::deserialize(std::string_view)` was a stub that threw `"requires JSON parser - use deserialize_binary() instead"`.

## How

- `value_store::deserialize(std::string_view)` now parses JSON via nlohmann/json (guarded by `HAS_NLOHMANN_JSON`; the throw stub remains as the `#else` fallback). It mirrors the format produced by `value::to_json()` -- each entry is `{"name","type","value"}` keyed by the store key.
- Added `value_store::deserialize_into(value_store&, std::string_view)`, the in-place JSON loader analogous to `deserialize_binary_into`. It parses into a temporary map, validates the whole document, then commits to `values_` under a write lock -- malformed input leaves the target unmodified.
- `message_container::deserialize` now calls `deserialize_into(container->payload_, ...)`; the TODO/placeholder is removed.
- `value_store::deserialize_result` uses the no-throw Result path, consistent with `deserialize_binary_result`.
- Scalar value types (null, bool, integers, float, double, string, bytes) are supported; `container_value`/`array_value` throw an explicit unsupported-type error.

## Where

- `include/kcenon/container/value_store.h`
- `src/core/value_store.cpp` (`deserialize`, `deserialize_into`, `deserialize_result`)
- `src/messaging/message_container.cpp` (`deserialize`)
- `tests/message_container_serialization_tests.cpp`

## Test plan

Added to `tests/message_container_serialization_tests.cpp` (registered in `tests/CMakeLists.txt`):

- `ValueStoreJsonDeserializeTest`: scalar round-trip, in-place population, replacement of prior contents, empty object, and malformed-input cases asserting the target store is unmodified.
- `MessageContainerJsonTest`: header round-trip, payload round-trip, empty payload.

Verified via `build-linux-arm64.yml` and `integration-tests.yml` workflow_dispatch on the PR branch (develop PRs do not trigger CI automatically).

Closes #546
